### PR TITLE
vine: visibility

### DIFF
--- a/tests/programs/basic_diverge.vi
+++ b/tests/programs/basic_diverge.vi
@@ -1,5 +1,5 @@
 
-fn main(&io: &IO) {
+pub fn main(&io: &IO) {
   let zero_count = 0;
   io.println(foo(0, &zero_count));
   io.println(foo(1, &zero_count));

--- a/tests/programs/break_result.vi
+++ b/tests/programs/break_result.vi
@@ -1,5 +1,5 @@
 
-fn main(&io: &IO) {
+pub fn main(&io: &IO) {
   io.println(loop {
     break "loop result";
   });

--- a/tests/programs/cyclist.vi
+++ b/tests/programs/cyclist.vi
@@ -1,7 +1,7 @@
 
 use std::option::Option::Some;
 
-fn main(&io: &IO) {
+pub fn main(&io: &IO) {
   let list = [0];
   while list.len() < 32 {
     list ++= list.map(fn(x: u32) list.len() + x);

--- a/tests/programs/fail/atypical.vi
+++ b/tests/programs/fail/atypical.vi
@@ -3,7 +3,7 @@
 type Foo[X] = (X, foo, _);
 fn foo(x, y: Foo) {}
 const bar: _ = return;
-fn main[T, U](io: IO) {
+pub fn main[T, U](io: IO) {
   let x: u32 = 0.0;
   let x: f32 = 0;
   let x: (u32, u32) = (1, 2) + 0.0;

--- a/tests/programs/fail/hallo_world.vi
+++ b/tests/programs/fail/hallo_world.vi
@@ -5,6 +5,6 @@ use std::io::{
   print_ln,
 };
 
-fn main(std::io) {
+pub fn main(std::io) {
   io.println(hallo, world)
 }

--- a/tests/programs/fail/informal.vi
+++ b/tests/programs/fail/informal.vi
@@ -1,7 +1,7 @@
 
 enum IO { I, O }
 
-fn main(move *io) {
+pub fn main(move *io) {
   1 + 1 = 2;
   ~_ = _;
   _ += ~1;

--- a/tests/programs/fail/is_not.vi
+++ b/tests/programs/fail/is_not.vi
@@ -1,5 +1,5 @@
 
-fn main(x) {
+pub fn main(x) {
   if x is y {} else { y }
   if !(x is y) { y }
   if x is y || y is z { (y, z) }

--- a/tests/programs/fail/visibility.vi
+++ b/tests/programs/fail/visibility.vi
@@ -14,8 +14,8 @@ mod lib {
   struct y();
 }
 
-// bad: ~1 error per line:
-pub fn main(&io: &IO) {
+// bad: ~1 error per line
+fn main(&io: &IO) {
   io.read_char();
   let lib::x: lib::x = lib::x;
   let lib::y: lib::y = lib::y;
@@ -30,7 +30,7 @@ mod p {
   };
 }
 
-// good:
+// good
 mod q {
   const x: fn() = lib::d;
   pub(visibility) use lib::{
@@ -41,5 +41,3 @@ mod q {
     d::g,
   };
 }
-
-

--- a/tests/programs/fail/visibility.vi
+++ b/tests/programs/fail/visibility.vi
@@ -1,0 +1,45 @@
+
+mod lib {
+  fn a() { fn b() {} }
+  pub mod a { pub fn c() {} }
+  use a::c;
+
+  pub fn d() {}
+  mod d { pub fn e() {} }
+  pub mod d { pub fn f() {} pub fn g() {} }
+  pub use d::{e, f};
+
+  struct x();
+  pub mod x {}
+  struct y();
+}
+
+// bad: ~1 error per line:
+pub fn main(&io: &IO) {
+  io.read_char();
+  let lib::x: lib::x = lib::x;
+  let lib::y: lib::y = lib::y;
+  pub fn x() {}
+}
+
+mod p {
+  pub(main) use lib::{
+    a::b,
+    c,
+    d::e,
+  };
+}
+
+// good:
+mod q {
+  const x: fn() = lib::d;
+  pub(visibility) use lib::{
+    a::c,
+    d,
+    e,
+    f,
+    d::g,
+  };
+}
+
+

--- a/tests/programs/final_countdown.vi
+++ b/tests/programs/final_countdown.vi
@@ -1,5 +1,5 @@
 
-fn main(&io: &IO) {
+pub fn main(&io: &IO) {
   let msg = "";
   let msg_ref = &msg;
   let i = 10;

--- a/tests/programs/inverse.vi
+++ b/tests/programs/inverse.vi
@@ -1,5 +1,5 @@
 
-fn main(&io: &IO) {
+pub fn main(&io: &IO) {
   refs(&io);
   io.println("");
   fns(&io);

--- a/tests/programs/logic.vi
+++ b/tests/programs/logic.vi
@@ -1,5 +1,5 @@
 
-fn main(&io: &IO) {
+pub fn main(&io: &IO) {
   dyn fn print_bool(bool) {
     io.println(if bool {
       "true"

--- a/tests/programs/loop_break_continue.vi
+++ b/tests/programs/loop_break_continue.vi
@@ -1,7 +1,7 @@
 
 const end: u32 = 5;
 
-fn main(&io: &IO) {
+pub fn main(&io: &IO) {
   let n = 0;
   loop {
     if n >= end {

--- a/tests/programs/loop_vi_loop.vi
+++ b/tests/programs/loop_vi_loop.vi
@@ -1,5 +1,5 @@
 
-fn main(&io: &IO) {
+pub fn main(&io: &IO) {
   let i = 0;
   let n = 0;
   while i < 5 {

--- a/tests/programs/maybe_set.vi
+++ b/tests/programs/maybe_set.vi
@@ -1,5 +1,5 @@
 
-fn main(&io: &IO) {
+pub fn main(&io: &IO) {
   let message = "original";
   if 0 {
     message = "gone";

--- a/tests/programs/move_it_move_it.vi
+++ b/tests/programs/move_it_move_it.vi
@@ -1,5 +1,5 @@
 
-fn main(&it: &IO) {
+pub fn main(&it: &IO) {
   let &move it = &move it;
   (move it).println("move it!");
   if 1 {

--- a/tests/programs/no_return.vi
+++ b/tests/programs/no_return.vi
@@ -1,5 +1,5 @@
 
-fn main(&io: &IO) {
+pub fn main(&io: &IO) {
   io.println("We should see this");
   return;
   io.println("But not this");

--- a/tests/programs/option_party.vi
+++ b/tests/programs/option_party.vi
@@ -1,7 +1,7 @@
 
 use std::option::Option::{Option, Some, None};
 
-fn main(&io: &IO) {
+pub fn main(&io: &IO) {
   dyn fn print_option_u32(option: Option[u32]) {
     io.println("  " ++ match option {
       Some(val) => "Some(" ++ val.to_string() ++ ")",

--- a/tests/programs/pretty_div.vi
+++ b/tests/programs/pretty_div.vi
@@ -1,5 +1,5 @@
 
-fn main(&io: &IO) {
+pub fn main(&io: &IO) {
   io.println(pretty_div(4, 2));
   io.println(pretty_div(5, 3));
   io.println(pretty_div(1, 1));

--- a/tests/programs/so_random.vi
+++ b/tests/programs/so_random.vi
@@ -1,7 +1,7 @@
 
 use std::rng::Rng;
 
-fn main(&io: &IO) {
+pub fn main(&io: &IO) {
   let i = 0;
   let rng = Rng::default;
   while i < 100 {

--- a/tests/programs/square_case.vi
+++ b/tests/programs/square_case.vi
@@ -1,5 +1,5 @@
 
-fn main(&io: &IO) {
+pub fn main(&io: &IO) {
   let x = 2;
   while x < 1000 {
     squares(&io, x);

--- a/tests/snaps/vine/fail/atypical.txt
+++ b/tests/snaps/vine/fail/atypical.txt
@@ -34,4 +34,4 @@ error tests/programs/fail/atypical.vi:27:10 - expected type `()`; found `f32`
 error tests/programs/fail/atypical.vi:28:14 - cannot apply operator `+` to types `~u32` and `~u32`
 error tests/programs/fail/atypical.vi:29:3 - cannot apply operator `+=` to types `u32` and `f32`
 error tests/programs/fail/atypical.vi:30:5 - `::std::u32::parse` cannot be used as a method; it does not take `::std::u32` as its first parameter
-error tests/programs/fail/atypical.vi:6:23 - expected type `()`; found `u32`
+error tests/programs/fail/atypical.vi:6:27 - expected type `()`; found `u32`

--- a/tests/snaps/vine/fail/hallo_world.txt
+++ b/tests/snaps/vine/fail/hallo_world.txt
@@ -1,7 +1,7 @@
 error tests/programs/fail/hallo_world.vi:4:3 - duplicate definition of `println`
 error tests/programs/fail/hallo_world.vi:5:3 - cannot find `print_ln` in `::std::io`
 error tests/programs/fail/hallo_world.vi:3:3 - cannot find `println` in `::std::io`
-error tests/programs/fail/hallo_world.vi:8:9 - invalid pattern; this path is not a struct or enum variant
+error tests/programs/fail/hallo_world.vi:8:13 - invalid pattern; this path is not a struct or enum variant
 error tests/programs/fail/hallo_world.vi:9:3 - cannot find `io` in `::hallo_world::main`
 error tests/programs/fail/hallo_world.vi:9:14 - cannot find `hallo` in `::hallo_world::main`
 error tests/programs/fail/hallo_world.vi:9:21 - cannot find `world` in `::hallo_world::main`

--- a/tests/snaps/vine/fail/hallo_world.txt
+++ b/tests/snaps/vine/fail/hallo_world.txt
@@ -5,3 +5,4 @@ error tests/programs/fail/hallo_world.vi:8:13 - invalid pattern; this path is no
 error tests/programs/fail/hallo_world.vi:9:3 - cannot find `io` in `::hallo_world::main`
 error tests/programs/fail/hallo_world.vi:9:14 - cannot find `hallo` in `::hallo_world::main`
 error tests/programs/fail/hallo_world.vi:9:21 - cannot find `world` in `::hallo_world::main`
+error tests/programs/fail/hallo_world.vi:8:13 - fn item parameters must be explicitly typed

--- a/tests/snaps/vine/fail/informal.txt
+++ b/tests/snaps/vine/fail/informal.txt
@@ -1,5 +1,5 @@
-error tests/programs/fail/informal.vi:4:9 - fn item parameters must be explicitly typed
-error tests/programs/fail/informal.vi:4:9 - `move` is only valid in a place pattern
+error tests/programs/fail/informal.vi:4:13 - fn item parameters must be explicitly typed
+error tests/programs/fail/informal.vi:4:13 - `move` is only valid in a place pattern
 error tests/programs/fail/informal.vi:5:3 - expected a space expression; found a value expression
 error tests/programs/fail/informal.vi:6:3 - expected a space expression; found a value expression
 error tests/programs/fail/informal.vi:6:8 - expected a value expression; found a space expression

--- a/tests/snaps/vine/fail/is_not.txt
+++ b/tests/snaps/vine/fail/is_not.txt
@@ -4,3 +4,5 @@ error tests/programs/fail/is_not.vi:5:16 - cannot find `y` in `::is_not::main`
 error tests/programs/fail/is_not.vi:5:26 - cannot find `y` in `::is_not::main`
 error tests/programs/fail/is_not.vi:5:29 - cannot find `z` in `::is_not::main`
 error tests/programs/fail/is_not.vi:7:3 - cannot find `y` in `::is_not::main`
+error tests/programs/fail/is_not.vi:2:13 - fn item parameters must be explicitly typed
+error tests/programs/fail/is_not.vi:5:3 - then block has type `(??, ??)` but else block has type `()`

--- a/tests/snaps/vine/fail/visibility.txt
+++ b/tests/snaps/vine/fail/visibility.txt
@@ -1,0 +1,13 @@
+error tests/programs/fail/visibility.vi:22:3 - subitems must be private
+error tests/programs/fail/visibility.vi:26:7 - invalid visibility; expected the name of an ancestor module
+error tests/programs/fail/visibility.vi:27:5 - `::visibility::lib::a::b` is only visible within `::visibility::lib::a`
+error tests/programs/fail/visibility.vi:28:5 - `::visibility::lib::c` is only visible within `::visibility::lib`
+error tests/programs/fail/visibility.vi:29:5 - `::visibility::lib::d::e` is only visible within `::visibility::lib`
+error - `::visibility::main` is only visible within `::visibility`
+error tests/programs/fail/visibility.vi:21:15 - `::visibility::lib::y` is only visible within `::visibility::lib`
+error tests/programs/fail/visibility.vi:21:24 - `::visibility::lib::y` is only visible within `::visibility::lib`
+error tests/programs/fail/visibility.vi:21:7 - `::visibility::lib::y` is only visible within `::visibility::lib`
+error tests/programs/fail/visibility.vi:19:6 - cannot find `read_char` in `::std::io::IO`
+error tests/programs/fail/visibility.vi:20:15 - the type `::visibility::lib::x` is only visible within `::visibility::lib`
+error tests/programs/fail/visibility.vi:20:7 - the pattern `::visibility::lib::x` is only visible within `::visibility::lib`
+error tests/programs/fail/visibility.vi:20:24 - the value `::visibility::lib::x` is only visible within `::visibility::lib`

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -61,6 +61,7 @@ fn tests(t: &mut DynTester) {
       test_vi_fail(t, "tests/programs/fail/informal.vi");
       test_vi_fail(t, "tests/programs/fail/is_not.vi");
       test_vi_fail(t, "tests/programs/fail/missing_no.vi");
+      test_vi_fail(t, "tests/programs/fail/visibility.vi");
     });
   });
 }

--- a/vine/examples/fib.vi
+++ b/vine/examples/fib.vi
@@ -1,7 +1,7 @@
 
 const end: u32 = 32;
 
-fn main(&io: &IO) {
+pub fn main(&io: &IO) {
   let n = 0;
   let a = 0;
   let b = 1;

--- a/vine/examples/fib_repl.vi
+++ b/vine/examples/fib_repl.vi
@@ -11,7 +11,7 @@ pub fn main(&io: &IO) {
   }
 }
 
-fn fib(n: u32) -> u32 {
+pub fn fib(n: u32) -> u32 {
   let a = 0;
   let b = 1;
   while n {

--- a/vine/examples/fib_repl.vi
+++ b/vine/examples/fib_repl.vi
@@ -1,7 +1,7 @@
 
 use std::option::Option::{Some, None};
 
-fn main(&io: &IO) {
+pub fn main(&io: &IO) {
   while io.prompt("> ") is Some(line) {
     let num = u32::parse(line);
     io.println(match num {

--- a/vine/examples/fizzbuzz.vi
+++ b/vine/examples/fizzbuzz.vi
@@ -1,7 +1,7 @@
 
 const end: u32 = 100;
 
-fn main(&io: &IO) {
+pub fn main(&io: &IO) {
   let n = 1;
   while n <= end {
     io.println(message(n));

--- a/vine/examples/hello_world.vi
+++ b/vine/examples/hello_world.vi
@@ -1,4 +1,4 @@
 
-fn main(&io: &IO) {
+pub fn main(&io: &IO) {
   io.println("Hello, world!");
 }

--- a/vine/examples/mandelbrot.vi
+++ b/vine/examples/mandelbrot.vi
@@ -5,7 +5,7 @@ const height: u32 = 45;
 const scale: f32 = 2.6;
 const center: (f32, f32) = (-0.8, 0.0);
 
-fn main(&io: &IO) {
+pub fn main(&io: &IO) {
   let j = 0;
   while j < height {
     let i = 0;

--- a/vine/examples/mandelbrot_sixel.vi
+++ b/vine/examples/mandelbrot_sixel.vi
@@ -5,7 +5,7 @@ const height: u32 = 512;
 const scale: f32 = 2.6;
 const center: (f32, f32) = (-0.8, 0.0);
 
-fn main(&io: &IO) {
+pub fn main(&io: &IO) {
   io.print_bytes([27, 'P', 'q']);
 
   let c = 0;

--- a/vine/examples/mandelbrot_tga.vi
+++ b/vine/examples/mandelbrot_tga.vi
@@ -5,7 +5,7 @@ const height: u32 = 1024;
 const scale: f32 = 2.6;
 const center: (f32, f32) = (-0.8, 0.0);
 
-fn main(&io: &IO) {
+pub fn main(&io: &IO) {
   io.print_bytes([0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, width, width >> 8, height, height >> 8, 8, 32]);
   let j = 0;
   while j < height {

--- a/vine/examples/primes.vi
+++ b/vine/examples/primes.vi
@@ -21,7 +21,7 @@ pub fn main(&io: &IO) {
   }
 }
 
-fn is_prime(n: u32) -> Result[bool, String] {
+pub fn is_prime(n: u32) -> Result[bool, String] {
   if n <= 0 {
     return Err("primes have to be positive!");
   }

--- a/vine/examples/primes.vi
+++ b/vine/examples/primes.vi
@@ -3,7 +3,7 @@ use std::result::Result::{Result, Ok, Err};
 
 const end: u32 = 46;
 
-fn main(&io: &IO) {
+pub fn main(&io: &IO) {
   let n = 0;
   while n <= end {
     let primeness = is_prime(n);

--- a/vine/examples/sub_min.vi
+++ b/vine/examples/sub_min.vi
@@ -7,7 +7,7 @@ pub fn main(&io: &IO) {
   io.println(list.to_string(u32::to_string));
 }
 
-fn sub_min(&list: &List[u32]) {
+pub fn sub_min(&list: &List[u32]) {
   let ~min: u32;
   let min_acc = None[u32];
 

--- a/vine/examples/sub_min.vi
+++ b/vine/examples/sub_min.vi
@@ -1,7 +1,7 @@
 
 use std::option::Option::{Some, None};
 
-fn main(&io: &IO) {
+pub fn main(&io: &IO) {
   let list = [4, 3, 7, 9];
   sub_min(&list);
   io.println(list.to_string(u32::to_string));

--- a/vine/examples/sum_divisors.vi
+++ b/vine/examples/sum_divisors.vi
@@ -17,7 +17,7 @@ pub fn main(&io: &IO) {
   }
 }
 
-fn sum_divisors(n: u32) -> u32 {
+pub fn sum_divisors(n: u32) -> u32 {
   let sum = 1;
   let d = 2;
   while d * d <= n {

--- a/vine/examples/sum_divisors.vi
+++ b/vine/examples/sum_divisors.vi
@@ -1,7 +1,7 @@
 
 const end: u32 = 100;
 
-fn main(&io: &IO) {
+pub fn main(&io: &IO) {
   let n = 1;
   while n <= end {
     let sum = sum_divisors(n);

--- a/vine/src/ast.rs
+++ b/vine/src/ast.rs
@@ -88,7 +88,7 @@ pub struct ModItem {
 
 #[derive(Debug, Clone)]
 pub enum ModKind {
-  Loaded(Vec<Item>),
+  Loaded(Span, Vec<Item>),
   Unloaded(Span, PathBuf),
   Error(ErrorGuaranteed),
 }

--- a/vine/src/ast.rs
+++ b/vine/src/ast.rs
@@ -10,14 +10,15 @@ use vine_util::interner::Interned;
 
 use crate::{diag::ErrorGuaranteed, resolve::DefId};
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Item {
   pub span: Span,
+  pub vis: Vis,
   pub attrs: Vec<Attr>,
   pub kind: ItemKind,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Default, Debug, Clone)]
 pub enum ItemKind {
   Fn(FnItem),
   Const(ConstItem),
@@ -28,6 +29,7 @@ pub enum ItemKind {
   Mod(ModItem),
   Use(UseItem),
   Ivy(InlineIvy),
+  #[default]
   Taken,
 }
 
@@ -110,6 +112,14 @@ pub struct InlineIvy {
   pub generics: Vec<Ident>,
   pub ty: Ty,
   pub net: Net,
+}
+
+#[derive(Default, Debug, Clone)]
+pub enum Vis {
+  #[default]
+  Private,
+  Public,
+  PublicTo(Path),
 }
 
 #[derive(Clone)]

--- a/vine/src/ast.rs
+++ b/vine/src/ast.rs
@@ -119,7 +119,7 @@ pub enum Vis {
   #[default]
   Private,
   Public,
-  PublicTo(Path),
+  PublicTo(Span, Ident),
 }
 
 #[derive(Clone)]

--- a/vine/src/checker/check_expr/check_method.rs
+++ b/vine/src/checker/check_expr/check_method.rs
@@ -57,7 +57,7 @@ impl Checker<'_> {
     self.concretize(&mut ty);
     let mod_id = self.get_ty_mod(&ty)?;
     let Some(mod_id) = mod_id else { Err(Diag::NoMethods { span, ty: self.display_type(&ty) })? };
-    let fn_id = self.resolver.resolve_path(path.span, mod_id, &path.path)?;
+    let fn_id = self.resolver.resolve_path(path.span, self.cur_def, mod_id, &path.path)?;
     let sub_path = replace(&mut path.path, self.resolver.defs[fn_id].canonical.clone());
     let (form, mut receiver_ty, params, ret) = self.method_sig(span, path, args.len())?;
     if self.get_ty_mod(&receiver_ty)? != Some(mod_id) {

--- a/vine/src/checker/typeof_def.rs
+++ b/vine/src/checker/typeof_def.rs
@@ -13,6 +13,13 @@ impl Checker<'_> {
     let Some(value_def) = &def.value_def else {
       return Err(Diag::PathNoValue { span, path: def.canonical.clone() });
     };
+    if !self.resolver.visible(value_def.vis, self.cur_def) {
+      return Err(Diag::ValueInvisible {
+        span,
+        path: def.canonical.clone(),
+        vis: self.resolver.defs[value_def.vis].canonical.clone(),
+      });
+    }
     let generic_count = value_def.generics.len();
     Self::check_generic_count(span, def, path, generic_count)?;
     let generics = self.hydrate_generics(path, generic_count);
@@ -31,6 +38,13 @@ impl Checker<'_> {
     let Some(type_def) = &def.type_def else {
       Err(Diag::PathNoType { span, path: def.canonical.clone() })?
     };
+    if !self.resolver.visible(type_def.vis, self.cur_def) {
+      return Err(Diag::TypeInvisible {
+        span,
+        path: def.canonical.clone(),
+        vis: self.resolver.defs[type_def.vis].canonical.clone(),
+      });
+    }
     let generic_count = type_def.generics.len();
     Self::check_generic_count(span, def, path, generic_count)?;
     if !inference && path.generics.is_none() && generic_count != 0 {
@@ -62,6 +76,13 @@ impl Checker<'_> {
     let Some(variant_def) = &variant.variant_def else {
       Err(Diag::PathNoPat { span, path: variant.canonical.clone() })?
     };
+    if !self.resolver.visible(variant_def.vis, self.cur_def) {
+      return Err(Diag::PatInvisible {
+        span,
+        path: variant.canonical.clone(),
+        vis: self.resolver.defs[variant_def.vis].canonical.clone(),
+      });
+    }
     let adt_id = variant_def.adt;
     let adt = &self.resolver.defs[adt_id];
     let adt_def = adt.adt_def.as_ref().unwrap();

--- a/vine/src/diag.rs
+++ b/vine/src/diag.rs
@@ -134,6 +134,18 @@ diags! {
     ["type `{ty}` has no methods"]
   BadMethodReceiver { base_path: Path, sub_path: Path }
     ["`{base_path}::{sub_path}` cannot be used as a method; it does not take `{base_path}` as its first parameter"]
+  Invisible { path: Path, vis: Path }
+    ["`{path}` is only visible within `{vis}`"]
+  BadVis
+    ["invalid visibility; expected the name of an ancestor module"]
+  ValueInvisible { path: Path, vis: Path }
+    ["the value `{path}` is only visible within `{vis}`"]
+  TypeInvisible { path: Path, vis: Path }
+    ["the type `{path}` is only visible within `{vis}`"]
+  PatInvisible { path: Path, vis: Path }
+    ["the pattern `{path}` is only visible within `{vis}`"]
+  VisibleSubitem
+    ["subitems must be private"]
 }
 
 fn plural<'a>(n: usize, plural: &'a str, singular: &'a str) -> &'a str {
@@ -153,6 +165,10 @@ impl DiagGroup {
   pub(crate) fn add(&mut self, diag: Diag) -> ErrorGuaranteed {
     self.diags.push(diag);
     ErrorGuaranteed(())
+  }
+
+  pub fn add_all(&mut self, diags: &mut DiagGroup) {
+    self.diags.append(&mut diags.diags);
   }
 
   pub fn ok(&mut self) -> Result<(), Diag> {

--- a/vine/src/fmt.rs
+++ b/vine/src/fmt.rs
@@ -37,7 +37,7 @@ impl<'src> Formatter<'src> {
       match &item.vis {
         Vis::Private => Doc::EMPTY,
         Vis::Public => Doc("pub "),
-        Vis::PublicTo(path) => Doc::concat([Doc("pub("), self.fmt_path(path), Doc(") ")]),
+        Vis::PublicTo(_, name) => Doc::concat([Doc("pub("), Doc(*name), Doc(") ")]),
       },
       match &item.kind {
         ItemKind::Fn(f) => {

--- a/vine/src/fmt.rs
+++ b/vine/src/fmt.rs
@@ -97,12 +97,12 @@ impl<'src> Formatter<'src> {
           Doc("mod "),
           Doc(m.name),
           match &m.kind {
-            ModKind::Loaded(items) => Doc::concat([
+            ModKind::Loaded(_, items) if items.is_empty() => Doc(" {}"),
+            ModKind::Loaded(span, items) => Doc::concat([
               Doc(" {"),
-              Doc::indent([self.line_break_separated(
-                item.span,
-                items.iter().map(|x| (x.span, self.fmt_item(x))),
-              )]),
+              Doc::indent([
+                self.line_break_separated(*span, items.iter().map(|x| (x.span, self.fmt_item(x)))),
+              ]),
               Doc("}"),
             ]),
             ModKind::Unloaded(span, _) => {

--- a/vine/src/fmt.rs
+++ b/vine/src/fmt.rs
@@ -6,7 +6,7 @@ use doc::{Doc, Writer};
 use crate::{
   ast::{
     Block, ComparisonOp, Expr, ExprKind, GenericPath, Ident, Item, ItemKind, LogicalOp, ModKind,
-    Pat, PatKind, Path, Span, Stmt, StmtKind, Ty, TyKind, UseTree,
+    Pat, PatKind, Path, Span, Stmt, StmtKind, Ty, TyKind, UseTree, Vis,
   },
   diag::Diag,
   parser::VineParser,
@@ -34,6 +34,11 @@ struct Formatter<'src> {
 impl<'src> Formatter<'src> {
   fn fmt_item(&self, item: &Item) -> Doc<'src> {
     Doc::concat(item.attrs.iter().flat_map(|x| [self.fmt_verbatim(x.span), Doc::LINE]).chain([
+      match &item.vis {
+        Vis::Private => Doc::EMPTY,
+        Vis::Public => Doc("pub "),
+        Vis::PublicTo(path) => Doc::concat([Doc("pub("), self.fmt_path(path), Doc(") ")]),
+      },
       match &item.kind {
         ItemKind::Fn(f) => {
           let params = &f.params;
@@ -111,7 +116,7 @@ impl<'src> Formatter<'src> {
           self.fmt_use_tree(&u.tree),
           Doc(";"),
         ]),
-        ItemKind::Ivy(_) => self.fmt_verbatim(item.span),
+        ItemKind::Ivy(_) => return self.fmt_verbatim(item.span),
         ItemKind::Pattern(_) => todo!(),
         ItemKind::Taken => unreachable!(),
       },

--- a/vine/src/lexer.rs
+++ b/vine/src/lexer.rs
@@ -92,6 +92,8 @@ pub enum Token {
   #[token("_")]
   Hole,
 
+  #[token("pub")]
+  Pub,
   #[token("mod")]
   Mod,
   #[token("use")]

--- a/vine/src/loader.rs
+++ b/vine/src/loader.rs
@@ -47,7 +47,7 @@ impl<'ctx> Loader<'ctx> {
     let io = Ident(self.interner.intern("IO"));
     self.root.push(Item {
       span: Span::NONE,
-      vis: Vis::Public,
+      vis: Vis::Private,
       attrs: Vec::new(),
       kind: ItemKind::Const(ConstItem {
         name: main,
@@ -61,7 +61,7 @@ impl<'ctx> Loader<'ctx> {
                 span: Span::NONE,
                 kind: TyKind::Path(GenericPath {
                   span: Span::NONE,
-                  path: ast::Path { segments: vec![io], absolute: true, resolved: None },
+                  path: ast::Path { segments: vec![io], absolute: false, resolved: None },
                   generics: None,
                 }),
               })),

--- a/vine/src/loader.rs
+++ b/vine/src/loader.rs
@@ -11,7 +11,7 @@ use vine_util::interner::StringInterner;
 use crate::{
   ast::{
     self, ConstItem, Expr, ExprKind, GenericPath, Ident, Item, ItemKind, ModItem, ModKind, Span,
-    Ty, TyKind,
+    Ty, TyKind, Vis,
   },
   diag::{Diag, DiagGroup, FileInfo},
   parser::VineParser,
@@ -47,6 +47,7 @@ impl<'ctx> Loader<'ctx> {
     let io = Ident(self.interner.intern("IO"));
     self.root.push(Item {
       span: Span::NONE,
+      vis: Vis::Public,
       attrs: Vec::new(),
       kind: ItemKind::Const(ConstItem {
         name: main,
@@ -89,6 +90,7 @@ impl<'ctx> Loader<'ctx> {
     let path = path.into();
     let module = Item {
       span: Span::NONE,
+      vis: Vis::Public,
       attrs: Vec::new(),
       kind: ItemKind::Mod(ModItem {
         name: self.auto_mod_name(&path),

--- a/vine/src/loader.rs
+++ b/vine/src/loader.rs
@@ -38,7 +38,7 @@ impl<'ctx> Loader<'ctx> {
   }
 
   pub fn finish(&mut self) -> ModKind {
-    ModKind::Loaded(take(&mut self.root))
+    ModKind::Loaded(Span::NONE, take(&mut self.root))
   }
 
   pub fn load_main_mod(&mut self, path: impl Into<PathBuf>) {
@@ -114,7 +114,7 @@ impl<'ctx> Loader<'ctx> {
 
   fn load_file(&mut self, path: PathBuf, span: Span) -> ModKind {
     match self._load_file(path, span) {
-      Ok(items) => ModKind::Loaded(items),
+      Ok(items) => ModKind::Loaded(span, items),
       Err(diag) => ModKind::Error(self.diags.add(diag)),
     }
   }

--- a/vine/src/parser.rs
+++ b/vine/src/parser.rs
@@ -91,9 +91,11 @@ impl<'ctx, 'src> VineParser<'ctx, 'src> {
   fn parse_vis(&mut self) -> Parse<'src, Vis> {
     Ok(if self.eat(Token::Pub)? {
       if self.eat(Token::OpenParen)? {
-        let path = self.parse_path()?;
+        let span = self.start_span();
+        let ancestor = self.parse_ident()?;
+        let span = self.end_span(span);
         self.expect(Token::CloseParen)?;
-        Vis::PublicTo(path)
+        Vis::PublicTo(span, ancestor)
       } else {
         Vis::Public
       }

--- a/vine/src/repl.rs
+++ b/vine/src/repl.rs
@@ -67,7 +67,7 @@ impl<'ctx, 'ivm> Repl<'ctx, 'ivm> {
 
     resolver.diags.report(&loader.files)?;
 
-    let repl_mod = resolver.get_or_insert_child(0, Ident(interner.intern("repl"))).id;
+    let repl_mod = resolver.get_or_insert_child(0, Ident(interner.intern("repl")), 0).id;
 
     let mut checker = Checker::new(&mut resolver);
     checker.check_defs();
@@ -122,7 +122,7 @@ impl<'ctx, 'ivm> Repl<'ctx, 'ivm> {
 
     let new_defs = self.resolver.defs.len();
     let new_uses = self.resolver.next_use_id;
-    self.resolver.build_mod(self.loader.finish(), 0);
+    self.resolver.build_mod(0, self.loader.finish(), 0);
     self.resolver.extract_subitems(self.repl_mod, &mut stmts);
     let new_defs = new_defs..self.resolver.defs.len();
 

--- a/vine/src/resolve.rs
+++ b/vine/src/resolve.rs
@@ -35,10 +35,17 @@ pub struct Def {
 
   members: HashMap<Ident, Member>,
   parent: Option<DefId>,
+  ancestors: Vec<DefId>,
 }
 
 #[derive(Debug)]
-enum Member {
+struct Member {
+  pub vis: DefId,
+  pub kind: MemberKind,
+}
+
+#[derive(Debug)]
+enum MemberKind {
   Child(DefId),
   ResolvedImport(DefId, UseId),
   UnresolvedImport(Span, Option<Path>, UseId),
@@ -46,6 +53,7 @@ enum Member {
 
 #[derive(Debug)]
 pub struct ValueDef {
+  pub vis: DefId,
   pub generics: Vec<Ident>,
   pub annotation: Option<Ty>,
   pub ty: Option<Type>,
@@ -62,6 +70,7 @@ pub enum ValueDefKind {
 
 #[derive(Debug)]
 pub struct TypeDef {
+  pub vis: DefId,
   pub generics: Vec<Ident>,
   pub alias: Option<Ty>,
   pub ty: Option<Type>,
@@ -75,6 +84,7 @@ pub struct AdtDef {
 
 #[derive(Debug)]
 pub struct VariantDef {
+  pub vis: DefId,
   pub generics: Vec<Ident>,
   pub adt: DefId,
   pub variant: usize,

--- a/vine/src/resolve/build_graph.rs
+++ b/vine/src/resolve/build_graph.rs
@@ -1,46 +1,53 @@
 use std::{collections::hash_map::Entry, mem::take};
 
 use crate::{
-  ast::{AttrKind, Builtin, Expr, ExprKind, Ident, Item, ItemKind, ModKind, Path, Span, UseTree},
+  ast::{
+    AttrKind, Builtin, Expr, ExprKind, Ident, Item, ItemKind, ModKind, Path, Span, UseTree, Vis,
+  },
   diag::{Diag, DiagGroup},
   visit::{VisitMut, Visitee},
 };
 
 use super::{
-  AdtDef, Def, DefId, Member, Resolver, TypeDef, UseId, ValueDef, ValueDefKind, VariantDef,
+  AdtDef, Def, DefId, Member, MemberKind, Resolver, TypeDef, UseId, ValueDef, ValueDefKind,
+  VariantDef,
 };
 
 impl Resolver {
   pub fn build_graph(&mut self, root: ModKind) {
-    let def = self.new_def(Path::ROOT, None);
+    let def = self.new_def(Path::ROOT, None, 0);
     debug_assert_eq!(def, 0);
-    self.build_mod(root, def);
+    self.build_mod(0, root, def);
     if let Some(&prelude) = self.builtins.get(&Builtin::Prelude) {
       self.defs[prelude].parent = None;
       self.defs[0].parent = Some(prelude);
     }
   }
 
-  pub(crate) fn build_mod(&mut self, module: ModKind, def: DefId) {
+  pub(crate) fn build_mod(&mut self, vis: DefId, module: ModKind, def: DefId) {
     let ModKind::Loaded(items) = module else { unreachable!("module not yet loaded") };
     for item in items {
-      self.build_item(item, def);
+      self.build_item(vis, item, def);
     }
   }
 
-  fn build_item(&mut self, item: Item, parent: DefId) {
+  fn build_item(&mut self, member_vis: DefId, item: Item, parent: DefId) {
+    let span = item.span;
+    let vis = self.resolve_vis(parent, item.vis);
+    let member_vis = vis.max(member_vis);
     let def_id = match item.kind {
       ItemKind::Fn(f) => self.define_value(
-        item.span,
+        span,
         parent,
         f.name,
         ValueDef {
+          vis,
           generics: f.generics,
           annotation: None,
           ty: None,
           locals: 0,
           kind: ValueDefKind::Expr(Expr {
-            span: item.span,
+            span,
             kind: ExprKind::Fn(
               f.params,
               Some(f.ret),
@@ -48,34 +55,39 @@ impl Resolver {
             ),
           }),
         },
+        member_vis,
       ),
       ItemKind::Const(c) => self.define_value(
-        item.span,
+        span,
         parent,
         c.name,
         ValueDef {
+          vis,
           generics: c.generics,
           annotation: Some(c.ty),
           ty: None,
           locals: 0,
           kind: ValueDefKind::Expr(c.value),
         },
+        member_vis,
       ),
       ItemKind::Ivy(i) => self.define_value(
-        item.span,
+        span,
         parent,
         i.name,
         ValueDef {
+          vis,
           generics: i.generics,
           annotation: Some(i.ty),
           ty: None,
           locals: 0,
           kind: ValueDefKind::Ivy(i.net),
         },
+        member_vis,
       ),
       ItemKind::Mod(m) => {
-        let child = self.get_or_insert_child(parent, m.name).id;
-        self.build_mod(m.kind, child);
+        let child = self.get_or_insert_child(parent, m.name, member_vis).id;
+        self.build_mod(vis, m.kind, child);
         Some(child)
       }
       ItemKind::Use(u) => {
@@ -85,23 +97,25 @@ impl Resolver {
           u.tree,
           &mut self.defs[parent],
           &mut Path { segments: Vec::new(), absolute: u.absolute, resolved: None },
+          member_vis,
         );
         self.next_use_id += 1;
         None
       }
       ItemKind::Struct(s) => {
-        let child = self.get_or_insert_child(parent, s.name);
+        let child = self.get_or_insert_child(parent, s.name, member_vis);
         if child.type_def.is_some()
           || child.adt_def.is_some()
           || child.variant_def.is_some()
           || child.value_def.is_some()
         {
-          self.diags.add(Diag::DuplicateItem { span: item.span, name: s.name });
+          self.diags.add(Diag::DuplicateItem { span, name: s.name });
           return;
         }
-        child.type_def = Some(TypeDef { generics: s.generics.clone(), alias: None, ty: None });
+        child.type_def = Some(TypeDef { vis, generics: s.generics.clone(), alias: None, ty: None });
         child.adt_def = Some(AdtDef { generics: s.generics.clone(), variants: vec![child.id] });
         child.variant_def = Some(VariantDef {
+          vis,
           generics: s.generics.clone(),
           adt: child.id,
           variant: 0,
@@ -109,6 +123,7 @@ impl Resolver {
           field_types: None,
         });
         child.value_def = Some(ValueDef {
+          vis,
           generics: s.generics,
           annotation: None,
           ty: None,
@@ -118,9 +133,9 @@ impl Resolver {
         Some(child.id)
       }
       ItemKind::Enum(e) => {
-        let child = self.get_or_insert_child(parent, e.name);
+        let child = self.get_or_insert_child(parent, e.name, member_vis);
         if child.type_def.is_some() || child.adt_def.is_some() {
-          self.diags.add(Diag::DuplicateItem { span: item.span, name: e.name });
+          self.diags.add(Diag::DuplicateItem { span, name: e.name });
           return;
         }
         let adt = child.id;
@@ -129,12 +144,13 @@ impl Resolver {
           .into_iter()
           .enumerate()
           .filter_map(|(i, v)| {
-            let variant = self.get_or_insert_child(adt, v.name);
+            let variant = self.get_or_insert_child(adt, v.name, member_vis);
             if variant.variant_def.is_some() || variant.value_def.is_some() {
-              self.diags.add(Diag::DuplicateItem { span: item.span, name: v.name });
+              self.diags.add(Diag::DuplicateItem { span, name: v.name });
               return None;
             }
             variant.variant_def = Some(VariantDef {
+              vis,
               generics: e.generics.clone(),
               adt,
               variant: i,
@@ -142,6 +158,7 @@ impl Resolver {
               field_types: None,
             });
             variant.value_def = Some(ValueDef {
+              vis,
               generics: e.generics.clone(),
               annotation: None,
               ty: None,
@@ -152,18 +169,18 @@ impl Resolver {
           })
           .collect();
         self.defs[adt].type_def =
-          Some(TypeDef { generics: e.generics.clone(), alias: None, ty: None });
+          Some(TypeDef { vis, generics: e.generics.clone(), alias: None, ty: None });
         self.defs[adt].adt_def = Some(AdtDef { generics: e.generics, variants });
         Some(adt)
       }
       ItemKind::Type(t) => {
-        let child = self.get_or_insert_child(parent, t.name);
+        let child = self.get_or_insert_child(parent, t.name, member_vis);
         if child.type_def.is_some() || child.adt_def.is_some() {
-          self.diags.add(Diag::DuplicateItem { span: item.span, name: t.name });
+          self.diags.add(Diag::DuplicateItem { span, name: t.name });
           return;
         }
         child.type_def =
-          Some(TypeDef { generics: t.generics.clone(), alias: Some(t.ty), ty: None });
+          Some(TypeDef { vis, generics: t.generics.clone(), alias: Some(t.ty), ty: None });
         Some(child.id)
       }
       ItemKind::Pattern(_) => todo!(),
@@ -173,13 +190,31 @@ impl Resolver {
       match attr.kind {
         AttrKind::Builtin(b) => {
           let Some(def_id) = def_id else {
-            self.diags.add(Diag::BadBuiltin { span: item.span });
+            self.diags.add(Diag::BadBuiltin { span });
             continue;
           };
           let old = self.builtins.insert(b, def_id);
           if old.is_some() {
-            self.diags.add(Diag::BadBuiltin { span: item.span });
+            self.diags.add(Diag::BadBuiltin { span });
           }
+        }
+      }
+    }
+  }
+
+  fn resolve_vis(&mut self, base: DefId, vis: Vis) -> DefId {
+    match vis {
+      Vis::Private => base,
+      Vis::Public => 0,
+      Vis::PublicTo(span, name) => {
+        let ancestors = &self.defs[base].ancestors;
+        if let Some(&ancestor) =
+          ancestors.iter().rev().find(|&&a| self.defs[a].canonical.segments.last() == Some(&name))
+        {
+          ancestor
+        } else {
+          self.diags.add(Diag::BadVis { span });
+          0
         }
       }
     }
@@ -191,8 +226,9 @@ impl Resolver {
     parent: DefId,
     name: Ident,
     mut value: ValueDef,
+    vis: DefId,
   ) -> Option<DefId> {
-    let child = self.get_or_insert_child(parent, name);
+    let child = self.get_or_insert_child(parent, name, vis);
     if child.value_def.is_some() {
       self.diags.add(Diag::DuplicateItem { span, name });
       return None;
@@ -211,24 +247,25 @@ impl Resolver {
     SubitemVisitor { resolver: self, def }.visit(visitee);
   }
 
-  pub(crate) fn get_or_insert_child(&mut self, parent: DefId, name: Ident) -> &mut Def {
+  pub(crate) fn get_or_insert_child(&mut self, parent: DefId, name: Ident, vis: DefId) -> &mut Def {
     let next_child = self.next_def_id();
     let parent_def = &mut self.defs[parent];
     let mut new = false;
     let member = parent_def.members.entry(name).or_insert_with(|| {
       new = true;
-      Member::Child(next_child)
+      Member { vis, kind: MemberKind::Child(next_child) }
     });
-    let child = match member {
-      Member::Child(child) => *child,
+    let child = match member.kind {
+      MemberKind::Child(child) => child,
       _ => {
         new = true;
         next_child
       }
     };
+    member.vis = member.vis.min(vis);
     if new {
       let path = parent_def.canonical.extend(&[name]);
-      self.new_def(path, Some(parent));
+      self.new_def(path, Some(parent), vis);
     }
     &mut self.defs[child]
   }
@@ -239,18 +276,19 @@ impl Resolver {
     tree: UseTree,
     def: &mut Def,
     path: &mut Path,
+    vis: DefId,
   ) {
     let initial_len = path.segments.len();
     path.segments.extend(&tree.path.segments);
     if let Some(children) = tree.children {
       for child in children {
-        Self::build_imports(use_id, diags, child, def, path);
+        Self::build_imports(use_id, diags, child, def, path, vis);
       }
     } else {
       let name = *path.segments.last().unwrap();
       let path = path.clone();
       if let Entry::Vacant(e) = def.members.entry(name) {
-        e.insert(Member::UnresolvedImport(tree.span, Some(path), use_id));
+        e.insert(Member { vis, kind: MemberKind::UnresolvedImport(tree.span, Some(path), use_id) });
       } else {
         diags.add(Diag::DuplicateItem { span: tree.span, name });
       }
@@ -262,7 +300,7 @@ impl Resolver {
     self.defs.len()
   }
 
-  fn new_def(&mut self, mut canonical: Path, parent: Option<usize>) -> DefId {
+  fn new_def(&mut self, mut canonical: Path, parent: Option<usize>, vis: DefId) -> DefId {
     let id = self.defs.len();
     canonical.resolved = Some(id);
     let mut def = Def {
@@ -270,13 +308,17 @@ impl Resolver {
       canonical,
       members: Default::default(),
       parent,
+      ancestors: Vec::new(),
       value_def: None,
       type_def: None,
       adt_def: None,
       variant_def: None,
     };
+    if let Some(parent) = parent {
+      def.ancestors = self.defs[parent].ancestors.iter().copied().chain([parent]).collect();
+    }
     if let Some(&name) = def.canonical.segments.last() {
-      def.members.insert(name, Member::Child(id));
+      def.members.insert(name, Member { vis, kind: MemberKind::Child(id) });
     }
     self.defs.push(def);
     id
@@ -285,9 +327,11 @@ impl Resolver {
   pub fn revert(&mut self, old_def_count: usize, old_use_count: usize) {
     self.defs.truncate(old_def_count);
     for def in &mut self.defs {
-      def.members.retain(|_, m| match *m {
-        Member::Child(id) => id < old_def_count,
-        Member::ResolvedImport(_, id) | Member::UnresolvedImport(_, _, id) => id < old_use_count,
+      def.members.retain(|_, m| match m.kind {
+        MemberKind::Child(id) => id < old_def_count,
+        MemberKind::ResolvedImport(_, id) | MemberKind::UnresolvedImport(_, _, id) => {
+          id < old_use_count
+        }
       });
     }
   }
@@ -300,6 +344,9 @@ struct SubitemVisitor<'a> {
 
 impl VisitMut<'_> for SubitemVisitor<'_> {
   fn visit_item(&mut self, item: &mut Item) {
-    self.resolver.build_item(take(item), self.def);
+    if !matches!(item.vis, Vis::Private) {
+      self.resolver.diags.add(Diag::VisibleSubitem { span: item.span });
+    }
+    self.resolver.build_item(self.def, take(item), self.def);
   }
 }

--- a/vine/src/resolve/build_graph.rs
+++ b/vine/src/resolve/build_graph.rs
@@ -1,4 +1,4 @@
-use std::{collections::hash_map::Entry, mem::replace};
+use std::{collections::hash_map::Entry, mem::take};
 
 use crate::{
   ast::{AttrKind, Builtin, Expr, ExprKind, Ident, Item, ItemKind, ModKind, Path, Span, UseTree},
@@ -300,9 +300,6 @@ struct SubitemVisitor<'a> {
 
 impl VisitMut<'_> for SubitemVisitor<'_> {
   fn visit_item(&mut self, item: &mut Item) {
-    self.resolver.build_item(
-      replace(item, Item { span: Span::NONE, attrs: Vec::new(), kind: ItemKind::Taken }),
-      self.def,
-    );
+    self.resolver.build_item(take(item), self.def);
   }
 }

--- a/vine/src/resolve/build_graph.rs
+++ b/vine/src/resolve/build_graph.rs
@@ -25,7 +25,7 @@ impl Resolver {
   }
 
   pub(crate) fn build_mod(&mut self, vis: DefId, module: ModKind, def: DefId) {
-    let ModKind::Loaded(items) = module else { unreachable!("module not yet loaded") };
+    let ModKind::Loaded(_, items) = module else { unreachable!("module not yet loaded") };
     for item in items {
       self.build_item(vis, item, def);
     }

--- a/vine/src/visit.rs
+++ b/vine/src/visit.rs
@@ -254,7 +254,7 @@ pub trait VisitMut<'a> {
         self.visit_expr(&mut c.value);
       }
       ItemKind::Mod(m) => match &mut m.kind {
-        ModKind::Loaded(items) => {
+        ModKind::Loaded(_, items) => {
           for item in items {
             self.visit_item(item);
           }

--- a/vine/std/bool.vi
+++ b/vine/std/bool.vi
@@ -1,5 +1,5 @@
 
-type bool = u32;
+pub type bool = u32;
 
-const true: bool = 1;
-const false: bool = 0;
+pub const true: bool = 1;
+pub const false: bool = 0;

--- a/vine/std/f32.vi
+++ b/vine/std/f32.vi
@@ -1,3 +1,3 @@
 
 #[builtin = "f32"]
-mod f32 {}
+pub mod f32 {}

--- a/vine/std/f32.vi
+++ b/vine/std/f32.vi
@@ -1,5 +1,3 @@
 
 #[builtin = "f32"]
-pub mod f32 {
-
-}
+pub mod f32 {}

--- a/vine/std/f32.vi
+++ b/vine/std/f32.vi
@@ -1,3 +1,5 @@
 
 #[builtin = "f32"]
-pub mod f32 {}
+pub mod f32 {
+
+}

--- a/vine/std/io.vi
+++ b/vine/std/io.vi
@@ -2,13 +2,13 @@
 use std::{list::Buf, option::Option::{Option, Some, None}};
 
 #[builtin = "IO"]
-mod IO {
-  fn println(&io: &IO, str: String) {
+pub mod IO {
+  pub fn println(&io: &IO, str: String) {
     io.print(str);
     io.print_char('\n');
   }
 
-  fn print(&io: &IO, str: String) {
+  pub fn print(&io: &IO, str: String) {
     let List(len, chars, _) = str;
     while len {
       len = len - 1;
@@ -18,11 +18,11 @@ mod IO {
     }
   }
 
-  inline_ivy! print_char: fn(&IO, u32) {
+  pub inline_ivy! print_char: fn(&IO, u32) {
     fn(ref(@io_print_char(char io) io) fn(char _))
   }
 
-  fn print_bytes(&io: &IO, bytes: String) {
+  pub fn print_bytes(&io: &IO, bytes: String) {
     let List(len, bytes, _) = bytes;
     while len {
       len = len - 1;
@@ -32,21 +32,21 @@ mod IO {
     }
   }
 
-  inline_ivy! print_byte: fn(&IO, u32) {
+  pub inline_ivy! print_byte: fn(&IO, u32) {
     fn(ref(@io_print_byte(char io) io) fn(char _))
   }
 
-  inline_ivy! flush: fn(&IO) {
+  pub inline_ivy! flush: fn(&IO) {
     fn(ref(@io_flush(0 io) io) _)
   }
 
-  fn prompt(&io: &IO, msg: String) -> Option[String] {
+  pub fn prompt(&io: &IO, msg: String) -> Option[String] {
     io.print(msg);
     io.flush();
     io.read_line()
   }
 
-  fn read_line(&io: &IO) -> Option[String] {
+  pub fn read_line(&io: &IO) -> Option[String] {
     let byte = io.read_byte(0);
     if byte {
       Some(if byte == '\n' {

--- a/vine/std/list.vi
+++ b/vine/std/list.vi
@@ -2,18 +2,18 @@
 use std::option::Option::{Option, Some, None};
 
 #[builtin = "List"]
-struct List[T](u32, Buf[T], ~Buf[T]);
+pub struct List[T](u32, Buf[T], ~Buf[T]);
 
-struct Buf[T](T, Buf[T]);
+pub(std) struct Buf[T](T, Buf[T]);
 
-type String = List[u32];
+pub type String = List[u32];
 
-mod List {
-  fn len[T](&List(len, _, _): &List[T]) -> u32 {
+pub mod List {
+  pub fn len[T](&List(len, _, _): &List[T]) -> u32 {
     len
   }
 
-  fn map[T, U](List(l, buf, ~_): List[T], f: fn(T) -> U) -> List[U] {
+  pub fn map[T, U](List(l, buf, ~_): List[T], f: fn(T) -> U) -> List[U] {
     let len = l;
     let cur;
     let result = move ~cur;
@@ -28,7 +28,7 @@ mod List {
     List(len, result, move cur)
   }
 
-  fn pop_front[T](&List(len, buf, _): &List[T]) -> Option[T] {
+  pub fn pop_front[T](&List(len, buf, _): &List[T]) -> Option[T] {
     if len {
       len -= 1;
       let Buf(head, tail) = buf;
@@ -40,22 +40,22 @@ mod List {
   }
 
   #[builtin = "concat"]
-  fn concat[T](a: List[T], b: List[T]) -> List[T] {
+  pub fn concat[T](a: List[T], b: List[T]) -> List[T] {
     let List(a_len, a_buf, ~a_end) = a;
     let List(b_len, b_buf, ~b_end) = b;
     a_end = b_buf;
     List(a_len + b_len, a_buf, move ~b_end)
   }
 
-  fn push_back[T](&list: &List[T], el: T) {
+  pub fn push_back[T](&list: &List[T], el: T) {
     list ++= [el];
   }
 
-  fn push_front[T](&list: &List[T], el: T) {
+  pub fn push_front[T](&list: &List[T], el: T) {
     list = [el] ++ list;
   }
 
-  fn join(list: List[String], sep: String) -> String {
+  pub fn join(list: List[String], sep: String) -> String {
     let it = list.into_iter();
     if it.next() is Some(str) {
       while it.next() is Some(val) {
@@ -67,18 +67,18 @@ mod List {
     }
   }
 
-  fn to_string[T](list: List[T], elem_to_string: fn(T) -> String) -> String {
+  pub fn to_string[T](list: List[T], elem_to_string: fn(T) -> String) -> String {
     "[" ++ list.map(elem_to_string).join(", ") ++ "]"
   }
 
-  struct Iter[T](u32, &Buf[T]);
+  pub struct Iter[T](u32, &Buf[T]);
 
-  fn iter[T](&List(len, buf, _): &List[T]) -> Iter[T] {
+  pub fn iter[T](&List(len, buf, _): &List[T]) -> Iter[T] {
     Iter(len, &buf)
   }
 
-  mod Iter {
-    fn next[T](&Iter(len, buf): &Iter[T]) -> Option[&T] {
+  pub mod Iter {
+    pub fn next[T](&Iter(len, buf): &Iter[T]) -> Option[&T] {
       if len {
         len -= 1;
         let &Buf(*head, *tail) = buf;
@@ -91,14 +91,14 @@ mod List {
     }
   }
 
-  struct IntoIter[T](u32, Buf[T]);
+  pub struct IntoIter[T](u32, Buf[T]);
 
-  fn into_iter[T](List(len, buf, _): List[T]) -> IntoIter[T] {
+  pub fn into_iter[T](List(len, buf, _): List[T]) -> IntoIter[T] {
     IntoIter(len, buf)
   }
 
-  mod IntoIter {
-    fn next[T](&IntoIter(len, buf): &IntoIter[T]) -> Option[T] {
+  pub mod IntoIter {
+    pub fn next[T](&IntoIter(len, buf): &IntoIter[T]) -> Option[T] {
       if len {
         len -= 1;
         let Buf(head, tail) = buf;

--- a/vine/std/option.vi
+++ b/vine/std/option.vi
@@ -1,50 +1,50 @@
 
-enum Option[T] {
+pub enum Option[T] {
   Some(T),
   None,
 }
 
-mod Option {
-  fn map[T, U](self: Option[T], f: fn(T) -> U) -> Option[U] {
+pub mod Option {
+  pub fn map[T, U](self: Option[T], f: fn(T) -> U) -> Option[U] {
     match self {
       Some(val) => Some(f(val)),
       None => None,
     }
   }
 
-  fn as_ref[T](&self: &Option[T]) -> Option[&T] {
+  pub fn as_ref[T](&self: &Option[T]) -> Option[&T] {
     match &self {
       &Some(val) => Some(&val),
       &None => None,
     }
   }
 
-  fn flatten[T](self: Option[Option[T]]) -> Option[T] {
+  pub fn flatten[T](self: Option[Option[T]]) -> Option[T] {
     match self {
       Some(Some(val)) => Some(val),
       _ => None,
     }
   }
 
-  fn and_then[T, U](self: Option[T], f: fn(T) -> Option[U]) -> Option[U] {
+  pub fn and_then[T, U](self: Option[T], f: fn(T) -> Option[U]) -> Option[U] {
     self.map(f).flatten()
   }
 
-  fn or[T](self: Option[T], default: Option[T]) -> Option[T] {
+  pub fn or[T](self: Option[T], default: Option[T]) -> Option[T] {
     match self {
       None => default,
       x => x,
     }
   }
 
-  fn unwrap_or[T](self: Option[T], default: T) -> T {
+  pub fn unwrap_or[T](self: Option[T], default: T) -> T {
     match self {
       Some(val) => val,
       None => default,
     }
   }
 
-  fn unwrap[T](self: Option[T]) -> T {
+  pub fn unwrap[T](self: Option[T]) -> T {
     match self {
       Some(val) => val,
     }

--- a/vine/std/result.vi
+++ b/vine/std/result.vi
@@ -1,25 +1,25 @@
 
-enum Result[T, E] {
+pub enum Result[T, E] {
   Ok(T),
   Err(E),
 }
 
-mod Result {
-  fn map[T, U, E](self: Result[T, E], f: fn(T) -> U) -> Result[U, E] {
+pub mod Result {
+  pub fn map[T, U, E](self: Result[T, E], f: fn(T) -> U) -> Result[U, E] {
     match self {
       Ok(val) => Ok(f(val)),
       Err(err) => Err(err),
     }
   }
 
-  fn as_ref[T, E](&self: &Result[T, E]) -> Result[&T, &E] {
+  pub fn as_ref[T, E](&self: &Result[T, E]) -> Result[&T, &E] {
     match &self {
       &Ok(val) => Ok(&val),
       &Err(err) => Err(&err),
     }
   }
 
-  fn flatten[T, E](self: Result[Result[T, E], E]) -> Result[T, E] {
+  pub fn flatten[T, E](self: Result[Result[T, E], E]) -> Result[T, E] {
     match self {
       Ok(Ok(val)) => Ok(val),
       Ok(Err(err)) => Err(err),
@@ -27,25 +27,25 @@ mod Result {
     }
   }
 
-  fn and_then[T, U, E](self: Result[T, E], f: fn(T) -> Result[U, E]) -> Result[U, E] {
+  pub fn and_then[T, U, E](self: Result[T, E], f: fn(T) -> Result[U, E]) -> Result[U, E] {
     self.map(f).flatten()
   }
 
-  fn or[T, E](self: Result[T, E], default: Result[T, E]) -> Result[T, E] {
+  pub fn or[T, E](self: Result[T, E], default: Result[T, E]) -> Result[T, E] {
     match self {
       Err(_) => default,
       x => x,
     }
   }
 
-  fn unwrap_or[T, E](self: Result[T, E], default: T) -> T {
+  pub fn unwrap_or[T, E](self: Result[T, E], default: T) -> T {
     match self {
       Ok(val) => val,
       Err(_) => default,
     }
   }
 
-  fn unwrap[T, E](self: Result[T, E], default: T) -> T {
+  pub fn unwrap[T, E](self: Result[T, E], default: T) -> T {
     match self {
       Ok(val) => val,
     }

--- a/vine/std/rng.vi
+++ b/vine/std/rng.vi
@@ -3,21 +3,21 @@
 
 use std::u64;
 
-struct Rng(u64, u64);
+pub struct Rng(u64, u64);
 
-mod Rng {
-  fn new(state: u64, increment: u64) -> Rng {
+pub mod Rng {
+  pub fn new(state: u64, increment: u64) -> Rng {
     increment |= u64::from_u32(1);
     state = u64::add(state, increment);
     state = u64::add(u64::mul(state, multiplier), increment);
     Rng(state, increment)
   }
 
-  const default: Rng = new((0xd15ea5e5, 0xcafef00d), (0xf767814f, 0x14057b7e));
+  pub const default: Rng = new((0xd15ea5e5, 0xcafef00d), (0xf767814f, 0x14057b7e));
 
   const multiplier: u64 = (0x4c957f2d, 0x5851f42d);
 
-  fn gen_u32(&Rng(state, increment): &Rng) -> u32 {
+  pub fn gen_u32(&Rng(state, increment): &Rng) -> u32 {
     let (lo, hi) = state;
     state = u64::add(u64::mul(state, multiplier), increment);
     u32::rotate_right((hi >> 13) ^ (hi << 5) ^ (lo >> 27), hi >> 27)

--- a/vine/std/std.vi
+++ b/vine/std/std.vi
@@ -10,6 +10,6 @@ pub mod f32 = "./f32.vi";
 pub mod u64 = "./u64.vi";
 
 #[builtin = "prelude"]
-mod prelude {
-  use ::std::{u32, f32, io::IO, list::{List, String}, bool::{bool, true, false}};
+pub mod prelude {
+  pub use ::std::{u32, f32, io::IO, list::{List, String}, bool::{bool, true, false}};
 }

--- a/vine/std/std.vi
+++ b/vine/std/std.vi
@@ -1,13 +1,13 @@
 
-mod bool = "./bool.vi";
-mod io = "./io.vi";
-mod list = "./list.vi";
-mod option = "./option.vi";
-mod result = "./result.vi";
-mod rng = "./rng.vi";
-mod u32 = "./u32.vi";
-mod f32 = "./f32.vi";
-mod u64 = "./u64.vi";
+pub mod bool = "./bool.vi";
+pub mod io = "./io.vi";
+pub mod list = "./list.vi";
+pub mod option = "./option.vi";
+pub mod result = "./result.vi";
+pub mod rng = "./rng.vi";
+pub mod u32 = "./u32.vi";
+pub mod f32 = "./f32.vi";
+pub mod u64 = "./u64.vi";
 
 #[builtin = "prelude"]
 mod prelude {

--- a/vine/std/u32.vi
+++ b/vine/std/u32.vi
@@ -2,8 +2,8 @@
 use std::{list::Buf, option::Option::{Option, Some, None}};
 
 #[builtin = "u32"]
-mod u32 {
-  fn to_string(n: u32) -> String {
+pub mod u32 {
+  pub fn to_string(n: u32) -> String {
     if n {
       let str = "";
       while n {
@@ -16,7 +16,7 @@ mod u32 {
     }
   }
 
-  fn parse(str: String) -> Option[u32] {
+  pub fn parse(str: String) -> Option[u32] {
     let List(len, chars, _) = str;
     if len == 0 {
       None
@@ -36,11 +36,11 @@ mod u32 {
     }
   }
 
-  inline_ivy! rotate_left: fn(u32, u32) -> u32 {
+  pub inline_ivy! rotate_left: fn(u32, u32) -> u32 {
     fn(@u32_rotl(x y) fn(x y))
   }
 
-  inline_ivy! rotate_right: fn(u32, u32) -> u32 {
+  pub inline_ivy! rotate_right: fn(u32, u32) -> u32 {
     fn(@u32_rotr(x y) fn(x y))
   }
 }

--- a/vine/std/u64.vi
+++ b/vine/std/u64.vi
@@ -1,22 +1,22 @@
 
-type u64 = (u32, u32);
+pub type u64 = (u32, u32);
 
-fn from_u32(val: u32) -> u64 {
+pub fn from_u32(val: u32) -> u64 {
   (val, 0)
 }
 
-fn to_u32((lo, hi): u64) -> u32 {
+pub fn to_u32((lo, hi): u64) -> u32 {
   lo
 }
 
-inline_ivy! add: fn(u64, u64) -> u64 {
+pub inline_ivy! add: fn(u64, u64) -> u64 {
   fn(tup(dup(al0 al1) ah) fn(tup(dup(bl0 bl1) bh) tup(l h)))
   al0 = @add(bl0 l)
   al1 = @u32_add_high(bl1 c)
   ah = @add(bh @add(c h))
 }
 
-inline_ivy! mul: fn(u64, u64) -> u64 {
+pub inline_ivy! mul: fn(u64, u64) -> u64 {
   fn(tup(dup(al0 dup(al1 al2)) ah) fn(tup(dup(bl0 dup(bl1 bl2)) bh) tup(l h)))
   al0 = @mul(bl0 l)
   al1 = @u32_mul_high(bl1 ll)


### PR DESCRIPTION
- Resolves #12

Now cursed things like `use std::list::Some` are disallowed, as expected.

Unlike rust, `fn main` must be `pub`.
