### PR TITLE
vine: fix type display

### DIFF
--- a/tests/snaps/vine/fail/atypical.txt
+++ b/tests/snaps/vine/fail/atypical.txt
@@ -5,33 +5,33 @@ error tests/programs/fail/atypical.vi:4:14 - types in item signatures cannot be 
 error tests/programs/fail/atypical.vi:5:12 - types in item signatures cannot be elided
 error - expected type `fn(&IO)`; found `fn(IO)`
 error tests/programs/fail/atypical.vi:5:16 - no function to return from
-error tests/programs/fail/atypical.vi:7:16 - expected type `u32`; found `f32`
-error tests/programs/fail/atypical.vi:8:16 - expected type `f32`; found `u32`
-error tests/programs/fail/atypical.vi:9:23 - expected type `(u32, u32)`; found `(f32, f32)`
-error tests/programs/fail/atypical.vi:10:16 - expected type `(?4, ?5)`; found `u32`
+error tests/programs/fail/atypical.vi:7:16 - expected type `N32`; found `F32`
+error tests/programs/fail/atypical.vi:8:16 - expected type `F32`; found `N32`
+error tests/programs/fail/atypical.vi:9:23 - expected type `(N32, N32)`; found `(F32, F32)`
+error tests/programs/fail/atypical.vi:10:16 - expected type `(?4, ?5)`; found `N32`
 error tests/programs/fail/atypical.vi:11:7 - cannot infer type
-error tests/programs/fail/atypical.vi:12:3 - cannot call non-function type `u32`
-error tests/programs/fail/atypical.vi:13:14 - cannot apply operator `+` to types `u32` and `~u32`
+error tests/programs/fail/atypical.vi:12:3 - cannot call non-function type `N32`
+error tests/programs/fail/atypical.vi:13:14 - cannot apply operator `+` to types `N32` and `~N32`
 error tests/programs/fail/atypical.vi:14:5 - cannot find `noop` in `::std::n32::N32`
-error tests/programs/fail/atypical.vi:15:6 - expected type `bool`; found `f32`
-error tests/programs/fail/atypical.vi:15:3 - then block has type `u32` but else block has type `::std::list::List[char]`
+error tests/programs/fail/atypical.vi:15:6 - expected type `Bool`; found `F32`
+error tests/programs/fail/atypical.vi:15:3 - then block has type `N32` but else block has type `::std::list::List[Char]`
 error tests/programs/fail/atypical.vi:16:3 - function type `fn(IO)` expects 1 argument; was passed 3
-error tests/programs/fail/atypical.vi:17:3 - cannot compare `u32` and `f32`
-error tests/programs/fail/atypical.vi:17:3 - cannot compare `f32` and `u32`
-error tests/programs/fail/atypical.vi:17:3 - cannot compare `u32` and `f32`
+error tests/programs/fail/atypical.vi:17:3 - cannot compare `N32` and `F32`
+error tests/programs/fail/atypical.vi:17:3 - cannot compare `F32` and `N32`
+error tests/programs/fail/atypical.vi:17:3 - cannot compare `N32` and `F32`
 error tests/programs/fail/atypical.vi:18:7 - `::atypical::Thing` has 2 fields; 1 was matched
 error tests/programs/fail/atypical.vi:18:18 - no value associated with `::atypical::Foo`
 error tests/programs/fail/atypical.vi:19:12 - no type associated with `::atypical::foo`
-error tests/programs/fail/atypical.vi:20:14 - expected type `T`; found `u32`
+error tests/programs/fail/atypical.vi:20:14 - expected type `T`; found `N32`
 error tests/programs/fail/atypical.vi:21:14 - expected type `U`; found `T`
 error tests/programs/fail/atypical.vi:22:7 - expected an irrefutable pattern
-error tests/programs/fail/atypical.vi:22:17 - expected type `::atypical::Ay`; found `u32`
-error tests/programs/fail/atypical.vi:23:4 - cannot apply operator `+` to types `::std::list::List[char]` and `u32`
-error tests/programs/fail/atypical.vi:24:7 - expected type `u32`; found `&?15`
+error tests/programs/fail/atypical.vi:22:17 - expected type `::atypical::Ay`; found `N32`
+error tests/programs/fail/atypical.vi:23:4 - cannot apply operator `+` to types `::std::list::List[Char]` and `N32`
+error tests/programs/fail/atypical.vi:24:7 - expected type `N32`; found `&?15`
 error tests/programs/fail/atypical.vi:25:3 - no loop to continue
 error tests/programs/fail/atypical.vi:26:3 - no loop to break from
-error tests/programs/fail/atypical.vi:27:10 - expected type `()`; found `f32`
-error tests/programs/fail/atypical.vi:28:14 - cannot apply operator `+` to types `~u32` and `~u32`
-error tests/programs/fail/atypical.vi:29:3 - cannot apply operator `+=` to types `u32` and `f32`
+error tests/programs/fail/atypical.vi:27:10 - expected type `()`; found `F32`
+error tests/programs/fail/atypical.vi:28:14 - cannot apply operator `+` to types `~N32` and `~N32`
+error tests/programs/fail/atypical.vi:29:3 - cannot apply operator `+=` to types `N32` and `F32`
 error tests/programs/fail/atypical.vi:30:5 - `::std::n32::N32::parse` cannot be used as a method; it does not take `::std::n32::N32` as its first parameter
-error tests/programs/fail/atypical.vi:6:27 - expected type `()`; found `u32`
+error tests/programs/fail/atypical.vi:6:27 - expected type `()`; found `N32`

--- a/vine/src/checker/display_type.rs
+++ b/vine/src/checker/display_type.rs
@@ -11,10 +11,10 @@ impl<'core> Checker<'core, '_> {
 
   fn _display_type(&self, ty: &Type, str: &mut String) {
     match ty {
-      Type::Bool => *str += "bool",
-      Type::N32 => *str += "u32",
-      Type::F32 => *str += "f32",
-      Type::Char => *str += "char",
+      Type::Bool => *str += "Bool",
+      Type::N32 => *str += "N32",
+      Type::F32 => *str += "F32",
+      Type::Char => *str += "Char",
       Type::IO => *str += "IO",
       Type::Tuple(t) => {
         *str += "(";


### PR DESCRIPTION
`checker/display_type` was not properly updated in #93, and was still printing types with their old names.