### PR TITLE
vine: make annotations a kind of pattern

### DIFF
--- a/tests/programs/aoc_2024/day_04.vi
+++ b/tests/programs/aoc_2024/day_04.vi
@@ -9,7 +9,7 @@ pub fn main(&io: &IO) {
 
   let matches = diamond(
     lines,
-    fn(char: Char, Neighbors(nw, n, ne, w, e, sw, s, se): Neighbors[Char], &matches: &N32) {
+    fn(char: Char, Neighbors[Char](nw, n, ne, w, e, sw, s, se), &matches: &N32) {
       if char == 'X' {
         nw.send('X');
         n.send('X');
@@ -43,7 +43,7 @@ pub fn main(&io: &IO) {
 
   let matches = diamond(
     lines,
-    fn(char: Char, Neighbors(nw, _, ne, _, _, sw, _, se): Neighbors[Char], &matches: &N32) {
+    fn(char: Char, Neighbors[Char](nw, _, ne, _, _, sw, _, se), &matches: &N32) {
       if char == 'A' {
         let nw = nw.send('A');
         let ne = ne.send('A');
@@ -71,17 +71,17 @@ pub fn main(&io: &IO) {
 struct Channel[M](M, ~M);
 
 mod Channel {
-  pub fn send[M](Channel(got, ~out): Channel[M], value: M) -> M {
+  pub fn send[M](Channel[M](got, ~out), value: M) -> M {
     out = value;
     got
   }
 
-  pub fn get[M](&Channel(i, _): &Channel[M]) -> M {
+  pub fn get[M](&Channel[M](i, _)) -> M {
     i
   }
 }
 
-fn relay(Channel(ai, ~ao): Channel[Char], Channel(bi, ~bo): Channel[Char], recv: Char, send: Char) {
+fn relay(Channel[Char](ai, ~ao), Channel[Char](bi, ~bo), recv: Char, send: Char) {
   bo = if ai == recv {
     send
   } else {
@@ -94,7 +94,7 @@ fn relay(Channel(ai, ~ao): Channel[Char], Channel(bi, ~bo): Channel[Char], recv:
   };
 }
 
-fn check(Channel(i, ~o): Channel[Char], recv: Char) -> N32 {
+fn check(Channel[Char](i, ~o), recv: Char) -> N32 {
   o = '_';
   if i == recv {
     1

--- a/tests/programs/aoc_2024/day_05.vi
+++ b/tests/programs/aoc_2024/day_05.vi
@@ -44,7 +44,7 @@ pub fn main(&io: &IO) {
       }
       part2 += *out.get(out.len() / 2);
 
-      fn process(num: N32, &(out, pending, nums_mask): &(List[N32], List[(N32, Mask)], Mask)) {
+      fn process(num: N32, &(out: List[N32], pending: List[(N32, Mask)], nums_mask: Mask)) {
         out ++= [num];
         set_bit(&nums_mask, num, false);
         let ~future;

--- a/tests/programs/aoc_2024/day_08.vi
+++ b/tests/programs/aoc_2024/day_08.vi
@@ -13,13 +13,13 @@ pub fn main(&io: &IO) {
   let width = (*grid.get(0)).len();
   let height = grid.len();
 
-  dyn fn check_antinode((x, y): (N32, N32)) {
+  dyn fn check_antinode((x: N32, y: N32)) {
     if x < width && y < height {
       antinodes1.insert((x, y), ());
     }
   }
 
-  dyn fn check_dir((x, y): (N32, N32), dir: (N32, N32)) {
+  dyn fn check_dir((x: N32, y: N32), dir: (N32, N32)) {
     while x < width && y < height {
       antinodes2.insert((x, y), ());
       (x, y) += dir;

--- a/tests/programs/aoc_2024/day_10.vi
+++ b/tests/programs/aoc_2024/day_10.vi
@@ -9,7 +9,7 @@ pub fn main(&io: &IO) {
   let ratings = 0;
   cross(
     input.split_trim("\n"),
-    fn(char: Char, Neighbors(n, s, e, w), &(io, id, scores, ratings): &(IO, N32, N32, N32)) {
+    fn(char: Char, Neighbors(n, s, e, w), &(io: IO, id: N32, scores: N32, ratings: N32)) {
       let Channel((nit, nis), ~(not, nos)) = n;
       let Channel((sit, sis), ~(sot, sos)) = s;
       let Channel((eit, eis), ~(eot, eos)) = e;
@@ -26,7 +26,7 @@ pub fn main(&io: &IO) {
         let prev = char - 1;
         let in_s = zero_set;
         let in_n = 0;
-        dyn fn recv(t: Char, (s, n): (Set, N32)) {
+        dyn fn recv(t: Char, (s: Set, n: N32)) {
           if t == prev {
             in_s |= s;
             in_n += n;
@@ -101,17 +101,17 @@ fn count(s: Set) -> N32 {
 struct Channel[M](M, ~M);
 
 mod Channel {
-  pub fn send[M](Channel(got, ~out): Channel[M], value: M) -> M {
+  pub fn send[M](Channel[M](got, ~out), value: M) -> M {
     out = value;
     got
   }
 
-  pub fn get[M](&Channel(i, _): &Channel[M]) -> M {
+  pub fn get[M](&Channel[M](i, _)) -> M {
     i
   }
 }
 
-fn relay(Channel(ai, ~ao): Channel[Char], Channel(bi, ~bo): Channel[Char], recv: Char, send: Char) {
+fn relay(Channel[Char](ai, ~ao), Channel[Char](bi, ~bo), recv: Char, send: Char) {
   bo = if ai == recv {
     send
   } else {
@@ -124,7 +124,7 @@ fn relay(Channel(ai, ~ao): Channel[Char], Channel(bi, ~bo): Channel[Char], recv:
   };
 }
 
-fn check(Channel(i, ~o): Channel[Char], recv: Char) -> N32 {
+fn check(Channel[Char](i, ~o), recv: Char) -> N32 {
   o = '_';
   if i == recv {
     1

--- a/tests/programs/aoc_2024/day_12.vi
+++ b/tests/programs/aoc_2024/day_12.vi
@@ -96,17 +96,17 @@ mod Region {
 }
 
 mod Regions {
-  pub fn to_string(Regions(array): Regions) -> String {
+  pub fn to_string(Regions(array)) -> String {
     array.to_list().to_string(Region::to_string)
   }
 
-  pub fn new(&Regions(array): &Regions) -> N32 {
+  pub fn new(&Regions(array)) -> N32 {
     let i = array.len();
     array.push_back(Region::Root(1, 0));
     i
   }
 
-  pub fn find(&Regions(array): &Regions, i: N32) -> N32 {
+  pub fn find(&Regions(array), i: N32) -> N32 {
     let ~root;
     while array.get(i) is &Region::Child(p) {
       i = p;
@@ -124,7 +124,7 @@ mod Regions {
     }
   }
 
-  pub fn union_found(&Regions(array): &Regions, i: N32, j: N32) -> N32 {
+  pub fn union_found(&Regions(array), i: N32, j: N32) -> N32 {
     if i == j {
       match array.get(i) {
         &Region::Root(_, p) => {

--- a/tests/programs/aoc_2024/day_18.vi
+++ b/tests/programs/aoc_2024/day_18.vi
@@ -107,7 +107,7 @@ mod DisjointSet {
     DisjointSet(Array::new(len, Node::Root(1)))
   }
 
-  pub fn find(&DisjointSet(array): &DisjointSet, i: N32) -> N32 {
+  pub fn find(&DisjointSet(array), i: N32) -> N32 {
     let ~root;
     while array.get(i) is &Node::Child(parent) {
       i = parent;
@@ -160,7 +160,7 @@ fn pathfind(grid: Array[Array[N32]], size: N32, iters: N32) -> N32 {
       let &cell = (*grid.get(y)).get(x);
       if cell >= iters {
         cell = 0;
-        dyn fn visit((x, y): (N32, N32)) {
+        dyn fn visit((x: N32, y: N32)) {
           if x < size && y < size && *(*grid.get(y)).get(x) >= iters {
             next ++= [(x, y)];
           }

--- a/tests/programs/aoc_2024/day_24.vi
+++ b/tests/programs/aoc_2024/day_24.vi
@@ -65,11 +65,11 @@ mod Wire {
     Wire(~_, value)
   }
 
-  pub fn get(&Wire(_, value): &Wire) -> Bool {
+  pub fn get(&Wire(_, value)) -> Bool {
     value
   }
 
-  pub fn set(&Wire(~out, _): &Wire, value: Bool) {
+  pub fn set(&Wire(~out, _), value: Bool) {
     out = value;
   }
 }

--- a/tests/programs/inverse.vi
+++ b/tests/programs/inverse.vi
@@ -18,7 +18,7 @@ fn refs(&io: &IO) {
 }
 
 mod refs {
-  fn inc((init, ~fin): (N32, ~N32)) {
+  fn inc((init: N32, ~fin: ~N32)) {
     fin = init + 1;
   }
 }

--- a/tests/snaps/vine/fail/atypical.txt
+++ b/tests/snaps/vine/fail/atypical.txt
@@ -4,7 +4,7 @@ error tests/programs/fail/atypical.vi:31:3 - cannot find label `stuff`
 error tests/programs/fail/atypical.vi:32:14 - cannot continue label `stuff`
 error tests/programs/fail/atypical.vi:3:19 - no type associated with `::atypical::foo`
 error tests/programs/fail/atypical.vi:3:24 - types in item signatures cannot be elided
-error tests/programs/fail/atypical.vi:4:8 - fn item parameters must be explicitly typed
+error tests/programs/fail/atypical.vi:4:8 - types in item signatures cannot be elided
 error tests/programs/fail/atypical.vi:4:14 - types in item signatures cannot be elided
 error tests/programs/fail/atypical.vi:5:12 - types in item signatures cannot be elided
 error - expected type `fn(&IO)`; found `fn(IO)`

--- a/tests/snaps/vine/fail/hallo_world.txt
+++ b/tests/snaps/vine/fail/hallo_world.txt
@@ -5,4 +5,3 @@ error tests/programs/fail/hallo_world.vi:8:13 - invalid pattern; this path is no
 error tests/programs/fail/hallo_world.vi:9:3 - cannot find `io` in `::hallo_world::main`
 error tests/programs/fail/hallo_world.vi:9:14 - cannot find `hallo` in `::hallo_world::main`
 error tests/programs/fail/hallo_world.vi:9:21 - cannot find `world` in `::hallo_world::main`
-error tests/programs/fail/hallo_world.vi:8:13 - fn item parameters must be explicitly typed

--- a/tests/snaps/vine/fail/informal.txt
+++ b/tests/snaps/vine/fail/informal.txt
@@ -1,4 +1,4 @@
-error tests/programs/fail/informal.vi:4:13 - fn item parameters must be explicitly typed
+error tests/programs/fail/informal.vi:4:13 - types in item signatures cannot be elided
 error tests/programs/fail/informal.vi:4:13 - `*` is only valid in a place pattern
 error tests/programs/fail/informal.vi:5:3 - expected a space expression; found a value expression
 error tests/programs/fail/informal.vi:6:3 - expected a space expression; found a value expression

--- a/tests/snaps/vine/fail/is_not.txt
+++ b/tests/snaps/vine/fail/is_not.txt
@@ -4,5 +4,5 @@ error tests/programs/fail/is_not.vi:5:16 - cannot find `y` in `::is_not::main`
 error tests/programs/fail/is_not.vi:5:26 - cannot find `y` in `::is_not::main`
 error tests/programs/fail/is_not.vi:5:29 - cannot find `z` in `::is_not::main`
 error tests/programs/fail/is_not.vi:7:3 - cannot find `y` in `::is_not::main`
-error tests/programs/fail/is_not.vi:2:13 - fn item parameters must be explicitly typed
+error tests/programs/fail/is_not.vi:2:13 - types in item signatures cannot be elided
 error tests/programs/fail/is_not.vi:5:3 - then block has type `(??, ??)` but else block has type `()`

--- a/tests/snaps/vine/fail/visibility.txt
+++ b/tests/snaps/vine/fail/visibility.txt
@@ -4,9 +4,9 @@ error tests/programs/fail/visibility.vi:27:5 - `::visibility::lib::a::b` is only
 error tests/programs/fail/visibility.vi:28:5 - `::visibility::lib::c` is only visible within `::visibility::lib`
 error tests/programs/fail/visibility.vi:29:5 - `::visibility::lib::d::e` is only visible within `::visibility::lib`
 error - `::visibility::main` is only visible within `::visibility`
-error tests/programs/fail/visibility.vi:21:15 - `::visibility::lib::y` is only visible within `::visibility::lib`
 error tests/programs/fail/visibility.vi:21:24 - `::visibility::lib::y` is only visible within `::visibility::lib`
 error tests/programs/fail/visibility.vi:21:7 - `::visibility::lib::y` is only visible within `::visibility::lib`
+error tests/programs/fail/visibility.vi:21:15 - `::visibility::lib::y` is only visible within `::visibility::lib`
 error tests/programs/fail/visibility.vi:19:6 - cannot find `read_char` in `::std::io::IO`
 error tests/programs/fail/visibility.vi:20:15 - the type `::visibility::lib::x` is only visible within `::visibility::lib`
 error tests/programs/fail/visibility.vi:20:7 - the pattern `::visibility::lib::x` is only visible within `::visibility::lib`

--- a/vine/src/ast.rs
+++ b/vine/src/ast.rs
@@ -39,7 +39,7 @@ pub enum ItemKind<'core> {
 pub struct FnItem<'core> {
   pub name: Ident<'core>,
   pub generics: Vec<Ident<'core>>,
-  pub params: Vec<(Pat<'core>, Option<Ty<'core>>)>,
+  pub params: Vec<Pat<'core>>,
   pub ret: Option<Ty<'core>>,
   pub body: Block<'core>,
 }
@@ -179,7 +179,6 @@ pub enum StmtKind<'core> {
 #[derive(Debug, Clone)]
 pub struct LetStmt<'core> {
   pub bind: Pat<'core>,
-  pub ty: Option<Ty<'core>>,
   pub init: Option<Expr<'core>>,
   pub else_block: Option<Block<'core>>,
 }
@@ -188,7 +187,7 @@ pub struct LetStmt<'core> {
 pub struct DynFnStmt<'core> {
   pub name: Ident<'core>,
   pub id: Option<DynFnId>,
-  pub params: Vec<(Pat<'core>, Option<Ty<'core>>)>,
+  pub params: Vec<Pat<'core>>,
   pub ret: Option<Ty<'core>>,
   pub body: Block<'core>,
 }
@@ -227,7 +226,7 @@ pub enum ExprKind<'core> {
   #[class(value)]
   Loop(Label<'core>, Block<'core>),
   #[class(value)]
-  Fn(Vec<(Pat<'core>, Option<Ty<'core>>)>, Option<Option<Ty<'core>>>, B<Expr<'core>>),
+  Fn(Vec<Pat<'core>>, Option<Option<Ty<'core>>>, B<Expr<'core>>),
   #[class(value)]
   Return(Option<B<Expr<'core>>>),
   #[class(value)]
@@ -329,6 +328,8 @@ pub enum PatKind<'core> {
   Hole,
   #[class(value, place, space)]
   Paren(B<Pat<'core>>),
+  #[class(value, place, space)]
+  Annotation(B<Pat<'core>>, B<Ty<'core>>),
   #[class(value, place, space)]
   Adt(GenericPath<'core>, Option<Vec<Pat<'core>>>),
   #[class(value, place, space)]

--- a/vine/src/checker/check_expr.rs
+++ b/vine/src/checker/check_expr.rs
@@ -122,7 +122,7 @@ impl<'core> Checker<'core, '_> {
         let adt_id = variant.adt;
         let generics = variant.generics.len();
         let form = if adt_id == variant_id { self.tuple_form(span, &forms) } else { Form::Value };
-        let generics = self.hydrate_generics(path, generics);
+        let generics = self.hydrate_generics(path, generics, true);
         let variant = self.resolver.defs[variant_id].variant_def.as_ref().unwrap();
         let field_types = variant
           .field_types
@@ -221,10 +221,7 @@ impl<'core> Checker<'core, '_> {
         result
       }
       ExprKind::Fn(args, ret, body) => Type::Fn(
-        args
-          .iter_mut()
-          .map(|(pat, ty)| self.check_pat_annotation(pat, ty.as_mut(), Form::Value, false))
-          .collect(),
+        args.iter_mut().map(|pat| self.check_pat(pat, Form::Value, false)).collect(),
         Box::new({
           let mut ret = match ret {
             Some(Some(t)) => self.hydrate_type(t, true),

--- a/vine/src/distiller.rs
+++ b/vine/src/distiller.rs
@@ -313,7 +313,7 @@ impl<'core, 'r> Distiller<'core, 'r> {
     match &pat.kind {
       PatKind![!value] => unreachable!(),
       PatKind::Hole => Port::Erase,
-      PatKind::Paren(inner) => self.distill_pat_value(stage, inner),
+      PatKind::Paren(inner) | PatKind::Annotation(inner, _) => self.distill_pat_value(stage, inner),
       PatKind::Inverse(inner) => self.distill_pat_space(stage, inner),
       PatKind::Local(local) => {
         stage.declarations.push(*local);
@@ -336,7 +336,7 @@ impl<'core, 'r> Distiller<'core, 'r> {
     match &pat.kind {
       PatKind![!space] => unreachable!(),
       PatKind::Hole => Port::Erase,
-      PatKind::Paren(inner) => self.distill_pat_space(stage, inner),
+      PatKind::Paren(inner) | PatKind::Annotation(inner, _) => self.distill_pat_space(stage, inner),
       PatKind::Inverse(inner) => self.distill_pat_value(stage, inner),
       PatKind::Local(local) => {
         stage.declarations.push(*local);
@@ -353,7 +353,7 @@ impl<'core, 'r> Distiller<'core, 'r> {
     match &pat.kind {
       PatKind![!place] => unreachable!(),
       PatKind::Hole => stage.new_wire(),
-      PatKind::Paren(inner) => self.distill_pat_place(stage, inner),
+      PatKind::Paren(inner) | PatKind::Annotation(inner, _) => self.distill_pat_place(stage, inner),
       PatKind::Inverse(inner) => {
         let (value, space) = self.distill_pat_place(stage, inner);
         (space, value)

--- a/vine/src/distiller/control_flow.rs
+++ b/vine/src/distiller/control_flow.rs
@@ -1,7 +1,7 @@
 use ivm::ext::ExtFnKind;
 
 use crate::{
-  ast::{Block, ComparisonOp, Expr, ExprKind, LabelId, Local, LogicalOp, Pat, Stmt, StmtKind, Ty},
+  ast::{Block, ComparisonOp, Expr, ExprKind, LabelId, Local, LogicalOp, Pat, Stmt, StmtKind},
   vir::{Interface, InterfaceKind, Layer, Port, Stage, Step, Transfer},
 };
 
@@ -107,7 +107,7 @@ impl<'core, 'r> Distiller<'core, 'r> {
   pub(super) fn distill_fn(
     &mut self,
     stage: &mut Stage,
-    params: &Vec<(Pat<'core>, Option<Ty<'core>>)>,
+    params: &[Pat<'core>],
     body: &Expr<'core>,
   ) -> Port {
     let fn_local = self.new_local(stage);
@@ -125,13 +125,13 @@ impl<'core, 'r> Distiller<'core, 'r> {
     &mut self,
     stage: &mut Stage,
     fn_local: Local,
-    params: &[(Pat<'core>, Option<Ty<'core>>)],
+    params: &[Pat<'core>],
     body: &B,
     distill_body: impl Fn(&mut Self, &mut Stage, &B) -> Port,
   ) {
     let return_local = self.new_local(stage);
 
-    let params = params.iter().map(|(p, _)| self.distill_pat_value(stage, p)).collect::<Vec<_>>();
+    let params = params.iter().map(|p| self.distill_pat_value(stage, p)).collect::<Vec<_>>();
 
     let result = stage.take_local(return_local);
     let wire = stage.new_wire();

--- a/vine/src/distiller/pattern_matching.rs
+++ b/vine/src/distiller/pattern_matching.rs
@@ -304,7 +304,7 @@ impl<'core, 'd, 'r> Matcher<'core, 'd, 'r> {
       return match &pat.kind {
         PatKind::Error(_) => unreachable!(),
         PatKind::Hole | PatKind::Local(_) => None,
-        PatKind::Paren(p) => {
+        PatKind::Paren(p) | PatKind::Annotation(p, _) => {
           *pat = p;
           continue;
         }

--- a/vine/src/visit.rs
+++ b/vine/src/visit.rs
@@ -112,11 +112,8 @@ pub trait VisitMut<'core, 'a> {
       }
       ExprKind::Fn(a, b, c) => {
         self.enter_scope();
-        for (p, t) in a {
+        for p in a {
           self.visit_pat(p);
-          if let Some(t) = t {
-            self.visit_type(t);
-          }
         }
         if let Some(Some(b)) = b {
           self.visit_type(b);
@@ -174,6 +171,10 @@ pub trait VisitMut<'core, 'a> {
           }
         }
       }
+      PatKind::Annotation(p, t) => {
+        self.visit_pat(p);
+        self.visit_type(t);
+      }
     }
   }
 
@@ -202,9 +203,6 @@ pub trait VisitMut<'core, 'a> {
   fn _visit_stmt(&mut self, stmt: &'a mut Stmt<'core>) {
     match &mut stmt.kind {
       StmtKind::Let(l) => {
-        if let Some(ty) = &mut l.ty {
-          self.visit_type(ty);
-        }
         if let Some(init) = &mut l.init {
           self.visit_expr(init);
         }
@@ -215,11 +213,8 @@ pub trait VisitMut<'core, 'a> {
       }
       StmtKind::DynFn(d) => {
         self.enter_scope();
-        for (p, t) in &mut d.params {
+        for p in &mut d.params {
           self.visit_pat(p);
-          if let Some(t) = t {
-            self.visit_type(t);
-          }
         }
         if let Some(t) = &mut d.ret {
           self.visit_type(t);
@@ -236,11 +231,8 @@ pub trait VisitMut<'core, 'a> {
   fn _visit_item(&mut self, item: &'a mut Item<'core>) {
     match &mut item.kind {
       ItemKind::Fn(f) => {
-        for (param, ty) in &mut f.params {
-          self.visit_pat(param);
-          if let Some(ty) = ty {
-            self.visit_type(ty);
-          }
+        for p in &mut f.params {
+          self.visit_pat(p);
         }
         if let Some(ty) = &mut f.ret {
           self.visit_type(ty);

--- a/vine/std/array.vi
+++ b/vine/std/array.vi
@@ -14,7 +14,7 @@ pub mod Array {
     Array(len, Node::new(len, value))
   }
 
-  pub fn from_list[T](List(len, buf, _): List[T]) -> Array[T] {
+  pub fn from_list[T](List[T](len, buf, _)) -> Array[T] {
     Array::from_fn(
       len,
       &buf,
@@ -56,7 +56,7 @@ pub mod Array {
     )
   }
 
-  pub fn fold_front[T, U](Array(len, node): Array[T], initial: U, f: fn(U, T) -> U) -> U {
+  pub fn fold_front[T, U](Array[T](len, node), initial: U, f: fn(U, T) -> U) -> U {
     if len == 0 {
       initial
     } else {
@@ -70,7 +70,7 @@ pub mod Array {
     }
   }
 
-  pub fn fold_back[T, U](Array(len, node): Array[T], initial: U, f: fn(U, T) -> U) -> U {
+  pub fn fold_back[T, U](Array[T](len, node), initial: U, f: fn(U, T) -> U) -> U {
     if len == 0 {
       initial
     } else {
@@ -88,7 +88,7 @@ pub mod Array {
     self.0
   }
 
-  pub fn get[T](&Array(len, *node): &Array[T], i: N32) -> &T {
+  pub fn get[T](&Array[T](len, *node), i: N32) -> &T {
     let size = len;
     while size > 1 {
       (node, size) = Node::half(node, size, i % 2);
@@ -97,7 +97,7 @@ pub mod Array {
     (*node).as_leaf()
   }
 
-  pub fn push_back[T](&Array(len, *node): &Array[T], value: T) {
+  pub fn push_back[T](&Array[T](len, *node), value: T) {
     if len == 0 {
       let &node = node;
       node = Node::leaf(value)
@@ -112,7 +112,7 @@ pub mod Array {
     len += 1;
   }
 
-  pub fn push_front[T](&Array(len, *node): &Array[T], value: T) {
+  pub fn push_front[T](&Array[T](len, *node), value: T) {
     if len == 0 {
       let &node = node;
       node = Node::leaf(value)
@@ -130,7 +130,7 @@ pub mod Array {
     len += 1;
   }
 
-  pub fn pop_back[T](&Array(len, *node): &Array[T]) -> Option[T] {
+  pub fn pop_back[T](&Array[T](len, *node)) -> Option[T] {
     if len == 0 {
       None
     } else if len == 1 {
@@ -157,7 +157,7 @@ pub mod Array {
     }
   }
 
-  pub fn pop_front[T](&Array(len, *node): &Array[T]) -> Option[T] {
+  pub fn pop_front[T](&Array[T](len, *node)) -> Option[T] {
     if len == 0 {
       None
     } else if len == 1 {
@@ -181,7 +181,7 @@ pub mod Array {
     }
   }
 
-  pub fn reverse[T](&Array(len, node): &Array[T]) {
+  pub fn reverse[T](&Array[T](len, node)) {
     node.reverse(len)
   }
 

--- a/vine/std/list.vi
+++ b/vine/std/list.vi
@@ -22,7 +22,7 @@ pub mod List {
     list
   }
 
-  pub fn get[T](&List(len, *buf, _): &List[T], i: N32) -> &T {
+  pub fn get[T](&List[T](len, *buf, _), i: N32) -> &T {
     while i != 0 {
       let &Buf(_, *tail) = buf;
       buf = tail;
@@ -32,7 +32,7 @@ pub mod List {
     head
   }
 
-  pub fn slice[T](List(len, buf, end): List[T], i: N32) -> List[T] {
+  pub fn slice[T](List[T](len, buf, end), i: N32) -> List[T] {
     if i >= len {
       []
     } else {
@@ -45,7 +45,7 @@ pub mod List {
     }
   }
 
-  pub fn map[T, U](List(l, buf, ~_): List[T], f: fn(T) -> U) -> List[U] {
+  pub fn map[T, U](List[T](l, buf, ~_), f: fn(T) -> U) -> List[U] {
     let len = l;
     let cur;
     let result = move ~cur;
@@ -60,7 +60,7 @@ pub mod List {
     List(len, result, move cur)
   }
 
-  pub fn pop_front[T](&List(len, buf, _): &List[T]) -> Option[T] {
+  pub fn pop_front[T](&List[T](len, buf, _)) -> Option[T] {
     if len != 0 {
       len -= 1;
       let Buf(head, tail) = buf;
@@ -87,7 +87,7 @@ pub mod List {
     list = [el] ++ list;
   }
 
-  pub fn insert[T](&List(len, *buf, _): &List[T], i: N32, el: T) {
+  pub fn insert[T](&List[T](len, *buf, _), i: N32, el: T) {
     len += 1;
     while i != 0 {
       let &Buf(_, *tail) = buf;
@@ -133,12 +133,12 @@ pub mod List {
 
   pub struct Iter[T](N32, &Buf[T]);
 
-  pub fn iter[T](&List(len, buf, _): &List[T]) -> Iter[T] {
+  pub fn iter[T](&List[T](len, buf, _)) -> Iter[T] {
     Iter(len, &buf)
   }
 
   pub mod Iter {
-    pub fn next[T](&Iter(len, buf): &Iter[T]) -> Option[&T] {
+    pub fn next[T](&Iter[T](len, buf)) -> Option[&T] {
       if len != 0 {
         len -= 1;
         let &Buf(*head, *tail) = buf;
@@ -157,12 +157,12 @@ pub mod List {
 
   pub struct IntoIter[T](N32, Buf[T]);
 
-  pub fn into_iter[T](List(len, buf, _): List[T]) -> IntoIter[T] {
+  pub fn into_iter[T](List[T](len, buf, _)) -> IntoIter[T] {
     IntoIter(len, buf)
   }
 
   pub mod IntoIter {
-    pub fn next[T](&IntoIter(len, buf): &IntoIter[T]) -> Option[T] {
+    pub fn next[T](&IntoIter[T](len, buf)) -> Option[T] {
       if len != 0 {
         len -= 1;
         let Buf(head, tail) = buf;

--- a/vine/std/map.vi
+++ b/vine/std/map.vi
@@ -24,19 +24,19 @@ pub mod Map {
     map
   }
 
-  pub fn clear[K, V](&Map(_, node): &Map[K, V]) {
+  pub fn clear[K, V](&Map[K, V](_, node)) {
     node = Node::leaf;
   }
 
-  pub fn len[K, V](&Map(_, Node(len, _)): &Map[K, V]) -> N32 {
+  pub fn len[K, V](&Map[K, V](_, Node(len, _))) -> N32 {
     len
   }
 
-  pub fn insert[K, V](&Map(cmp, node): &Map[K, V], key: K, value: V) -> Option[V] {
+  pub fn insert[K, V](&Map[K, V](cmp, node), key: K, value: V) -> Option[V] {
     node.insert(cmp, key, value)
   }
 
-  pub fn get_or_insert[K, V](&Map(cmp, node): &Map[K, V], key: K, value: V) -> &V {
+  pub fn get_or_insert[K, V](&Map[K, V](cmp, node), key: K, value: V) -> &V {
     let ~insert;
     let old = node.insert(cmp, key, ~insert);
     let value = old.unwrap_or(value);
@@ -45,23 +45,23 @@ pub mod Map {
     ref
   }
 
-  pub fn get[K, V](&Map(cmp, node): &Map[K, V], &key: &K) -> Option[&V] {
+  pub fn get[K, V](&Map[K, V](cmp, node), &key: &K) -> Option[&V] {
     node.get(cmp, &key)
   }
 
-  pub fn get_le[K, V](&Map(cmp, node): &Map[K, V], &key: &K) -> Option[&(K, V)] {
+  pub fn get_le[K, V](&Map[K, V](cmp, node), &key: &K) -> Option[&(K, V)] {
     node.get_le(cmp, &key)
   }
 
-  pub fn get_ge[K, V](&Map(cmp, node): &Map[K, V], &key: &K) -> Option[&(K, V)] {
+  pub fn get_ge[K, V](&Map[K, V](cmp, node), &key: &K) -> Option[&(K, V)] {
     node.get_ge(cmp, &key)
   }
 
-  pub fn remove[K, V](&Map(cmp, node): &Map[K, V], &key: &K) -> Option[V] {
+  pub fn remove[K, V](&Map[K, V](cmp, node), &key: &K) -> Option[V] {
     node.remove(cmp, &key)
   }
 
-  pub fn remove_min[K, V](&Map(cmp, node): &Map[K, V]) -> Option[(K, V)] {
+  pub fn remove_min[K, V](&Map[K, V](cmp, node)) -> Option[(K, V)] {
     if node.size() == 0 {
       None
     } else {
@@ -69,7 +69,7 @@ pub mod Map {
     }
   }
 
-  pub fn remove_max[K, V](&Map(cmp, node): &Map[K, V]) -> Option[(K, V)] {
+  pub fn remove_max[K, V](&Map[K, V](cmp, node)) -> Option[(K, V)] {
     if node.size() == 0 {
       None
     } else {
@@ -77,14 +77,14 @@ pub mod Map {
     }
   }
 
-  pub fn iter[K, V](&Map(_, node): &Map[K, V]) -> Iter[K, V] {
+  pub fn iter[K, V](&Map[K, V](_, node)) -> Iter[K, V] {
     Iter(&node, [])
   }
 
   pub struct Iter[K, V](&Node[K, V], List[&((K, V), Node[K, V])]);
 
   pub mod Iter {
-    pub fn next[K, V](&Iter(node, stack): &Iter[K, V]) -> Option[&(K, V)] {
+    pub fn next[K, V](&Iter[K, V](node, stack)) -> Option[&(K, V)] {
       loop {
         let &Node(len, data) = move node;
         if len == 0 {
@@ -109,14 +109,14 @@ pub mod Map {
     }
   }
 
-  pub fn into_iter[K, V](Map(_, node): Map[K, V]) -> IntoIter[K, V] {
+  pub fn into_iter[K, V](Map[K, V](_, node)) -> IntoIter[K, V] {
     IntoIter(node, [])
   }
 
   pub struct IntoIter[K, V](Node[K, V], List[((K, V), Node[K, V])]);
 
   pub mod IntoIter {
-    pub fn next[K, V](&IntoIter(node, stack): &IntoIter[K, V]) -> Option[(K, V)] {
+    pub fn next[K, V](&IntoIter[K, V](node, stack)) -> Option[(K, V)] {
       loop {
         let Node(len, data) = move node;
         if len == 0 {
@@ -135,7 +135,7 @@ pub mod Map {
     }
   }
 
-  pub fn to_list[K, V](Map(_, node): Map[K, V]) -> List[(K, V)] {
+  pub fn to_list[K, V](Map[K, V](_, node)) -> List[(K, V)] {
     node.to_list()
   }
 
@@ -165,7 +165,7 @@ type NodeData[K, V] = (Node[K, V], (K, V), Node[K, V]);
 mod Node {
   pub const leaf[K, V]: Node[K, V] = Node(0, ~_);
 
-  pub fn size[K, V](&Node(size, _): &Node[K, V]) -> N32 {
+  pub fn size[K, V](&Node[K, V](size, _)) -> N32 {
     size
   }
 
@@ -173,7 +173,7 @@ mod Node {
     Node(left.size() + right.size() + 1, (left, entry, right))
   }
 
-  pub fn insert[K, V](&Node(len, data): &Node[K, V], cmp: Cmp[K], key: K, value: V) -> Option[V] {
+  pub fn insert[K, V](&Node[K, V](len, data), cmp: Cmp[K], key: K, value: V) -> Option[V] {
     if len == 0 {
       len = 1;
       data = (leaf, (key, value), leaf);
@@ -202,7 +202,7 @@ mod Node {
     }
   }
 
-  pub fn get[K, V](&Node(len, data): &Node[K, V], cmp: Cmp[K], &key: &K) -> Option[&V] {
+  pub fn get[K, V](&Node[K, V](len, data), cmp: Cmp[K], &key: &K) -> Option[&V] {
     if len == 0 {
       None
     } else {
@@ -215,7 +215,7 @@ mod Node {
     }
   }
 
-  pub fn get_le[K, V](&Node(len, data): &Node[K, V], cmp: Cmp[K], &key: &K) -> Option[&(K, V)] {
+  pub fn get_le[K, V](&Node[K, V](len, data), cmp: Cmp[K], &key: &K) -> Option[&(K, V)] {
     if len == 0 {
       None
     } else {
@@ -232,7 +232,7 @@ mod Node {
     }
   }
 
-  pub fn get_ge[K, V](&Node(len, data): &Node[K, V], cmp: Cmp[K], &key: &K) -> Option[&(K, V)] {
+  pub fn get_ge[K, V](&Node[K, V](len, data), cmp: Cmp[K], &key: &K) -> Option[&(K, V)] {
     if len == 0 {
       None
     } else {
@@ -249,7 +249,7 @@ mod Node {
     }
   }
 
-  pub fn remove[K, V](&Node(len, data): &Node[K, V], cmp: Cmp[K], &key: &K) -> Option[V] {
+  pub fn remove[K, V](&Node[K, V](len, data), cmp: Cmp[K], &key: &K) -> Option[V] {
     if len == 0 {
       None
     } else {
@@ -276,7 +276,7 @@ mod Node {
     }
   }
 
-  pub fn remove_min[K, V](&Node(len, data): &Node[K, V], cmp: Cmp[K]) -> (K, V) {
+  pub fn remove_min[K, V](&Node[K, V](len, data), cmp: Cmp[K]) -> (K, V) {
     len -= 1;
     let &(left, entry, right) = &data;
     if left.size() == 0 {
@@ -290,7 +290,7 @@ mod Node {
     }
   }
 
-  pub fn remove_max[K, V](&Node(len, data): &Node[K, V], cmp: Cmp[K]) -> (K, V) {
+  pub fn remove_max[K, V](&Node[K, V](len, data), cmp: Cmp[K]) -> (K, V) {
     len -= 1;
     let &(left, entry, right) = &data;
     if right.size() == 0 {
@@ -304,7 +304,7 @@ mod Node {
     }
   }
 
-  pub fn to_list[K, V](Node(len, data): Node[K, V]) -> List[(K, V)] {
+  pub fn to_list[K, V](Node[K, V](len, data)) -> List[(K, V)] {
     if len == 0 {
       []
     } else {
@@ -313,7 +313,7 @@ mod Node {
     }
   }
 
-  pub fn balanced[K, V](&Node(len, data): &Node[K, V]) -> Bool {
+  pub fn balanced[K, V](&Node[K, V](len, data)) -> Bool {
     if len == 0 {
       true
     } else {
@@ -370,11 +370,11 @@ fn merge_balanced[K, V](cmp: Cmp[K], left: Node[K, V], right: Node[K, V]) -> Nod
   }
 }
 
-fn is_balanced[K, V](&Node(a, _): &Node[K, V], &Node(b, _): &Node[K, V]) -> Bool {
+fn is_balanced[K, V](&Node[K, V](a, _), &Node[K, V](b, _)) -> Bool {
   3 * a + 2 >= b
 }
 
-fn is_single[K, V](&Node(a, _): &Node[K, V], &Node(b, _): &Node[K, V]) -> Bool {
+fn is_single[K, V](&Node[K, V](a, _), &Node[K, V](b, _)) -> Bool {
   a <= 2 * b
 }
 

--- a/vine/std/n64.vi
+++ b/vine/std/n64.vi
@@ -12,7 +12,7 @@ pub mod N64 {
     N64(val, 0)
   }
 
-  pub fn to_n32(N64(lo, hi): N64) -> N32 {
+  pub fn to_n32(N64(lo, hi)) -> N32 {
     lo
   }
 
@@ -45,7 +45,7 @@ pub mod N64 {
     a1 = @n32_mul_high(b1 h)
   }
 
-  pub fn div_rem_n32(N64(al, ah): N64, d: N32) -> (N64, N32) {
+  pub fn div_rem_n32(N64(al, ah), d: N32) -> (N64, N32) {
     let qh = ah / d;
     ah %= d;
     if ah > d {
@@ -65,19 +65,19 @@ pub mod N64 {
     (N64(ql, qh), al)
   }
 
-  pub fn or(N64(al, ah): N64, N64(bl, bh): N64) -> N64 {
+  pub fn or(N64(al, ah), N64(bl, bh)) -> N64 {
     N64(al | bl, ah | bh)
   }
 
-  pub fn xor(N64(al, ah): N64, N64(bl, bh): N64) -> N64 {
+  pub fn xor(N64(al, ah), N64(bl, bh)) -> N64 {
     N64(al ^ bl, ah ^ bh)
   }
 
-  pub fn and(N64(al, ah): N64, N64(bl, bh): N64) -> N64 {
+  pub fn and(N64(al, ah), N64(bl, bh)) -> N64 {
     N64(al & bl, ah & bh)
   }
 
-  pub fn shl(N64(al, ah): N64, bits: N32) -> N64 {
+  pub fn shl(N64(al, ah), bits: N32) -> N64 {
     if bits & 32 != 0 {
       N64(0, al << bits)
     } else {
@@ -85,7 +85,7 @@ pub mod N64 {
     }
   }
 
-  pub fn shr(N64(al, ah): N64, bits: N32) -> N64 {
+  pub fn shr(N64(al, ah), bits: N32) -> N64 {
     if bits & 32 != 0 {
       N64(ah >> bits, 0)
     } else {
@@ -93,23 +93,23 @@ pub mod N64 {
     }
   }
 
-  pub fn eq(N64(al, ah): N64, N64(bl, bh): N64) -> Bool {
+  pub fn eq(N64(al, ah), N64(bl, bh)) -> Bool {
     al == bl && ah == bh
   }
 
-  pub fn lt(N64(al, ah): N64, N64(bl, bh): N64) -> Bool {
+  pub fn lt(N64(al, ah), N64(bl, bh)) -> Bool {
     ah < bh || ah == bh && al < bl
   }
 
-  pub fn le(N64(al, ah): N64, N64(bl, bh): N64) -> Bool {
+  pub fn le(N64(al, ah), N64(bl, bh)) -> Bool {
     ah < bh || ah == bh && al <= bl
   }
 
-  pub fn gt(N64(al, ah): N64, N64(bl, bh): N64) -> Bool {
+  pub fn gt(N64(al, ah), N64(bl, bh)) -> Bool {
     ah > bh || ah == bh && al > bl
   }
 
-  pub fn ge(N64(al, ah): N64, N64(bl, bh): N64) -> Bool {
+  pub fn ge(N64(al, ah), N64(bl, bh)) -> Bool {
     ah > bh || ah == bh && al >= bl
   }
 
@@ -129,7 +129,7 @@ pub mod N64 {
     }
   }
 
-  pub fn cmp(&N64(al, ah): &N64, &N64(bl, bh): &N64) -> Ord {
+  pub fn cmp(&N64(al, ah), &N64(bl, bh)) -> Ord {
     if ah < bh {
       Ord::Lt
     } else if ah > bh {

--- a/vine/std/rng.vi
+++ b/vine/std/rng.vi
@@ -17,13 +17,13 @@ pub mod Rng {
 
   const multiplier: N64 = N64(0x4c957f2d, 0x5851f42d);
 
-  pub fn gen_n32(&Rng(state, increment): &Rng) -> N32 {
+  pub fn gen_n32(&Rng(state, increment)) -> N32 {
     let N64(lo, hi) = state;
     state = N64::add(N64::mul(state, multiplier), increment);
     N32::rotate_right((hi >> 13) ^ (hi << 5) ^ (lo >> 27), hi >> 27)
   }
 
-  pub fn mix(&Rng(state, increment): &Rng, n: N32) {
+  pub fn mix(&Rng(state, increment), n: N32) {
     state = state.xor(N64(0, n));
     state = N64::add(N64::mul(state, multiplier), increment);
   }

--- a/vine/std/tuple.vi
+++ b/vine/std/tuple.vi
@@ -6,7 +6,7 @@ pub type Pair[A, B] = (A, B);
 pub mod Pair {
   pub fn cmp[A, B](f: Cmp[A], g: Cmp[B]) -> Cmp[(A, B)] {
     (
-      fn(&(a0, b0): &(A, B), &(a1, b1): &(A, B)) {
+      fn(&(a0: A, b0: B), &(a1: A, b1: B)) {
         match f(&a0, &a1) {
           Ord::Lt => Ord::Lt,
           Ord::Gt => Ord::Gt,
@@ -17,6 +17,6 @@ pub mod Pair {
   }
 
   pub fn to_string[A, B](show_a: fn(A) -> String, show_b: fn(B) -> String) -> fn((A, B)) -> String {
-    (fn((a, b): (A, B)) "(" ++ show_a(a) ++ ", " ++ show_b(b) ++ ")")
+    (fn((a: A, b: B)) "(" ++ show_a(a) ++ ", " ++ show_b(b) ++ ")")
   }
 }


### PR DESCRIPTION
- resolves #128

this allows things like
```rs
// before:
fn foo((a, b): (N32, String), Bar(x, y): Bar[Baz])
// after:
fn foo((a: N32, b: String), Bar[Baz](x, y))
```
