### PR TITLE
docs: fix indentation in code blocks

### DIFF
--- a/docs/theme/index.hbs
+++ b/docs/theme/index.hbs
@@ -333,7 +333,11 @@
 
     </div>
         <script>
-            document.querySelectorAll("pre > code").forEach(code => code.innerHTML = code.innerHTML.replace(/(^|\n(?!$))/g, `$1<span class="line"></span>`))
+            document.querySelectorAll("pre > code").forEach(code =>
+                code.innerHTML = code.innerHTM
+                    .replace(/(^|\n) /g, "$1&nbsp;")
+                    .replace(/(^|\n(?!$))/g, `$1<span class="line"></span>`)
+            )
         </script>
     </body>
 </html>


### PR DESCRIPTION
was broken on chrome & safari