### PR TITLE
fix off-by-one error in `segmented_sieve.vi`

### DIFF
--- a/tests/programs/segmented_sieve.vi
+++ b/tests/programs/segmented_sieve.vi
@@ -5,7 +5,7 @@ const max: N32 = 1_000_000;
 
 pub fn main(&io: &IO) {
   let sqrt = max.sqrt();
-  let array = Array::new(sqrt - 2, true);
+  let array = Array::new(sqrt - 1, true);
   let offset = 2;
   let primes = [];
   while array.pop_front() is Some(prime) {
@@ -15,7 +15,7 @@ pub fn main(&io: &IO) {
       io.println(n.to_string());
       primes.push_back(n);
       let i = n * n;
-      while i < sqrt {
+      while i <= sqrt {
         *array.get(i - offset) = false;
         i += n;
       }

--- a/tests/snaps/vine/segmented_sieve/compiled.iv
+++ b/tests/snaps/vine/segmented_sieve/compiled.iv
@@ -13,7 +13,7 @@
 
 ::segmented_sieve::main {
   fn(ref(w1 w28) _)
-  ::std::numeric::N32::sqrt = fn(1000000 dup5(@sub(2 w8) dup5(w21 w26)))
+  ::std::numeric::N32::sqrt = fn(1000000 dup5(@sub(1 w8) dup5(w21 w26)))
   ::std::data::Array::new = fn(w8 fn(1 w9))
   ::segmented_sieve::main::1 = x(x(w1 w23) x(w21 x(w9 x(x(2 w19) x(tup(0 tup(w15 w15)) w17)))))
   ::segmented_sieve::main::12 = x(x(w23 w28) x(w26 x(w19 w17)))
@@ -41,7 +41,7 @@
 
 ::segmented_sieve::main::8 { x(x(w9 w9) x(_ x(x(w6 w6) x(_ x(x(w3 w3) _))))) }
 
-::segmented_sieve::main::9 { x(dup56(w1 w14) x(w7 x(w5 x(w4 dup61(@lt(w1 ?(::segmented_sieve::main::11 ::segmented_sieve::main::10 x(w14 x(w7 x(w5 x(w4 w9)))))) w9))))) }
+::segmented_sieve::main::9 { x(dup56(w1 w14) x(w7 x(w5 x(w4 dup61(@le(w1 ?(::segmented_sieve::main::11 ::segmented_sieve::main::10 x(w14 x(w7 x(w5 x(w4 w9)))))) w9))))) }
 
 ::segmented_sieve::main::10 {
   x(w17 x(x(w16 w22) x(dup66(w4 w20) x(dup67(w9 w19) dup68(@sub(w4 w5) @add(w9 w11))))))

--- a/tests/snaps/vine/segmented_sieve/stats.txt
+++ b/tests/snaps/vine/segmented_sieve/stats.txt
@@ -1,15 +1,15 @@
 
 Interactions
-  Total         1_090_538_294
-  Annihilate      592_993_295
+  Total         1_090_035_442
+  Annihilate      592_993_108
   Commute             169_830
-  Copy             82_273_662
-  Erase            77_459_141
-  Expand          132_189_231
-  Call            143_231_272
-  Branch           62_221_863
+  Copy             82_273_642
+  Erase            77_459_121
+  Expand          132_189_187
+  Call            142_728_713
+  Branch           62_221_841
 
 Memory
-  Heap                120_640 B
-  Allocated    23_694_798_064 B
-  Freed        23_694_798_064 B
+  Heap                120_496 B
+  Allocated    23_686_750_464 B
+  Freed        23_686_750_464 B


### PR DESCRIPTION
Fixes an off-by-one error that caused it to identify `9` as a prime number when supplied a max of `10`.

Thanks @nilscrm for finding this issue.