### PR TITLE
Allow the lexer to work on Windows by permitting `\r` between tokens

### DIFF
--- a/ivy/src/lexer.rs
+++ b/ivy/src/lexer.rs
@@ -5,7 +5,7 @@ use logos::Logos;
 use vine_util::lexer::{lex_block_comment, Token as TokenTrait};
 
 #[derive(Logos, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[logos(skip r"[ \t\n\f]+")]
+#[logos(skip r"[ \t\r\n\f]+")]
 #[repr(u8)]
 pub enum Token {
   #[token("(")]

--- a/vine/src/lexer.rs
+++ b/vine/src/lexer.rs
@@ -4,7 +4,7 @@ use logos::Logos;
 use vine_util::lexer::{lex_block_comment, Token as TokenTrait};
 
 #[derive(Logos, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[logos(skip r"[ \t\n\f]+")]
+#[logos(skip r"[ \t\r\n\f]+")]
 #[repr(u8)]
 pub enum Token {
   #[token(".")]


### PR DESCRIPTION
Before this change, the lexer would complain about `\r\n` in files checked out on Windows:

```
error \\?\C:\Users\Gordon\Source\Repos\Vine\vine\vine\examples\hello_world.vi:1:1 - lexing error
error \\?\C:\Users\Gordon\Source\Repos\Vine\vine\vine\std\std.vi:1:1 - lexing error
```

This change allows `\r` between tokens in the Ivy and Vine lexers.