### PR TITLE
meta: add nix flake build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .DS_Store
 target
 tests/snaps/**/timing.txt
+
+# Nix build outputs
+result

--- a/cli/src/vine_cli.rs
+++ b/cli/src/vine_cli.rs
@@ -1,6 +1,5 @@
 use std::{
-  fs,
-  env,
+  env, fs,
   io::{stdin, Read},
   path::PathBuf,
   process::exit,
@@ -92,7 +91,7 @@ fn std_path() -> PathBuf {
     Some(std_path) => {
       path.push(std_path);
       path.push("std.vi");
-    },
+    }
     None => {
       path.push(env!("CARGO_MANIFEST_DIR"));
       path.push("../vine/std/std.vi");

--- a/cli/src/vine_cli.rs
+++ b/cli/src/vine_cli.rs
@@ -87,7 +87,7 @@ fn std_path() -> PathBuf {
   let compile_time_std_path = option_env!("VINE_STD_PATH");
   let runtime_std_path = env::var("VINE_STD_PATH").ok();
 
-  match runtime_std_path.or(compile_time_std_path.map(String::from)) {
+  match runtime_std_path.as_deref().or(compile_time_std_path) {
     Some(std_path) => {
       path.push(std_path);
       path.push("std.vi");

--- a/cli/src/vine_cli.rs
+++ b/cli/src/vine_cli.rs
@@ -1,5 +1,6 @@
 use std::{
   fs,
+  env,
   io::{stdin, Read},
   path::PathBuf,
   process::exit,
@@ -84,8 +85,19 @@ impl CompileArgs {
 
 fn std_path() -> PathBuf {
   let mut path = PathBuf::new();
-  path.push(env!("CARGO_MANIFEST_DIR"));
-  path.push("../vine/std/std.vi");
+  let compile_time_std_path = option_env!("VINE_STD_PATH");
+  let runtime_std_path = env::var("VINE_STD_PATH").ok();
+
+  match runtime_std_path.or(compile_time_std_path.map(String::from)) {
+    Some(std_path) => {
+      path.push(std_path);
+      path.push("std.vi");
+    },
+    None => {
+      path.push(env!("CARGO_MANIFEST_DIR"));
+      path.push("../vine/std/std.vi");
+    }
+  }
   path
 }
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1743964447,
+        "narHash": "sha256-nEo1t3Q0F+0jQ36HJfbJtiRU4OI+/0jX/iITURKe3EE=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "063dece00c5a77e4a0ea24e5e5a5bd75232806f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1744079607,
+        "narHash": "sha256-5cog6Qd6w/bINdLO5mOysAHOHey8PwFXk4IWo+y+Czg=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "f6b62cc99c25e79a1c17e9fca91dc6b6faebec6c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -23,18 +23,6 @@
     }); 
   in
   {
-    devShells = forAllSystems (system: with (pkgs system);
-      {
-        default = mkShell {
-          buildInputs = [ rustup ];
-          shellHook = ''
-            source <(rustup completions bash)
-            source <(rustup completions bash cargo)
-          '';
-        };
-      }
-    );
-
     packages = forAllSystems (system: with (pkgs system);
     let 
       rustPlatform = makeRustPlatform rec {

--- a/flake.nix
+++ b/flake.nix
@@ -38,7 +38,7 @@
     packages = forAllSystems (system: with (pkgs system);
     let 
       rustPlatform = makeRustPlatform rec {
-        cargo = rust-bin.nightly."2024-12-24".default;
+        cargo = rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
         rustc = cargo;
       };
     in

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,61 @@
+{
+  description = "Dev environment + build for vine";
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { nixpkgs, rust-overlay, ... }: 
+  let
+    supportedSystems = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+    forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+    pkgs = system: (import nixpkgs { 
+      inherit system; 
+      overlays = [ rust-overlay.overlays.default ]; 
+    }); 
+  in
+  {
+    devShells = forAllSystems (system: with (pkgs system);
+      {
+        default = mkShell {
+          buildInputs = [ rustup ];
+          shellHook = ''
+            source <(rustup completions bash)
+            source <(rustup completions bash cargo)
+          '';
+        };
+      }
+    );
+
+    packages = forAllSystems (system: with (pkgs system);
+    let 
+      rustPlatform = makeRustPlatform rec {
+        cargo = rust-bin.nightly."2024-12-24".default;
+        rustc = cargo;
+      };
+    in
+    {
+      default = rustPlatform.buildRustPackage rec {
+        src = lib.cleanSource ./.;
+        pname = "vine";
+        version = "0.1";
+        CFG_RELEASE_CHANNEL = "nightly";
+        VINE_STD_PATH = "${src}/vine/std";
+        cargoLock = {
+          lockFile = "${src}/Cargo.lock";
+          outputHashes = {
+            "class-0.1.0" = "sha256-ye8DqeDRXsNpTWpGGlvWxSSc1AiXOLud99dHpB/VhZg=";
+          };
+        };
+      };
+    });
+  };
+}


### PR DESCRIPTION
Adds `flake.nix` to project, which allows one to build vine trivially with nix ecosystem.  For example, I can consume the project with this

```flake.nix
{
  inputs = {
    vine.url = "https://github.com/VineLang/vine";
    vine.inputs.nixpkgs.follows = "nixpkgs"; # I can override which other inputs and build inputs are used
  };
  { vine, ... }:
     # add vine to my system, shell, or as another build input
}
```

I can use `nix flake update` to pull latest vine versions and benefit from binary caching on all the rust components and libraries as well. 

Similarly, anyone with nix could run any "version" of vine by pointing `nix run` at it:

```bash
nix run git+https://github.com/VineLang/vine # with some branch or sha ref, for instance
```

Motivations:
1.  Because vine is unversioned currently and has no other release process.  I'm already tinkering with vine on my laptop and in docker containers.  Swapping out versions with a `flake.lock` is easy while experimenting.
2.  Binary caching in nix is great, saving a great deal of downloading and allowing swapping versions of components trivially.

Downsides:
1.  Dependencies in `Cargo.toml` that do not have checksums need she-256 explicitly in the flake.nix.  Currently this only applies to `class` module.  Either we could move to putting checksum in the `Cargo.toml` like other deps, or just live with the checksum in the `flake.nix`
2.  Some overhead ensuring changes don't break the flake.nix.  Not likely now as long as the build process is mostly rust, nix takes care of this effortlessly.  Willing to contribute time on maintenance.  Possible to easily add check to GitHub actions CI but decided against since it isn't critical for now.  Better that things can break freely.

In support of the ability to build with nix, also added ability to specify VINE_STD_LIB in the environment.  I decided for both a compile time and runtime environment check, but open to suggestion.



