### PR TITLE
std: add starts_with method to String

### DIFF
--- a/tests/programs/string_ops.vi
+++ b/tests/programs/string_ops.vi
@@ -1,0 +1,17 @@
+
+pub fn main(&io: &IO) {
+  let s = "hello world!";
+  io.println("{s.len()}");
+  let prefix = "";
+  io.println("{s.starts_with(&prefix)}");
+  let prefix = "h";
+  io.println("{s.starts_with(&prefix)}");
+  let prefix = "hello ";
+  io.println("{s.starts_with(&prefix)}");
+  let prefix = "world";
+  io.println("{s.starts_with(&prefix)}");
+  let prefix = "held";
+  io.println("{s.starts_with(&prefix)}");
+  let prefix = "hello world! hi";
+  io.println("{s.starts_with(&prefix)}");
+}

--- a/tests/snaps/vine/aoc_2024/day_21/compiled.iv
+++ b/tests/snaps/vine/aoc_2024/day_21/compiled.iv
@@ -314,7 +314,7 @@
 
 ::std::unicode::String::split_once::23 { x(tup(@n32_add(n0 n1) tup(n2 n3)) x(tup(n0 tup(n3 n4)) tup(tup(n1 tup(n2 n4)) ::std::logical::Option::None))) }
 
-::std::unicode::String::repeat::2 { x(dup3553(tup(n0 tup(n1 n2)) n3) x(@n32_sub(1 dup128(n4 @n32_ne(0 ?(::std::unicode::String::repeat::3 ::std::unicode::String::repeat::2 x(n3 x(n4 x(tup(n5 tup(n6 n2)) n7))))))) x(tup(@n32_add(n0 n5) tup(n6 n1)) n7))) }
+::std::unicode::String::repeat::2 { x(dup3593(tup(n0 tup(n1 n2)) n3) x(@n32_sub(1 dup128(n4 @n32_ne(0 ?(::std::unicode::String::repeat::3 ::std::unicode::String::repeat::2 x(n3 x(n4 x(tup(n5 tup(n6 n2)) n7))))))) x(tup(@n32_add(n0 n5) tup(n6 n1)) n7))) }
 
 ::std::unicode::String::repeat::3 { x(_ x(_ x(n0 n0))) }
 

--- a/tests/snaps/vine/string_ops/compiled.iv
+++ b/tests/snaps/vine/string_ops/compiled.iv
@@ -1,0 +1,84 @@
+
+::std::logical::Option::None { enum(_ enum(n0 n0)) }
+
+::main { ::string_ops::main }
+
+::string_ops::main {
+  fn(ref(w1 w95) _)
+  ::std::unicode::String::len = fn(ref(tup(12 tup(tup(104 tup(101 tup(108 tup(108 tup(111 tup(32 tup(119 tup(111 tup(114 tup(108 tup(100 tup(33 w110)))))))))))) w110)) w12) w14)
+  ::std::numeric::N32::to_string::to_string = fn(w14 tup(@n32_add(0 w111) w112))
+  ::std::IO::println = fn(ref(w1 w8) fn(tup(w111 w112) _))
+  ::std::unicode::String::starts_with = fn(ref(w12 w24) fn(ref(tup(0 tup(w118 w118)) _) w29))
+  ::std::logical::Bool::to_string::to_string = fn(w29 tup(@n32_add(0 w119) w120))
+  ::std::IO::println = fn(ref(w8 w20) fn(tup(w119 w120) _))
+  ::std::unicode::String::starts_with = fn(ref(w24 w39) fn(ref(tup(1 tup(tup(104 w126) w126)) _) w44))
+  ::std::logical::Bool::to_string::to_string = fn(w44 tup(@n32_add(0 w127) w128))
+  ::std::IO::println = fn(ref(w20 w35) fn(tup(w127 w128) _))
+  ::std::unicode::String::starts_with = fn(ref(w39 w54) fn(ref(tup(6 tup(tup(104 tup(101 tup(108 tup(108 tup(111 tup(32 w134)))))) w134)) _) w59))
+  ::std::logical::Bool::to_string::to_string = fn(w59 tup(@n32_add(0 w135) w136))
+  ::std::IO::println = fn(ref(w35 w50) fn(tup(w135 w136) _))
+  ::std::unicode::String::starts_with = fn(ref(w54 w69) fn(ref(tup(5 tup(tup(119 tup(111 tup(114 tup(108 tup(100 w142))))) w142)) _) w74))
+  ::std::logical::Bool::to_string::to_string = fn(w74 tup(@n32_add(0 w143) w144))
+  ::std::IO::println = fn(ref(w50 w65) fn(tup(w143 w144) _))
+  ::std::unicode::String::starts_with = fn(ref(w69 w84) fn(ref(tup(4 tup(tup(104 tup(101 tup(108 tup(100 w150)))) w150)) _) w89))
+  ::std::logical::Bool::to_string::to_string = fn(w89 tup(@n32_add(0 w151) w152))
+  ::std::IO::println = fn(ref(w65 w80) fn(tup(w151 w152) _))
+  ::std::unicode::String::starts_with = fn(ref(w84 _) fn(ref(tup(15 tup(tup(104 tup(101 tup(108 tup(108 tup(111 tup(32 tup(119 tup(111 tup(114 tup(108 tup(100 tup(33 tup(32 tup(104 tup(105 w158))))))))))))))) w158)) _) w104))
+  ::std::logical::Bool::to_string::to_string = fn(w104 tup(@n32_add(0 w159) w160))
+  ::std::IO::println = fn(ref(w80 w95) fn(tup(w159 w160) _))
+}
+
+::std::numeric::N32::to_string::to_string {
+  fn(w0 w10)
+  ::std::numeric::N32::eq::ne = fn(ref(w0 w6) fn(ref(0 _) ?(::std::numeric::N32::to_string::to_string::3 ::std::numeric::N32::to_string::to_string::2 x(w6 w10))))
+}
+
+::std::numeric::N32::to_string::to_string::2 {
+  x(w6 w9)
+  ::std::numeric::N32::to_string::to_string::4 = x(w6 x(tup(0 tup(w7 w7)) w9))
+}
+
+::std::numeric::N32::to_string::to_string::3 { x(_ tup(1 tup(tup(48 w5) w5))) }
+
+::std::numeric::N32::to_string::to_string::4 { x(dup44(n0 @n32_ne(0 ?(::std::numeric::N32::to_string::to_string::6 ::std::numeric::N32::to_string::to_string::5 x(n0 n1)))) n1) }
+
+::std::numeric::N32::to_string::to_string::5 { x(dup38(@n32_rem(10 @n32_add$(48 n0)) @n32_div(10 dup44(n1 @n32_ne(0 ?(::std::numeric::N32::to_string::to_string::6 ::std::numeric::N32::to_string::to_string::5 x(n1 x(tup(n2 tup(tup(n0 n3) n4)) n5))))))) x(tup(@n32_add$(1 n2) tup(n3 n4)) n5)) }
+
+::std::numeric::N32::to_string::to_string::6 { x(_ x(n0 n0)) }
+
+::std::numeric::N32::eq::ne { fn(ref(dup44(n0 @n32_ne(n1 n2)) n0) fn(ref(dup45(n3 n1) n3) n2)) }
+
+::std::logical::Bool::to_string::to_string { fn(?(::std::logical::Bool::to_string::to_string::3 ::std::logical::Bool::to_string::to_string::2 n0) n0) }
+
+::std::logical::Bool::to_string::to_string::2 { tup(4 tup(tup(116 tup(114 tup(117 tup(101 n0)))) n0)) }
+
+::std::logical::Bool::to_string::to_string::3 { tup(5 tup(tup(102 tup(97 tup(108 tup(115 tup(101 n0))))) n0)) }
+
+::std::data::List::Iter::iterator::next::2 { x(x(@n32_sub(1 n0) n0) x(x(ref(tup(n1 n2) tup(n3 n4)) ref(n2 n4)) enum(enum(ref(n1 n3) n5) enum(_ n5)))) }
+
+::std::data::List::Iter::iterator::next::3 { x(x(n0 n0) x(x(ref(n1 n1) _) ::std::logical::Option::None)) }
+
+::std::logical::Option::unwrap::3 { enum(n0 n0) }
+
+::std::unicode::String::len { fn(ref(tup(dup2560(n0 n1) n2) tup(n0 n2)) n1) }
+
+::std::unicode::String::starts_with { fn(ref(tup(dup2560(n0 dup223(_ @n32_lt(n1 ?(::std::unicode::String::starts_with::3 ::std::unicode::String::starts_with::2 x(x(tup(n0 n2) n3) x(x(tup(n4 n5) n6) n7)))))) n2) n3) fn(ref(tup(dup2560(n4 dup224(_ n1)) n5) n6) n7)) }
+
+::std::unicode::String::starts_with::2 { x(x(n0 n0) x(x(n1 n1) 0)) }
+
+::std::unicode::String::starts_with::3 { x(x(tup(dup803(n0 n1) tup(n2 n3)) tup(n0 tup(n4 n3))) x(x(tup(dup803(n5 dup44(n6 @n32_ne(0 ?(::std::data::List::Iter::iterator::next::3 ::std::data::List::Iter::iterator::next::2 x(x(n6 n7) x(x(ref(n8 n9) n10) enum(::std::unicode::String::starts_with::7 enum(::std::unicode::String::starts_with::8 x(tup(n1 ref(n2 n4)) x(tup(n7 n10) n11)))))))))) tup(n8 n12)) tup(n5 tup(n9 n12))) n11)) }
+
+::std::unicode::String::starts_with::4 { x(n0 x(tup(dup44(n1 @n32_ne(0 ?(::std::data::List::Iter::iterator::next::3 ::std::data::List::Iter::iterator::next::2 x(x(n1 n2) x(x(n3 n4) enum(::std::unicode::String::starts_with::7 enum(::std::unicode::String::starts_with::8 x(n0 x(tup(n2 n4) n5))))))))) n3) n5)) }
+
+::std::unicode::String::starts_with::7 { enum(ref(dup2508(n0 @n32_ne(n1 ?(::std::unicode::String::starts_with::4 ::std::unicode::String::starts_with::10 x(tup(n2 n3) n4)))) n0) x(tup(dup44(n5 @n32_ne(0 ?(::std::data::List::Iter::iterator::next::3 ::std::data::List::Iter::iterator::next::2 x(x(n5 n2) x(x(n6 n3) enum(::std::logical::Option::unwrap::3 enum(_ ref(dup2509(n7 n1) n7)))))))) n6) n4)) }
+
+::std::unicode::String::starts_with::8 { x(tup(_ ref(n0 n0)) x(_ 1)) }
+
+::std::unicode::String::starts_with::10 { x(tup(_ ref(n0 n0)) x(tup(_ ref(n1 n1)) 0)) }
+
+::std::IO::println { fn(ref(n0 n1) fn(tup(dup44(n2 @n32_ne(0 ?(::std::IO::print::3 ::std::IO::print::2 x(x(n0 @io_print_char(10 n1)) x(n2 n3))))) tup(n3 _)) _)) }
+
+::std::IO::print::2 { x(x(@io_print_char(n0 n1) n2) x(@n32_sub(1 dup44(n3 @n32_ne(0 ?(::std::IO::print::3 ::std::IO::print::2 x(x(n1 n2) x(n3 n4)))))) tup(n0 n4))) }
+
+::std::IO::print::3 { x(x(n0 n0) _) }
+

--- a/tests/snaps/vine/string_ops/output.txt
+++ b/tests/snaps/vine/string_ops/output.txt
@@ -1,0 +1,7 @@
+12
+true
+true
+true
+false
+false
+false

--- a/tests/snaps/vine/string_ops/stats.txt
+++ b/tests/snaps/vine/string_ops/stats.txt
@@ -1,0 +1,17 @@
+
+Interactions
+  Total                1_557
+    Depth                300
+    Breadth                5
+  Annihilate             708
+  Commute                  0
+  Copy                   198
+  Erase                  225
+  Expand                 146
+  Call                   189
+  Branch                  91
+
+Memory
+  Heap                 5_904 B
+  Allocated           30_672 B
+  Freed               30_672 B

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -71,6 +71,7 @@ fn tests(t: &mut DynTester) {
     test_vi(t, "tests/programs/so_random.vi", b"", ".txt", true);
     test_vi(t, "tests/programs/specializations.vi", b"", ".txt", true);
     test_vi(t, "tests/programs/square_case.vi", b"", ".txt", true);
+    test_vi(t, "tests/programs/string_ops.vi", b"", ".txt", true);
     test_vi(t, "tests/programs/verbose_add.vi", b"", ".txt", true);
 
     for (name, _) in t.glob_in("programs/aoc_2024/", "*.vi") {

--- a/vine/std/unicode/String.vi
+++ b/vine/std/unicode/String.vi
@@ -90,6 +90,24 @@ pub mod String {
     Ok(List(len, move buf, end) as String)
   }
 
+  pub fn .starts_with(&self: &String, &prefix: &String) -> Bool {
+    if self.len() < prefix.len() {
+      return false;
+    }
+    let self_iter = self.chars.iter();
+    let prefix_iter = prefix.chars.iter();
+    while prefix_iter.next() is Some(&a) {
+      let &b = self_iter.next().unwrap();
+      if a != b {
+        self_iter.drop()
+        prefix_iter.drop()
+        return false
+      }
+    }
+    self_iter.drop();
+    true
+  }
+
   pub fn .eq(&self: &String, &other: &String) -> Bool {
     if self.len() != other.len() {
       return false;


### PR DESCRIPTION
Currently, like `strip_prefix`, `starts_with` takes the prefix as reference and I can see reasons for doing this especially when reusing a prefix multiple times and repeatedly having diverging prefixes.

However, I can also see reasoning for why is might be nice to have `starts_with` take the prefix as value for performance reasons and better parallelism. Wdyt?