### PR TITLE
tooling: use installed vine bin for formatting

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -77,8 +77,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dsherret/rust-toolchain-file@v1
       - run: cargo fmt --check
-      - run: cargo build
-      - run: cargo install --path cli
+      - run: cargo build --release
       - uses: dprint/check@v2.2
 
   cspell:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -78,6 +78,7 @@ jobs:
       - uses: dsherret/rust-toolchain-file@v1
       - run: cargo fmt --check
       - run: cargo build
+      - run: cargo install --path cli
       - uses: dprint/check@v2.2
 
   cspell:

--- a/dprint.json
+++ b/dprint.json
@@ -8,7 +8,7 @@
   },
   "exec": {
     "commands": [{
-      "command": "cargo run --bin vine fmt",
+      "command": "vine fmt",
       "exts": ["vi"]
     }]
   },

--- a/dprint.json
+++ b/dprint.json
@@ -8,7 +8,7 @@
   },
   "exec": {
     "commands": [{
-      "command": "vine fmt",
+      "command": "target/release/vine fmt",
       "exts": ["vi"]
     }]
   },


### PR DESCRIPTION
Files get formatted instantly rather than in ~1s when using cargo and formatting also continues vine doesn't build while e.g. working on the compiler.

The downside is that changes to the formatter itself require a `cargo install` to propergate but I think that is reasonable and justified by the benefits.