### PR TITLE
std: remove ne_from_eq

### DIFF
--- a/vine/std/ops/comparison.vi
+++ b/vine/std/ops/comparison.vi
@@ -17,10 +17,6 @@ pub mod Eq {
       a0 != a1 || b0 != b1
     }
   }
-
-  pub fn ne_from_eq[T; Eq[T]](&a: &T, &b: &T) -> Bool {
-    !(a == b)
-  }
 }
 
 pub trait Ord[T] {


### PR DESCRIPTION
`ne_from_eq` is currently unused and I would argue that it is always easier to simply implement `ne` from `eq` directly as is done in #231 than to use `ne_from_eq`.