### PR TITLE
tooling: fix gitignore notation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 target
-tests/snaps/**/{compiled.iv,timing.txt}
+tests/snaps/**/compiled.iv
+tests/snaps/**/timing.txt
 
 # Nix build outputs
 result


### PR DESCRIPTION
Git actually doesn't understand the bracket notation so split this into two lines.