### PR TITLE
std: fix iterator dropping in List eq

### DIFF
--- a/tests/programs/string_ops.vi
+++ b/tests/programs/string_ops.vi
@@ -23,4 +23,9 @@ pub fn main(&io: &IO) {
   io.println("{"hello" != "world"}");
   io.println("{"hello" == "hello world"}");
   io.println("{"world" == "hello world"}");
+
+  let x = "hi";
+  io.println("{x == "xy"}");
+  io.println("{x == "hi"}");
+  io.println("{x}");
 }

--- a/tests/snaps/vine/string_ops/output.txt
+++ b/tests/snaps/vine/string_ops/output.txt
@@ -13,3 +13,6 @@ false
 true
 false
 false
+false
+true
+hi

--- a/tests/snaps/vine/string_ops/stats.txt
+++ b/tests/snaps/vine/string_ops/stats.txt
@@ -1,17 +1,17 @@
 
 Interactions
-  Total                3_397
-    Depth                344
-    Breadth                9
-  Annihilate           1_517
+  Total                3_866
+    Depth                358
+    Breadth               10
+  Annihilate           1_752
   Commute                  0
-  Copy                   471
-  Erase                  522
-  Expand                 296
-  Call                   399
-  Branch                 192
+  Copy                   516
+  Erase                  580
+  Expand                 339
+  Call                   459
+  Branch                 220
 
 Memory
-  Heap                13_504 B
-  Allocated           66_224 B
-  Freed               66_224 B
+  Heap                15_504 B
+  Allocated           75_936 B
+  Freed               75_936 B

--- a/vine/std/data/List.vi
+++ b/vine/std/data/List.vi
@@ -206,10 +206,12 @@ pub mod List {
       if a.len() != b.len() {
         return false;
       }
-      let a = a.iter();
-      let b = b.iter();
-      while a.next() is Some(&a) && b.next() is Some(&b) {
-        if a != b {
+      let a_iter = a.iter();
+      let b_iter = b.iter();
+      while a_iter.next() is Some(&a_elem) && b_iter.next() is Some(&b_elem) {
+        if a_elem != b_elem {
+          a_iter.drop();
+          b_iter.drop();
           return false;
         }
       }


### PR DESCRIPTION
When lists or strings of the same length were compared that are not equal, not dropping the iterator deletes part of the string.