### PR TITLE
std: parse ints without sign

### DIFF
--- a/tests/programs/repl/i32_misc.vi
+++ b/tests/programs/repl/i32_misc.vi
@@ -21,6 +21,8 @@
 I32::parse("")
 I32::parse("=0")
 I32::parse("+0")
+I32::parse("123")
 I32::parse("+123")
 I32::parse("-123")
 I32::parse("+a")
+I32::parse("a4321")

--- a/tests/snaps/vine/repl/i32_misc.repl.vi
+++ b/tests/snaps/vine/repl/i32_misc.repl.vi
@@ -92,6 +92,10 @@ io = #io
 Some(+0)
 
 io = #io
+> I32::parse("123")
+Some(+123)
+
+io = #io
 > I32::parse("+123")
 Some(+123)
 
@@ -101,6 +105,10 @@ Some(-123)
 
 io = #io
 > I32::parse("+a")
+None
+
+io = #io
+> I32::parse("a4321")
 None
 
 io = #io

--- a/vine/std/numeric/I32.vi
+++ b/vine/std/numeric/I32.vi
@@ -124,12 +124,12 @@ pub mod I32 {
 
   pub fn parse(str: String) -> Option[I32] {
     if str!.pop_front() is Some(prefix) {
-      if prefix == '+' {
-        N32::parse(str).map(fn(x: N32) { x as I32 })
-      } else if prefix == '-' {
+      if prefix == '-' {
         N32::parse(str).map(fn(x: N32) { -x as I32 })
       } else {
-        str!.push_front(prefix);
+        if prefix != '+' {
+          str!.push_front(prefix);
+        }
         N32::parse(str).map(fn(x: N32) { x as I32 })
       }
     } else {

--- a/vine/std/numeric/I32.vi
+++ b/vine/std/numeric/I32.vi
@@ -123,13 +123,14 @@ pub mod I32 {
   }
 
   pub fn parse(str: String) -> Option[I32] {
-    if str!.pop_front() is Some(sign) {
-      if sign == '+' {
-        N32::parse(str).map(fn(x: N32) { x.as[I32] })
-      } else if sign == '-' {
-        N32::parse(str).map(fn(x: N32) { -x.as[I32] })
+    if str!.pop_front() is Some(prefix) {
+      if prefix == '+' {
+        N32::parse(str).map(fn(x: N32) { x as I32 })
+      } else if prefix == '-' {
+        N32::parse(str).map(fn(x: N32) { -x as I32 })
       } else {
-        None
+        str!.push_front(prefix);
+        N32::parse(str).map(fn(x: N32) { x as I32 })
       }
     } else {
       None


### PR DESCRIPTION
Parsing of non-negative ints should also work with no plus sign in the front. No plus sign is probably even the more common case. My current case: Parsing exponents in scientific float notation (e.g. 1e3).