### PR TITLE
vine: add basic try operator

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -34,6 +34,7 @@
     "parens",
     "peekable",
     "primality",
+    "primenesses",
     "readback",
     "readline",
     "rels",

--- a/tests/programs/primenesses.vi
+++ b/tests/programs/primenesses.vi
@@ -1,0 +1,37 @@
+
+pub fn main(&io: &IO) {
+  let results = [
+    primenesses([]),
+    primenesses([2, 3, 5, 7, 11, 13]),
+    primenesses([1, 2, 3, 4]),
+    primenesses([3, 5, 7, 9]),
+    primenesses([2, 3, 5, 0, 9]),
+    primenesses([2, 3, 5, 8, 13]),
+  ];
+  io.println(results.show().as[String])
+}
+
+pub fn primenesses(list: List[N32]) -> Result[List[Bool], String] {
+  let out = [];
+  while list.pop_front() is Some(n) {
+    out.push_back(primeness(n)?);
+  }
+  Ok(out)
+}
+
+pub fn primeness(n: N32) -> Result[Bool, String] {
+  if n <= 0 {
+    return Err("primes have to be positive!");
+  }
+  if n == 1 {
+    return Err("depends who's asking");
+  }
+  let d = 2;
+  while d * d <= n {
+    if n % d == 0 {
+      return Ok(false);
+    }
+    d += 1;
+  }
+  Ok(true)
+}

--- a/tests/programs/repl/misc.vi
+++ b/tests/programs/repl/misc.vi
@@ -58,3 +58,7 @@ let x: { a: ~N32, b: ~N32 } = ~{ a, b };
 move (a, b, x)
 let x
 x.a; x.a
+Ok(true)?
+fn foo() -> N32 { Ok(123)? }
+fn foo() -> Result[N32, String] { Ok(123)? }
+fn foo() -> Result[N32, String] { Err(123)? }

--- a/tests/snaps/vine/primenesses/output.txt
+++ b/tests/snaps/vine/primenesses/output.txt
@@ -1,0 +1,8 @@
+[
+  Ok([]),
+  Ok([true, true, true, true, true, true]),
+  Err("depends who's asking"),
+  Ok([true, true, true, false]),
+  Err("primes have to be positive!"),
+  Ok([true, true, true, false, true]),
+]

--- a/tests/snaps/vine/primenesses/stats.txt
+++ b/tests/snaps/vine/primenesses/stats.txt
@@ -1,0 +1,17 @@
+
+Interactions
+  Total                7_865
+    Depth              2_228
+    Breadth                3
+  Annihilate           3_617
+  Commute                135
+  Copy                   870
+  Erase                1_042
+  Expand                 598
+  Call                 1_159
+  Branch                 444
+
+Memory
+  Heap                13_040 B
+  Allocated          164_752 B
+  Freed              164_752 B

--- a/tests/snaps/vine/repl/misc.repl.vi
+++ b/tests/snaps/vine/repl/misc.repl.vi
@@ -249,3 +249,19 @@ io = #io
 error input:1:5 - cannot infer type
 
 io = #io
+> Ok(true)?
+error input:1:1 - no function to return from
+
+io = #io
+> fn foo() -> N32 { Ok(123)? }
+error input:1:19 - cannot try `Result[N32, ?4]` in a function returning `N32`
+
+io = #io
+> fn foo() -> Result[N32, String] { Ok(123)? }
+error input:1:33 - expected type `Result[N32, String]`; found `N32`
+
+io = #io
+> fn foo() -> Result[N32, String] { Err(123)? }
+error input:1:35 - cannot try `Result[?5, N32]` in a function returning `Result[N32, String]`
+
+io = #io

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -66,6 +66,7 @@ fn tests(t: &mut DynTester) {
     test_vi(t, "tests/programs/option_party.vi", b"", ".txt", true);
     test_vi(t, "tests/programs/par.vi", b"", ".txt", true);
     test_vi(t, "tests/programs/pretty_div.vi", b"", ".txt", true);
+    test_vi(t, "tests/programs/primenesses.vi", b"", ".txt", true);
     test_vi(t, "tests/programs/segmented_sieve.vi", b"", ".txt", false);
     test_vi(t, "tests/programs/sieve.vi", b"", ".txt", false);
     test_vi(t, "tests/programs/so_random.vi", b"", ".txt", true);

--- a/vine/src/ast.rs
+++ b/vine/src/ast.rs
@@ -165,6 +165,7 @@ pub enum Builtin {
   Prelude,
   List,
   String,
+  Result,
   BinaryOp(BinaryOp),
   Neg,
   Not,
@@ -317,6 +318,8 @@ pub enum ExprKind<'core> {
   Cast(B<Expr<'core>>, B<Ty<'core>>, bool),
   #[class(value, space, place)]
   Unwrap(B<Expr<'core>>),
+  #[class(value)]
+  Try(B<Expr<'core>>),
   #[class(value)]
   N32(u32),
   #[class(value)]

--- a/vine/src/chart.rs
+++ b/vine/src/chart.rs
@@ -38,6 +38,7 @@ pub struct Builtins {
 
   pub list: Option<StructId>,
   pub string: Option<StructId>,
+  pub result: Option<EnumId>,
 
   pub neg: Option<ValueDefId>,
   pub not: Option<ValueDefId>,
@@ -364,6 +365,14 @@ impl<'core> TypeDefKind<'core> {
   pub fn struct_id(&self) -> Option<StructId> {
     if let TypeDefKind::Struct(struct_id) = self {
       Some(*struct_id)
+    } else {
+      None
+    }
+  }
+
+  pub fn enum_id(&self) -> Option<EnumId> {
+    if let TypeDefKind::Enum(enum_id) = self {
+      Some(*enum_id)
     } else {
       None
     }

--- a/vine/src/charter.rs
+++ b/vine/src/charter.rs
@@ -330,6 +330,7 @@ impl<'core> Charter<'core, '_> {
       }
     }
     let struct_id = || def.type_def.and_then(|id| self.chart.types[id].kind.struct_id());
+    let enum_id = || def.type_def.and_then(|id| self.chart.types[id].kind.enum_id());
 
     match builtin {
       Builtin::Bool => set(def.type_def, &mut self.chart.builtins.bool),
@@ -341,6 +342,7 @@ impl<'core> Charter<'core, '_> {
       Builtin::Prelude => set(Some(def_id), &mut self.chart.builtins.prelude),
       Builtin::List => set(struct_id(), &mut self.chart.builtins.list),
       Builtin::String => set(struct_id(), &mut self.chart.builtins.string),
+      Builtin::Result => set(enum_id(), &mut self.chart.builtins.result),
       Builtin::Neg => set(def.value_def, &mut self.chart.builtins.neg),
       Builtin::Not => set(def.value_def, &mut self.chart.builtins.not),
       Builtin::BoolNot => set(def.impl_def, &mut self.chart.builtins.bool_not),

--- a/vine/src/diag.rs
+++ b/vine/src/diag.rs
@@ -210,6 +210,9 @@ diags! {
     ["constructor expects data"]
   StructDataInvisible { ty: String, vis: &'core str }
     ["the data of `{ty}` is only visible within `{vis}`"]
+  TryBadReturnType { tried: String, ret: String }
+    ["cannot try `{tried}` in a function returning `{ret}`"]
+
 }
 
 fn plural<'a>(n: usize, plural: &'a str, singular: &'a str) -> &'a str {

--- a/vine/src/distiller.rs
+++ b/vine/src/distiller.rs
@@ -124,6 +124,7 @@ impl<'core, 'r> Distiller<'core, 'r> {
       ExprKind::Continue(label) => self.distill_continue(stage, label.as_id()),
       ExprKind::Fn(params, _, body) => self.distill_fn(stage, params, body),
       ExprKind::Match(value, arms) => self.distill_match(stage, value, arms),
+      ExprKind::Try(result) => self.distill_try(stage, result),
 
       ExprKind::Paren(inner) | ExprKind::Unwrap(inner) | ExprKind::Struct(_, _, inner) => {
         self.distill_expr_value(stage, inner)

--- a/vine/src/fmt.rs
+++ b/vine/src/fmt.rs
@@ -422,6 +422,7 @@ impl<'core: 'src, 'src> Formatter<'src> {
         Doc::concat([self.fmt_expr(x), Doc(".as["), self.fmt_ty(ty), Doc("]")])
       }
       ExprKind::Unwrap(x) => Doc::concat([self.fmt_expr(x), Doc("!")]),
+      ExprKind::Try(x) => Doc::concat([self.fmt_expr(x), Doc("?")]),
       ExprKind::Place(v, s) => {
         Doc::concat([Doc("("), self.fmt_expr(v), Doc("; "), self.fmt_expr(s), Doc(")")])
       }

--- a/vine/src/parser.rs
+++ b/vine/src/parser.rs
@@ -124,6 +124,7 @@ impl<'core, 'src> VineParser<'core, 'src> {
           "IO" => Builtin::IO,
           "List" => Builtin::List,
           "String" => Builtin::String,
+          "Result" => Builtin::Result,
           "prelude" => Builtin::Prelude,
           "neg" => Builtin::Neg,
           "not" => Builtin::Not,
@@ -687,6 +688,10 @@ impl<'core, 'src> VineParser<'core, 'src> {
 
     if self.eat(Token::Bang)? {
       return Ok(Ok(ExprKind::Unwrap(Box::new(lhs))));
+    }
+
+    if self.eat(Token::Question)? {
+      return Ok(Ok(ExprKind::Try(Box::new(lhs))));
     }
 
     if self.eat(Token::Dot)? {

--- a/vine/src/visit.rs
+++ b/vine/src/visit.rs
@@ -78,6 +78,7 @@ pub trait VisitMut<'core, 'a> {
       | ExprKind::ObjectField(a, _)
       | ExprKind::Inverse(a, _)
       | ExprKind::Unwrap(a)
+      | ExprKind::Try(a)
       | ExprKind::Copy(a)
       | ExprKind::Hedge(a)
       | ExprKind::Set(a) => self.visit_expr(a),

--- a/vine/std/logical/Result.vi
+++ b/vine/std/logical/Result.vi
@@ -1,6 +1,7 @@
 
 use debug::Show;
 
+#[builtin = "Result"]
 pub enum Result[T, E] {
   Ok(T),
   Err(E),


### PR DESCRIPTION
Adds a basic version of the try (`?`) operator. Only works on `Result`s for now, and does no casting of the error type. There is no `try {}` block yet either.

Partially implements #230

Drafted due to dependency on #246 