### PR TITLE
vine: rename `dyn fn` to `let fn`

### DIFF
--- a/tests/programs/aoc_2024/day_08.vi
+++ b/tests/programs/aoc_2024/day_08.vi
@@ -13,13 +13,13 @@ pub fn main(&io: &IO) {
   let width = (*grid.get(0)).len();
   let height = grid.len();
 
-  dyn fn check_antinode((x: N32, y: N32)) {
+  let fn check_antinode((x: N32, y: N32)) {
     if x < width && y < height {
       antinodes1.insert((x, y), ());
     }
   }
 
-  dyn fn check_dir((x: N32, y: N32), dir: (N32, N32)) {
+  let fn check_dir((x: N32, y: N32), dir: (N32, N32)) {
     while x < width && y < height {
       antinodes2.insert((x, y), ());
       (x, y) += dir;

--- a/tests/programs/aoc_2024/day_09.vi
+++ b/tests/programs/aoc_2024/day_09.vi
@@ -27,7 +27,7 @@ fn part1(input: String) -> N64 {
   let pos = 0;
   let remaining = used;
 
-  dyn fn push_block(id: N32, len: N32) {
+  let fn push_block(id: N32, len: N32) {
     let end = pos + len;
     sum = sum + N64::mul_n32_n32(id, ((end - 1) * end - (pos - 1) * pos) / 2);
     pos = end;

--- a/tests/programs/aoc_2024/day_10.vi
+++ b/tests/programs/aoc_2024/day_10.vi
@@ -26,7 +26,7 @@ pub fn main(&io: &IO) {
         let prev = char - 1;
         let in_s = zero_set;
         let in_n = 0;
-        dyn fn recv(t: Char, (s: Set, n: N32)) {
+        let fn recv(t: Char, (s: Set, n: N32)) {
           if t == prev {
             in_s |= s;
             in_n += n;
@@ -80,7 +80,7 @@ fn set(n: N32) -> Set {
 }
 
 fn count(s: Set) -> N32 {
-  dyn fn c32(x: N32) {
+  let fn c32(x: N32) {
     let n = 0;
     while x != 0 {
       n += x & 1;
@@ -88,10 +88,10 @@ fn count(s: Set) -> N32 {
     }
     n
   }
-  dyn fn c64((a, b)) {
+  let fn c64((a, b)) {
     c32(a) + c32(b)
   }
-  dyn fn c128((a, b)) {
+  let fn c128((a, b)) {
     c64(a) + c64(b)
   }
   let (x, y) = s;

--- a/tests/programs/aoc_2024/day_11.vi
+++ b/tests/programs/aoc_2024/day_11.vi
@@ -24,7 +24,7 @@ pub fn main(&io: &IO) {
 fn blink(&io: &IO, old: Map[N64, N64]) -> Map[N64, N64] {
   let new = Map::empty[N64, _];
   let iter = old.into_iter();
-  dyn fn add_stones(number: N64, count: N64) {
+  let fn add_stones(number: N64, count: N64) {
     let &c = new.get_or_insert(number, N64::zero);
     c += count;
   }

--- a/tests/programs/aoc_2024/day_12.vi
+++ b/tests/programs/aoc_2024/day_12.vi
@@ -57,7 +57,7 @@ pub fn main(&io: &IO) {
     while x <= width {
       let ne = north.pop_front().unwrap_or('#');
       let se = s.pop_front().unwrap_or('#');
-      dyn fn check_corner(x: N32, y: N32, a: Char, b: Char, c: Char, d: Char) {
+      let fn check_corner(x: N32, y: N32, a: Char, b: Char, c: Char, d: Char) {
         if a != '#' && (b != a != d || a == b == d != c) {
           let i = x + y * width;
           let a = regions.get_area(i);

--- a/tests/programs/aoc_2024/day_14.vi
+++ b/tests/programs/aoc_2024/day_14.vi
@@ -16,7 +16,7 @@ pub fn main(&io: &IO) {
     let vy = r.unwrap();
     let px = N32::parse(px).unwrap();
     let py = N32::parse(py).unwrap();
-    dyn fn parse_signed(x: String, m: N32) {
+    let fn parse_signed(x: String, m: N32) {
       if *x!.get(0) == '-' {
         x!.pop_front();
         m - N32::parse(x).unwrap()

--- a/tests/programs/aoc_2024/day_15.vi
+++ b/tests/programs/aoc_2024/day_15.vi
@@ -23,11 +23,11 @@ pub fn main(&io: &IO) {
 
   let initial_grid = grid;
 
-  dyn fn get((x, y)) {
+  let fn get((x, y)) {
     (*grid.get(y)).get(x)
   }
 
-  dyn fn show_grid() {
+  let fn show_grid() {
     io.println(grid.as[List].map(fn(array: Array) { array as List as String }).join("\n"));
   }
 

--- a/tests/programs/aoc_2024/day_16.vi
+++ b/tests/programs/aoc_2024/day_16.vi
@@ -22,7 +22,7 @@ pub fn main(&io: &IO) {
   let pq = Map::empty[N32, _];
   pq.insert(0, [(start, 0)]);
 
-  dyn fn try_insert(dist: N32, pos: (N32, N32), dir) {
+  let fn try_insert(dist: N32, pos: (N32, N32), dir) {
     let (x, y) = pos;
     let &(passable, dirs, _) = (*grid.get(y)).get(x);
     if passable {

--- a/tests/programs/aoc_2024/day_17.vi
+++ b/tests/programs/aoc_2024/day_17.vi
@@ -4,7 +4,7 @@ use std::data::Array;
 pub fn main(&io: &IO) {
   let input = io.full_input();
 
-  dyn fn read_value() {
+  let fn read_value() {
     let (_, rest) = input.split_once(": ");
     let (value, rest) = rest.unwrap().split_once("\n");
     input = rest.unwrap();
@@ -26,7 +26,7 @@ pub fn main(&io: &IO) {
     steps -= 1;
     let opcode = *program.get(ip);
     let operand = *program.get(ip + 1);
-    dyn fn combo() {
+    let fn combo() {
       if operand == 4 {
         a
       } else if operand == 5 {

--- a/tests/programs/aoc_2024/day_18.vi
+++ b/tests/programs/aoc_2024/day_18.vi
@@ -22,7 +22,7 @@ pub fn main(&io: &IO) {
 
   let bytes = i;
 
-  dyn fn show_grid(c: N32) {
+  let fn show_grid(c: N32) {
     io.println(grid.as[List].map(fn(row: Array[N32]) {
       row.fold_front(
         "",
@@ -47,14 +47,14 @@ pub fn main(&io: &IO) {
 
   let set = DisjointSet::new(size * size);
 
-  dyn fn coord(x: N32, y: N32) {
+  let fn coord(x: N32, y: N32) {
     y * size + x
   }
 
   let blocked = Array::new(size, Array::new(size, true));
 
-  dyn fn remove_data(x: N32, y: N32) {
-    dyn fn connect(dx: N32, dy: N32) {
+  let fn remove_data(x: N32, y: N32) {
+    let fn connect(dx: N32, dy: N32) {
       let X = x + dx;
       let Y = y + dy;
       if X < size && Y < size && !*(*blocked.get(Y)).get(X) {
@@ -160,7 +160,7 @@ fn pathfind(grid: Array[Array[N32]], size: N32, iters: N32) -> N32 {
       let &cell = (*grid.get(y)).get(x);
       if cell >= iters {
         cell = 0;
-        dyn fn visit((x: N32, y: N32)) {
+        let fn visit((x: N32, y: N32)) {
           if x < size && y < size && *(*grid.get(y)).get(x) >= iters {
             next ++= [(x, y)];
           }

--- a/tests/programs/aoc_2024/day_20.vi
+++ b/tests/programs/aoc_2024/day_20.vi
@@ -45,7 +45,7 @@ pub fn main(&io: &IO) {
 
   while !eq(cur, end) {
     let next;
-    dyn fn check(pos) {
+    let fn check(pos) {
       if !eq(prev, pos) && *(*grid.get(pos.1)).get(pos.0) {
         next = pos;
       }

--- a/tests/programs/aoc_2024/day_21.vi
+++ b/tests/programs/aoc_2024/day_21.vi
@@ -7,7 +7,7 @@ pub fn main(&io: &IO) {
   let sum = 0;
   let iter = lines.into_iter();
   while iter.next() is Some(line) {
-    dyn fn test_seed(seed: N32) {
+    let fn test_seed(seed: N32) {
       let line = control_string('A', line, seed, control_numeric);
       let line = control_string('A', line, 0, control_directional);
       let line = control_string('A', line, 0, control_directional);
@@ -36,7 +36,7 @@ pub fn main(&io: &IO) {
     let cost = N64::zero;
     let last = 2;
     while line!.pop_front() is Some(char) {
-      dyn fn pos(x: Char) {
+      let fn pos(x: Char) {
         if x == '0' {
           1
         } else if x == 'A' {
@@ -68,7 +68,7 @@ fn control_string(cur: Char, string: String, seed: N32, f: fn(Char, Char, Bool) 
 }
 
 fn control_numeric(from: Char, to: Char, horiz: Bool) -> String {
-  dyn fn pos(x: Char) {
+  let fn pos(x: Char) {
     if x == '0' {
       1
     } else if x == 'A' {
@@ -100,7 +100,7 @@ fn control_numeric(from: Char, to: Char, horiz: Bool) -> String {
 }
 
 fn control_directional(from: Char, to: Char, _: Bool) -> String {
-  dyn fn pos(x: Char) {
+  let fn pos(x: Char) {
     if x == '<' {
       0
     } else if x == 'v' {
@@ -148,18 +148,18 @@ fn cost_func(c: CostFunc, size: N32, dead_row: N32) -> CostFunc {
   while from < size {
     let to = 0;
     while to < size {
-      dyn fn test(horiz: Bool) {
+      let fn test(horiz: Bool) {
         let cost = N64::zero;
         let fx = from % 3;
         let fy = from / 3;
         let tx = to % 3;
         let ty = to / 3;
         let last = 5;
-        dyn fn press(button: N32) {
+        let fn press(button: N32) {
           cost += *(*c.get(last)).get(button);
           last = button;
         }
-        dyn fn do_horiz() {
+        let fn do_horiz() {
           while fx < tx {
             press(2)
             fx += 1;
@@ -169,7 +169,7 @@ fn cost_func(c: CostFunc, size: N32, dead_row: N32) -> CostFunc {
             fx -= 1;
           }
         }
-        dyn fn do_vert() {
+        let fn do_vert() {
           while fy < ty {
             press(4)
             fy += 1;

--- a/tests/programs/aoc_2024/day_24.vi
+++ b/tests/programs/aoc_2024/day_24.vi
@@ -10,7 +10,7 @@ pub fn main(&io: &IO) {
     map.insert(name, Wire::input(value));
   }
 
-  dyn fn get_wire(wire) {
+  let fn get_wire(wire) {
     map.get_or_insert(wire, Wire::new())
   }
 

--- a/tests/programs/logic.vi
+++ b/tests/programs/logic.vi
@@ -1,6 +1,6 @@
 
 pub fn main(&io: &IO) {
-  dyn fn print_bool(bool) {
+  let fn print_bool(bool) {
     io.println(if bool {
       "true"
     } else {

--- a/tests/programs/map_test.vi
+++ b/tests/programs/map_test.vi
@@ -15,7 +15,7 @@ pub fn main(&io: &IO) {
     map.insert(num, num * num)
   }
 
-  dyn fn integrity_check(expected_length: N32) {
+  let fn integrity_check(expected_length: N32) {
     let iter = map.iter();
     let last = 0;
     let count = 0;

--- a/tests/programs/option_party.vi
+++ b/tests/programs/option_party.vi
@@ -1,17 +1,17 @@
 
 pub fn main(&io: &IO) {
-  dyn fn print_option_n32(option: Option[N32]) {
+  let fn print_option_n32(option: Option[N32]) {
     io.println("  " ++ match option {
       Some(val) { "Some({val})" }
       None { "None" }
     })
   }
 
-  dyn fn print_n32(val: N32) {
+  let fn print_n32(val: N32) {
     io.println("  {val}")
   }
 
-  dyn fn print_bool(bool: Bool) {
+  let fn print_bool(bool: Bool) {
     io.println(if bool {
       "  true"
     } else {

--- a/tests/programs/par.vi
+++ b/tests/programs/par.vi
@@ -99,28 +99,28 @@ fn start_playing(&io: &IO) -> Game {
 
       io.println("{move1} {move2} {move3}");
 
-      dyn fn win1() {
+      let fn win1() {
         outcome1.send1(Win);
         outcome2.send1(Loss);
         outcome3.send1(Loss);
         winner.send1(First);
       }
 
-      dyn fn win2() {
+      let fn win2() {
         outcome1.send1(Loss);
         outcome2.send1(Win);
         outcome3.send1(Loss);
         winner.send1(Second);
       }
 
-      dyn fn win3() {
+      let fn win3() {
         outcome1.send1(Loss);
         outcome2.send1(Loss);
         outcome3.send1(Win);
         winner.send1(Third);
       }
 
-      dyn fn draw() {
+      let fn draw() {
         player1 = outcome1.choose[_, _, Player](fn(x) { Draw(x) });
         player2 = outcome2.choose[_, _, Player](fn(x) { Draw(x) });
         player3 = outcome3.choose[_, _, Player](fn(x) { Draw(x) });
@@ -142,7 +142,7 @@ fn start_playing(&io: &IO) -> Game {
 }
 
 fn random_player(&rng: &Pcg32) -> Player {
-  dyn fn random_move() {
+  let fn random_move() {
     if rng.gen_n32() & 1 == 0 {
       Move::Up
     } else {

--- a/vine/examples/guessing_game.vi
+++ b/vine/examples/guessing_game.vi
@@ -5,7 +5,7 @@ pub fn main(&io: &IO) {
   let seed = io.prompt("Enter a seed: ").unwrap();
   let rng = Pcg32::seeded(seed);
 
-  dyn fn prompt_num(msg: String) -> N32 {
+  let fn prompt_num(msg: String) -> N32 {
     loop {
       if io.prompt(msg) is Some(input) && N32::parse(input) is Some(n) {
         return n;

--- a/vine/src/ast.rs
+++ b/vine/src/ast.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 
 new_idx!(pub Local; n => ["l{n}"]);
-new_idx!(pub DynFnId; n => ["f{n}"]);
+new_idx!(pub LetFnId; n => ["f{n}"]);
 
 #[derive(Clone, Default)]
 pub struct Item<'core> {
@@ -204,7 +204,7 @@ pub struct Stmt<'core> {
 #[derive(Debug, Clone)]
 pub enum StmtKind<'core> {
   Let(LetStmt<'core>),
-  DynFn(DynFnStmt<'core>),
+  LetFn(LetFnStmt<'core>),
   Expr(Expr<'core>, bool),
   Item(Item<'core>),
   Empty,
@@ -218,9 +218,9 @@ pub struct LetStmt<'core> {
 }
 
 #[derive(Debug, Clone)]
-pub struct DynFnStmt<'core> {
+pub struct LetFnStmt<'core> {
   pub name: Ident<'core>,
-  pub id: Option<DynFnId>,
+  pub id: Option<LetFnId>,
   pub params: Vec<Pat<'core>>,
   pub ret: Option<Ty<'core>>,
   pub body: Block<'core>,
@@ -248,7 +248,7 @@ pub enum ExprKind<'core> {
   #[class(place, resolved)]
   Local(Local),
   #[class(value, resolved)]
-  DynFn(DynFnId),
+  LetFn(LetFnId),
   #[class(value)]
   Do(Label<'core>, Block<'core>),
   #[class(value)]

--- a/vine/src/checker/check_expr.rs
+++ b/vine/src/checker/check_expr.rs
@@ -249,7 +249,7 @@ impl<'core> Checker<'core, '_> {
     let span = expr.span;
     match &mut expr.kind {
       ExprKind![error || place || space || synthetic] | ExprKind::Path(..) => unreachable!(),
-      ExprKind::DynFn(x) => self.dyn_fns[x],
+      ExprKind::LetFn(x) => self.let_fns[x],
       ExprKind::Def(id, args) => {
         let type_params = self.check_generics(args, self.chart.values[*id].generics, true);
         self.types.import(&self.sigs.values[*id], Some(&type_params), |t, sig| t.transfer(sig.ty))

--- a/vine/src/distiller/control_flow.rs
+++ b/vine/src/distiller/control_flow.rs
@@ -3,7 +3,7 @@ use crate::{
   vir::{Interface, InterfaceKind, Layer, Port, Stage, Step, Transfer},
 };
 
-use super::{pattern_matching::Row, Distiller, DynFn, Label, Return};
+use super::{pattern_matching::Row, Distiller, Label, LetFn, Return};
 
 impl<'core, 'r> Distiller<'core, 'r> {
   pub fn distill_block(&mut self, stage: &mut Stage, block: &Block<'core>) -> Port {
@@ -53,13 +53,13 @@ impl<'core, 'r> Distiller<'core, 'r> {
             stage.steps.push(Step::Link(pat, value));
           }
         }
-        StmtKind::DynFn(dyn_fn) => {
+        StmtKind::LetFn(let_fn) => {
           let local = self.new_local(stage);
           stage.erase_local(local);
           let (layer, mut stage) = self.root_layer();
-          *self.dyn_fns.get_or_extend(dyn_fn.id.unwrap()) =
-            Some(DynFn { interface: stage.interface, local });
-          self._distill_fn(&mut stage, local, &dyn_fn.params, &dyn_fn.body);
+          *self.let_fns.get_or_extend(let_fn.id.unwrap()) =
+            Some(LetFn { interface: stage.interface, local });
+          self._distill_fn(&mut stage, local, &let_fn.params, &let_fn.body);
           self.finish_stage(stage);
           self.finish_layer(layer);
         }

--- a/vine/src/fmt.rs
+++ b/vine/src/fmt.rs
@@ -247,8 +247,8 @@ impl<'core: 'src, 'src> Formatter<'src> {
         },
         Doc(";"),
       ]),
-      StmtKind::DynFn(d) => Doc::concat([
-        Doc("dyn fn "),
+      StmtKind::LetFn(d) => Doc::concat([
+        Doc("let fn "),
         Doc(d.name),
         Doc::paren_comma(d.params.iter().map(|p| self.fmt_pat(p))),
         self.fmt_return_ty(d.ret.as_ref()),

--- a/vine/src/visit.rs
+++ b/vine/src/visit.rs
@@ -51,7 +51,7 @@ pub trait VisitMut<'core, 'a> {
     match &mut expr.kind {
       ExprKind::Hole
       | ExprKind::Local(_)
-      | ExprKind::DynFn(_)
+      | ExprKind::LetFn(_)
       | ExprKind::Bool(_)
       | ExprKind::N32(_)
       | ExprKind::I32(_)
@@ -273,7 +273,7 @@ pub trait VisitMut<'core, 'a> {
         }
         self.visit_pat(&mut l.bind);
       }
-      StmtKind::DynFn(d) => {
+      StmtKind::LetFn(d) => {
         self.enter_scope();
         for p in &mut d.params {
           self.visit_pat(p);


### PR DESCRIPTION
Originally when I named `dyn fn` I imagined that would also be the name for the equivalent of `FnMut`. But it's clear now with fork/drop imminent that that is not the path forward, and so I think `let fn` is better – as it is really nothing more than a local function declaration, like a merging of the `let` statement and the `fn` expression.