### PR TITLE
vine: add `Fork` and `Drop` traits [fork/drop]

### DIFF
--- a/tests/programs/aoc_2024/day_04.vi
+++ b/tests/programs/aoc_2024/day_04.vi
@@ -121,7 +121,7 @@ fn diamond[T, M, X](grid: List[List[T]], f: fn(T, Neighbors[M], &X), d: M, state
       let north = north.iter();
       let north_west = north_west.iter();
       let ~north_east = north_east.iter();
-      (~north_east).drop()
+      (~north_east).drop_iter()
       while row.pop_front() is Some(cell) {
         let (w, e) = foo_channel(&west);
         let (n, s) = foo_channel(north.next().unwrap());
@@ -129,8 +129,8 @@ fn diamond[T, M, X](grid: List[List[T]], f: fn(T, Neighbors[M], &X), d: M, state
         let (ne, sw) = foo_channel((~north_east).next().unwrap());
         f(cell, Neighbors(nw, n, ne, w, e, sw, s, se), &state);
       }
-      north.drop()
-      north_west.drop()
+      north.drop_iter()
+      north_west.drop_iter()
     }
     west.send(d);
     north_west.pop_front().unwrap().send(d);

--- a/tests/programs/aoc_2024/day_05.vi
+++ b/tests/programs/aoc_2024/day_05.vi
@@ -23,7 +23,7 @@ pub fn main(&io: &IO) {
       good &= !get_bit(mask, num);
       mask |= *masks.get(num);
     }
-    iter.drop();
+    iter.drop_iter();
     if good {
       part1 += middle;
     } else {

--- a/tests/programs/aoc_2024/day_09.vi
+++ b/tests/programs/aoc_2024/day_09.vi
@@ -86,7 +86,7 @@ fn part2(input: String) -> N64 {
         break;
       }
     }
-    iter.drop();
+    iter.drop_iter();
     let end = pos + len;
     sum = sum + N64::mul_n32_n32(id, ((end - 1) * end - (pos - 1) * pos) / 2);
   }

--- a/tests/programs/aoc_2024/day_10.vi
+++ b/tests/programs/aoc_2024/day_10.vi
@@ -147,7 +147,7 @@ fn cross[T, M, X](grid: List[List[T]], f: fn(T, Neighbors[M], &X), d: M, &state:
         let (n, s) = foo_channel(north.next().unwrap());
         f(cell, Neighbors(n, s, e, w), &state);
       }
-      north.drop()
+      north.drop_iter()
     }
     west.send(d);
   }

--- a/tests/programs/aoc_2024/day_15.vi
+++ b/tests/programs/aoc_2024/day_15.vi
@@ -16,7 +16,7 @@ pub fn main(&io: &IO) {
       };
       x += 1;
     }
-    iter.drop();
+    iter.drop_iter();
     grid.push_back(line as List as Array);
     y += 1;
   }

--- a/tests/programs/repl/misc.vi
+++ b/tests/programs/repl/misc.vi
@@ -62,3 +62,6 @@ Ok(true)?
 fn foo() -> N32 { Ok(123)? }
 fn foo() -> Result[N32, String] { Ok(123)? }
 fn foo() -> Result[N32, String] { Err(123)? }
+let x = (1, 2.0, [Some(Ok(true)), Some(Err("hi")), None], ((), ((),), ((), ())));
+x.fork()
+x.drop(); let x;

--- a/tests/snaps/vine/repl/misc.repl.vi
+++ b/tests/snaps/vine/repl/misc.repl.vi
@@ -265,3 +265,15 @@ io = #io
 error input:1:35 - cannot try `Result[?5, N32]` in a function returning `Result[N32, String]`
 
 io = #io
+> let x = (1, 2.0, [Some(Ok(true)), Some(Err("hi")), None], ((), ((),), ((), ())));
+
+io = #io
+x = (1, 2.0, [Some(Ok(true)), Some(Err("hi")), None], ((), ((),), ((), ())))
+> x.fork()
+(1, 2.0, [Some(Ok(true)), Some(Err("hi")), None], ((), ((),), ((), ())))
+
+io = #io
+x = (1, 2.0, [Some(Ok(true)), Some(Err("hi")), None], ((), ((),), ((), ())))
+> x.drop(); let x;
+
+io = #io

--- a/vine/src/ast.rs
+++ b/vine/src/ast.rs
@@ -174,7 +174,7 @@ pub enum Builtin {
   Cast,
 }
 
-pub type GenericParams<'core> = Generics<Ident<'core>, (Option<Ident<'core>>, Trait<'core>)>;
+pub type GenericParams<'core> = Generics<TypeParam<'core>, ImplParam<'core>>;
 pub type GenericArgs<'core> = Generics<Ty<'core>, Impl<'core>>;
 
 #[derive(Debug, Clone)]
@@ -188,6 +188,19 @@ impl<T, I> Default for Generics<T, I> {
   fn default() -> Self {
     Self { span: Span::default(), types: Default::default(), impls: Default::default() }
   }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct TypeParam<'core> {
+  pub span: Span,
+  pub name: Ident<'core>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ImplParam<'core> {
+  pub span: Span,
+  pub name: Option<Ident<'core>>,
+  pub trait_: Trait<'core>,
 }
 
 #[derive(Default, Debug, Clone)]

--- a/vine/src/ast.rs
+++ b/vine/src/ast.rs
@@ -172,6 +172,8 @@ pub enum Builtin {
   BoolNot,
   ComparisonOp(ComparisonOp),
   Cast,
+  Fork,
+  Drop,
 }
 
 pub type GenericParams<'core> = Generics<TypeParam<'core>, ImplParam<'core>>;
@@ -194,6 +196,7 @@ impl<T, I> Default for Generics<T, I> {
 pub struct TypeParam<'core> {
   pub span: Span,
   pub name: Ident<'core>,
+  pub flex: Flex,
 }
 
 #[derive(Debug, Clone)]
@@ -201,6 +204,24 @@ pub struct ImplParam<'core> {
   pub span: Span,
   pub name: Option<Ident<'core>>,
   pub trait_: Trait<'core>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum Flex {
+  None,
+  Fork,
+  Drop,
+  Full,
+}
+
+impl Flex {
+  pub fn fork(self) -> bool {
+    matches!(self, Flex::Fork | Flex::Full)
+  }
+
+  pub fn drop(self) -> bool {
+    matches!(self, Flex::Drop | Flex::Full)
+  }
 }
 
 #[derive(Default, Debug, Clone)]

--- a/vine/src/chart.rs
+++ b/vine/src/chart.rs
@@ -48,6 +48,9 @@ pub struct Builtins {
   pub cast: Option<ValueDefId>,
   pub binary_ops: IntMap<BinaryOp, Option<ValueDefId>>,
   pub comparison_ops: IntMap<ComparisonOp, Option<ValueDefId>>,
+
+  pub fork: Option<TraitDefId>,
+  pub drop: Option<TraitDefId>,
 }
 
 new_idx!(pub DefId);

--- a/vine/src/chart.rs
+++ b/vine/src/chart.rs
@@ -6,7 +6,9 @@ use vine_util::{
 };
 
 use crate::{
-  ast::{BinaryOp, Block, ComparisonOp, Expr, Ident, Local, Pat, Span, Trait, Ty},
+  ast::{
+    BinaryOp, Block, ComparisonOp, Expr, Ident, ImplParam, Local, Pat, Span, Trait, Ty, TypeParam,
+  },
   diag::ErrorGuaranteed,
 };
 
@@ -243,8 +245,8 @@ pub struct ImplSubitem<'core> {
 pub struct GenericsDef<'core> {
   pub span: Span,
   pub def: DefId,
-  pub type_params: Vec<Ident<'core>>,
-  pub impl_params: Vec<(Option<Ident<'core>>, Trait<'core>)>,
+  pub type_params: Vec<TypeParam<'core>>,
+  pub impl_params: Vec<ImplParam<'core>>,
 }
 
 #[derive(Debug)]

--- a/vine/src/charter.rs
+++ b/vine/src/charter.rs
@@ -4,8 +4,8 @@ use vine_util::idx::Counter;
 
 use crate::{
   ast::{
-    Attr, AttrKind, Builtin, GenericParams, Generics, Ident, Item, ItemKind, ModKind, Span, Trait,
-    TraitKind, Ty, TyKind, UseTree, Vis,
+    Attr, AttrKind, Builtin, GenericParams, Generics, Ident, ImplParam, Item, ItemKind, ModKind,
+    Span, Trait, TraitKind, Ty, TyKind, UseTree, Vis,
   },
   chart::{Chart, TraitSubitem},
   core::Core,
@@ -156,9 +156,10 @@ impl<'core> Charter<'core, '_> {
             span: generics.span,
             def,
             type_params: generics.type_params.clone(),
-            impl_params: vec![(
-              None,
-              Trait {
+            impl_params: vec![ImplParam {
+              span: Span::NONE,
+              name: None,
+              trait_: Trait {
                 span: Span::NONE,
                 kind: TraitKind::Def(
                   trait_id,
@@ -171,7 +172,7 @@ impl<'core> Charter<'core, '_> {
                   },
                 ),
               },
-            )],
+            }],
           })
         };
         let subitems = trait_item

--- a/vine/src/charter.rs
+++ b/vine/src/charter.rs
@@ -348,6 +348,8 @@ impl<'core> Charter<'core, '_> {
       Builtin::Not => set(def.value_def, &mut self.chart.builtins.not),
       Builtin::BoolNot => set(def.impl_def, &mut self.chart.builtins.bool_not),
       Builtin::Cast => set(def.value_def, &mut self.chart.builtins.cast),
+      Builtin::Fork => set(def.trait_def, &mut self.chart.builtins.fork),
+      Builtin::Drop => set(def.trait_def, &mut self.chart.builtins.drop),
       Builtin::BinaryOp(op) => {
         set(def.value_def, self.chart.builtins.binary_ops.entry(op).or_default())
       }

--- a/vine/src/checker.rs
+++ b/vine/src/checker.rs
@@ -264,7 +264,7 @@ impl<'core, 'a> Checker<'core, 'a> {
         )
       }
       TyKind::Param(index) => {
-        let name = self.chart.generics[self.cur_generics].type_params[*index];
+        let name = self.chart.generics[self.cur_generics].type_params[*index].name;
         self.types.new(TypeKind::Param(*index, name))
       }
       TyKind::Error(e) => self.types.error(*e),
@@ -423,7 +423,8 @@ impl<'core, 'a> Checker<'core, 'a> {
     let GenericsDef { def, ref mut impl_params, .. } = self.chart.generics[generics_id];
     let mut impl_params = take(impl_params);
     self.initialize(def, generics_id);
-    let impl_param_types = impl_params.iter_mut().map(|(_, t)| self.assess_trait(t)).collect();
+    let impl_param_types =
+      impl_params.iter_mut().map(|p| self.assess_trait(&mut p.trait_)).collect();
     self.sigs.generics.push(TypeCtx {
       types: take(&mut self.types),
       inner: GenericsSig { impl_params: impl_param_types },
@@ -627,7 +628,7 @@ impl<'core, 'a> Checker<'core, 'a> {
       .type_params
       .iter()
       .enumerate()
-      .map(|(i, name)| self.types.new(TypeKind::Param(i, *name)))
+      .map(|(i, p)| self.types.new(TypeKind::Param(i, p.name)))
       .collect::<Vec<_>>()
   }
 }

--- a/vine/src/finder.rs
+++ b/vine/src/finder.rs
@@ -94,9 +94,7 @@ impl<'core, 'a> Finder<'core, 'a> {
       },
     };
 
-    for &ancestor in &self.chart.defs[self.source].ancestors {
-      self.find_candidates_within(ancestor, search);
-    }
+    self.find_general_candidates(search);
 
     if let Some(def_id) = types.get_mod(self.chart, receiver) {
       self.find_candidates_within(def_id, search);
@@ -224,9 +222,7 @@ impl<'core, 'a> Finder<'core, 'a> {
       },
     };
 
-    for &ancestor in &self.chart.defs[self.source].ancestors {
-      self.find_candidates_within(ancestor, search);
-    }
+    self.find_general_candidates(search);
 
     if let ImplType::Trait(trait_id, params) = query {
       self.find_candidates_within(self.chart.traits[*trait_id].def, search);
@@ -238,6 +234,15 @@ impl<'core, 'a> Finder<'core, 'a> {
     }
 
     candidates
+  }
+
+  fn find_general_candidates(&mut self, search: &mut CandidateSearch<impl FnMut(&Def<'_>)>) {
+    for &ancestor in &self.chart.defs[self.source].ancestors {
+      self.find_candidates_within(ancestor, search);
+    }
+    if let Some(prelude) = self.chart.builtins.prelude {
+      self.find_candidates_within(prelude, search);
+    }
   }
 
   fn find_candidates_within<F: FnMut(&Def)>(

--- a/vine/src/fmt.rs
+++ b/vine/src/fmt.rs
@@ -4,7 +4,7 @@ use doc::{Doc, Writer};
 
 use crate::{
   ast::{
-    Block, ComparisonOp, Expr, ExprKind, GenericArgs, GenericParams, Generics, Ident, Impl,
+    Block, ComparisonOp, Expr, ExprKind, Flex, GenericArgs, GenericParams, Generics, Ident, Impl,
     ImplKind, ImplParam, Item, ItemKind, Label, LogicalOp, ModKind, Pat, PatKind, Path, Span, Stmt,
     StmtKind, Trait, TraitKind, Ty, TyKind, TypeParam, UseTree, Vis,
   },
@@ -291,7 +291,7 @@ impl<'core: 'src, 'src> Formatter<'src> {
   }
 
   fn fmt_type_param(&self, param: &TypeParam<'core>) -> Doc<'src> {
-    Doc(param.name)
+    Doc::concat([Doc(param.name), self.fmt_flex(param.flex)])
   }
 
   fn fmt_impl_param(&self, param: &ImplParam<'core>) -> Doc<'src> {
@@ -299,6 +299,15 @@ impl<'core: 'src, 'src> Formatter<'src> {
       Some(name) => Doc::concat([Doc(name), Doc(": "), self.fmt_trait(&param.trait_)]),
       None => self.fmt_trait(&param.trait_),
     }
+  }
+
+  fn fmt_flex(&self, flex: Flex) -> Doc<'src> {
+    Doc(match flex {
+      Flex::None => "",
+      Flex::Fork => "+",
+      Flex::Drop => "?",
+      Flex::Full => "*",
+    })
   }
 
   fn fmt_generic_args(&self, generics: &GenericArgs<'core>) -> Doc<'src> {

--- a/vine/src/fmt.rs
+++ b/vine/src/fmt.rs
@@ -5,8 +5,8 @@ use doc::{Doc, Writer};
 use crate::{
   ast::{
     Block, ComparisonOp, Expr, ExprKind, GenericArgs, GenericParams, Generics, Ident, Impl,
-    ImplKind, Item, ItemKind, Label, LogicalOp, ModKind, Pat, PatKind, Path, Span, Stmt, StmtKind,
-    Trait, TraitKind, Ty, TyKind, UseTree, Vis,
+    ImplKind, ImplParam, Item, ItemKind, Label, LogicalOp, ModKind, Pat, PatKind, Path, Span, Stmt,
+    StmtKind, Trait, TraitKind, Ty, TyKind, TypeParam, UseTree, Vis,
   },
   core::Core,
   diag::Diag,
@@ -287,14 +287,18 @@ impl<'core: 'src, 'src> Formatter<'src> {
   }
 
   fn fmt_generic_params(&self, generics: &GenericParams<'core>) -> Doc<'src> {
-    self.fmt_generics(
-      generics,
-      |i| Doc(*i),
-      |(i, t)| match i {
-        Some(i) => Doc::concat([Doc(*i), Doc(": "), self.fmt_trait(t)]),
-        None => self.fmt_trait(t),
-      },
-    )
+    self.fmt_generics(generics, |p| self.fmt_type_param(p), |p| self.fmt_impl_param(p))
+  }
+
+  fn fmt_type_param(&self, param: &TypeParam<'core>) -> Doc<'src> {
+    Doc(param.name)
+  }
+
+  fn fmt_impl_param(&self, param: &ImplParam<'core>) -> Doc<'src> {
+    match param.name {
+      Some(name) => Doc::concat([Doc(name), Doc(": "), self.fmt_trait(&param.trait_)]),
+      None => self.fmt_trait(&param.trait_),
+    }
   }
 
   fn fmt_generic_args(&self, generics: &GenericArgs<'core>) -> Doc<'src> {

--- a/vine/src/parser.rs
+++ b/vine/src/parser.rs
@@ -9,9 +9,9 @@ use crate::{core::Core, diag::Diag, lexer::Token};
 
 use crate::ast::{
   Attr, AttrKind, BinaryOp, Block, Builtin, ComparisonOp, ConstItem, EnumItem, Expr, ExprKind,
-  FnItem, GenericArgs, GenericParams, Generics, Ident, Impl, ImplItem, ImplKind, ImplParam, Item,
-  ItemKind, Key, Label, LetFnStmt, LetStmt, LogicalOp, ModItem, ModKind, Pat, PatKind, Path, Span,
-  Stmt, StmtKind, StructItem, Trait, TraitItem, TraitKind, Ty, TyKind, TypeItem, TypeParam,
+  Flex, FnItem, GenericArgs, GenericParams, Generics, Ident, Impl, ImplItem, ImplKind, ImplParam,
+  Item, ItemKind, Key, Label, LetFnStmt, LetStmt, LogicalOp, ModItem, ModKind, Pat, PatKind, Path,
+  Span, Stmt, StmtKind, StructItem, Trait, TraitItem, TraitKind, Ty, TyKind, TypeItem, TypeParam,
   UseItem, UseTree, Variant, Vis,
 };
 
@@ -148,6 +148,8 @@ impl<'core, 'src> VineParser<'core, 'src> {
           "gt" => Builtin::ComparisonOp(ComparisonOp::Gt),
           "le" => Builtin::ComparisonOp(ComparisonOp::Le),
           "ge" => Builtin::ComparisonOp(ComparisonOp::Ge),
+          "Fork" => Builtin::Fork,
+          "Drop" => Builtin::Drop,
           _ => Err(Diag::BadBuiltin { span: str_span })?,
         };
         AttrKind::Builtin(builtin)
@@ -255,8 +257,9 @@ impl<'core, 'src> VineParser<'core, 'src> {
   fn parse_type_param(&mut self) -> Parse<'core, TypeParam<'core>> {
     let span = self.start_span();
     let name = self.parse_ident()?;
+    let flex = self.parse_flex()?;
     let span = self.end_span(span);
-    Ok(TypeParam { span, name })
+    Ok(TypeParam { span, name, flex })
   }
 
   fn parse_impl_param(&mut self) -> Parse<'core, ImplParam<'core>> {
@@ -274,6 +277,18 @@ impl<'core, 'src> VineParser<'core, 'src> {
     };
     let span = self.end_span(span);
     Ok(ImplParam { span, name, trait_ })
+  }
+
+  fn parse_flex(&mut self) -> Parse<'core, Flex> {
+    if self.eat(Token::Plus)? {
+      Ok(Flex::Fork)
+    } else if self.eat(Token::Question)? {
+      Ok(Flex::Drop)
+    } else if self.eat(Token::Star)? {
+      Ok(Flex::Full)
+    } else {
+      Ok(Flex::None)
+    }
   }
 
   fn parse_generic_args(&mut self) -> Parse<'core, GenericArgs<'core>> {

--- a/vine/src/parser.rs
+++ b/vine/src/parser.rs
@@ -9,10 +9,10 @@ use crate::{core::Core, diag::Diag, lexer::Token};
 
 use crate::ast::{
   Attr, AttrKind, BinaryOp, Block, Builtin, ComparisonOp, ConstItem, EnumItem, Expr, ExprKind,
-  FnItem, GenericArgs, GenericParams, Generics, Ident, Impl, ImplItem, ImplKind, Item, ItemKind,
-  Key, Label, LetFnStmt, LetStmt, LogicalOp, ModItem, ModKind, Pat, PatKind, Path, Span, Stmt,
-  StmtKind, StructItem, Trait, TraitItem, TraitKind, Ty, TyKind, TypeItem, UseItem, UseTree,
-  Variant, Vis,
+  FnItem, GenericArgs, GenericParams, Generics, Ident, Impl, ImplItem, ImplKind, ImplParam, Item,
+  ItemKind, Key, Label, LetFnStmt, LetStmt, LogicalOp, ModItem, ModKind, Pat, PatKind, Path, Span,
+  Stmt, StmtKind, StructItem, Trait, TraitItem, TraitKind, Ty, TyKind, TypeItem, TypeParam,
+  UseItem, UseTree, Variant, Vis,
 };
 
 pub struct VineParser<'core, 'src> {
@@ -249,19 +249,31 @@ impl<'core, 'src> VineParser<'core, 'src> {
   }
 
   fn parse_generic_params(&mut self) -> Parse<'core, GenericParams<'core>> {
-    self.parse_generics(Self::parse_ident, |self_| {
-      if self_.check(Token::Ident) {
-        let path = self_.parse_path()?;
-        if path.as_ident().is_some() && self_.eat(Token::Colon)? {
-          let trait_ = self_.parse_trait()?;
-          Ok((path.as_ident(), trait_))
-        } else {
-          Ok((None, Trait { span: path.span, kind: TraitKind::Path(path) }))
-        }
+    self.parse_generics(Self::parse_type_param, Self::parse_impl_param)
+  }
+
+  fn parse_type_param(&mut self) -> Parse<'core, TypeParam<'core>> {
+    let span = self.start_span();
+    let name = self.parse_ident()?;
+    let span = self.end_span(span);
+    Ok(TypeParam { span, name })
+  }
+
+  fn parse_impl_param(&mut self) -> Parse<'core, ImplParam<'core>> {
+    let span = self.start_span();
+    let (name, trait_) = if self.check(Token::Ident) {
+      let path = self.parse_path()?;
+      if path.as_ident().is_some() && self.eat(Token::Colon)? {
+        let trait_ = self.parse_trait()?;
+        (path.as_ident(), trait_)
       } else {
-        Ok((None, self_.parse_trait()?))
+        (None, Trait { span: path.span, kind: TraitKind::Path(path) })
       }
-    })
+    } else {
+      (None, self.parse_trait()?)
+    };
+    let span = self.end_span(span);
+    Ok(ImplParam { span, name, trait_ })
   }
 
   fn parse_generic_args(&mut self) -> Parse<'core, GenericArgs<'core>> {

--- a/vine/src/resolver.rs
+++ b/vine/src/resolver.rs
@@ -210,10 +210,11 @@ impl<'core> ResolveVisitor<'core, '_, '_> {
       if self.type_params.len() != generics.type_params.len() {
         self.resolver.core.report(Diag::DuplicateTypeParam { span: generics.span });
       }
-      if self.impl_params.len() != generics.impl_params.iter().filter(|x| x.0.is_some()).count() {
+      if self.impl_params.len() != generics.impl_params.iter().filter(|x| x.name.is_some()).count()
+      {
         self.resolver.core.report(Diag::DuplicateImplParam { span: generics.span });
       }
-      self.visit(generics.impl_params.iter_mut().map(|(_, t)| t));
+      self.visit(generics.impl_params.iter_mut().map(|p| &mut p.trait_));
       self.resolver.chart.generics[id] = generics;
     }
 
@@ -235,10 +236,10 @@ impl<'core> ResolveVisitor<'core, '_, '_> {
 
     self.def = def;
     let generics = &self.resolver.chart.generics[generics];
-    self.type_params.extend(generics.type_params.iter().enumerate().map(|(i, &p)| (p, i)));
+    self.type_params.extend(generics.type_params.iter().enumerate().map(|(i, &p)| (p.name, i)));
     self
       .impl_params
-      .extend(generics.impl_params.iter().enumerate().filter_map(|(i, &(p, _))| Some((p?, i))));
+      .extend(generics.impl_params.iter().enumerate().filter_map(|(i, p)| Some((p.name?, i))));
   }
 }
 

--- a/vine/src/specializer.rs
+++ b/vine/src/specializer.rs
@@ -33,7 +33,13 @@ impl<'core, 'a> Specializer<'core, 'a> {
     for value_id in self.chart.values.keys_from(checkpoint.values) {
       let value_def = &mut self.chart.values[value_id];
       let def_info = {
-        let impl_params = self.chart.generics[value_def.generics].impl_params.len();
+        let generics = &self.chart.generics[value_def.generics];
+        let impl_params = generics
+          .type_params
+          .iter()
+          .map(|p| p.flex.fork() as usize + p.flex.drop() as usize)
+          .sum::<usize>()
+          + generics.impl_params.len();
         let mut kind = take(&mut value_def.kind);
         let mut extractor = RelExtractor { rels: IdxVec::new(), chart: self.chart };
         match &mut kind {

--- a/vine/src/visit.rs
+++ b/vine/src/visit.rs
@@ -344,8 +344,7 @@ pub trait VisitMut<'core, 'a> {
   }
 
   fn _visit_generic_params(&mut self, generics: &'a mut GenericParams<'core>) {
-    let x = generics.impls.iter_mut().map(|x| &mut x.1);
-    self.visit(x);
+    self.visit(generics.impls.iter_mut().map(|x| &mut x.trait_));
   }
 
   fn _visit_generic_args(&mut self, generics: &'a mut GenericArgs<'core>) {

--- a/vine/std/data/Array.vi
+++ b/vine/std/data/Array.vi
@@ -193,6 +193,26 @@ pub mod Array {
     self.reverse();
     self
   }
+
+  pub impl fork[T; Fork[T]]: Fork[Array[T]] {
+    fn .fork(&Array[T](len, node)) -> Array[T] {
+      if len == 0 {
+        Array::empty
+      } else {
+        Array(len, Node::fork[T](len, &node))
+      }
+    }
+  }
+
+  pub impl drop[T; Drop[T]]: Drop[Array[T]] {
+    fn .drop(Array[T](len, node)) {
+      if len == 0 {
+        Drop::erase(node)
+      } else {
+        Node::drop[T](len, node)
+      }
+    }
+  }
 }
 
 struct Node[T]((Node[T], Node[T]));
@@ -262,6 +282,25 @@ mod Node {
       let (lx, ly) = unzip_with((len + 1) / 2, l, f);
       let (rx, ry) = unzip_with(len / 2, r, f);
       (Node(lx, rx), Node(ly, ry))
+    }
+  }
+
+  pub fn fork[T; Fork[T]](len: N32, &node: &Node[T]) -> Node[T] {
+    if len == 1 {
+      (&node).as[&T].*.fork().as[Node[T]]
+    } else {
+      let &Node(l, r) = &node;
+      Node(fork[T]((len + 1) / 2, &l), fork[T](len / 2, &r))
+    }
+  }
+
+  pub fn drop[T; Drop[T]](len: N32, node: Node[T]) {
+    if len == 1 {
+      node.as[T].drop();
+    } else {
+      let &Node(l, r) = &node;
+      drop[T]((len + 1) / 2, l);
+      drop[T](len / 2, r);
     }
   }
 }

--- a/vine/std/data/Array.vi
+++ b/vine/std/data/Array.vi
@@ -194,7 +194,7 @@ pub mod Array {
     self
   }
 
-  pub impl fork[T; Fork[T]]: Fork[Array[T]] {
+  pub impl fork[T+]: Fork[Array[T]] {
     fn .fork(&Array[T](len, node)) -> Array[T] {
       if len == 0 {
         Array::empty
@@ -204,7 +204,7 @@ pub mod Array {
     }
   }
 
-  pub impl drop[T; Drop[T]]: Drop[Array[T]] {
+  pub impl drop[T?]: Drop[Array[T]] {
     fn .drop(Array[T](len, node)) {
       if len == 0 {
         Drop::erase(node)
@@ -285,7 +285,7 @@ mod Node {
     }
   }
 
-  pub fn fork[T; Fork[T]](len: N32, &node: &Node[T]) -> Node[T] {
+  pub fn fork[T+](len: N32, &node: &Node[T]) -> Node[T] {
     if len == 1 {
       (&node).as[&T].*.fork().as[Node[T]]
     } else {
@@ -294,7 +294,7 @@ mod Node {
     }
   }
 
-  pub fn drop[T; Drop[T]](len: N32, node: Node[T]) {
+  pub fn drop[T?](len: N32, node: Node[T]) {
     if len == 1 {
       node.as[T].drop();
     } else {

--- a/vine/std/data/Iterator.vi
+++ b/vine/std/data/Iterator.vi
@@ -2,5 +2,5 @@
 pub trait Iterator[T, Item] {
   fn .next(self: &T) -> Option[Item];
 
-  fn .drop(self: &T);
+  fn .drop_iter(self: &T);
 }

--- a/vine/std/data/List.vi
+++ b/vine/std/data/List.vi
@@ -249,4 +249,24 @@ pub mod List {
     const lt: fn(&List[T], &List[T]) -> Bool = Ord::lt_from_cmp[List[T]];
     const le: fn(&List[T], &List[T]) -> Bool = Ord::le_from_cmp[List[T]];
   }
+
+  pub impl fork[T; Fork[T]]: Fork[List[T]] {
+    fn .fork(&self: &List[T]) -> List[T] {
+      let iter = self.iter();
+      let out = [];
+      while iter.next() is Some(&value) {
+        out.push_back(value.fork());
+      }
+      out
+    }
+  }
+
+  pub impl drop[T; Drop[T]]: Drop[List[T]] {
+    fn .drop(self: List[T]) {
+      let iter = self.into_iter();
+      while iter.next() is Some(value) {
+        value.drop();
+      }
+    }
+  }
 }

--- a/vine/std/data/List.vi
+++ b/vine/std/data/List.vi
@@ -160,7 +160,7 @@ pub mod List {
         }
       }
 
-      fn .drop(&iter: &Iter[T]) {
+      fn .drop_iter(&iter: &Iter[T]) {
         let Iter(_, &_) = move iter;
       }
     }
@@ -185,7 +185,7 @@ pub mod List {
         }
       }
 
-      fn .drop(iter: &IntoIter[T]) {}
+      fn .drop_iter(iter: &IntoIter[T]) {}
     }
   }
 
@@ -210,8 +210,8 @@ pub mod List {
       let b_iter = b.iter();
       while a_iter.next() is Some(&a_elem) && b_iter.next() is Some(&b_elem) {
         if a_elem != b_elem {
-          a_iter.drop();
-          b_iter.drop();
+          a_iter.drop_iter();
+          b_iter.drop_iter();
           return false;
         }
       }
@@ -241,8 +241,8 @@ pub mod List {
           }
         }
       };
-      a.drop();
-      b.drop();
+      a.drop_iter();
+      b.drop_iter();
       ord
     }
 

--- a/vine/std/data/List.vi
+++ b/vine/std/data/List.vi
@@ -250,7 +250,7 @@ pub mod List {
     const le: fn(&List[T], &List[T]) -> Bool = Ord::le_from_cmp[List[T]];
   }
 
-  pub impl fork[T; Fork[T]]: Fork[List[T]] {
+  pub impl fork[T+]: Fork[List[T]] {
     fn .fork(&self: &List[T]) -> List[T] {
       let iter = self.iter();
       let out = [];
@@ -261,7 +261,7 @@ pub mod List {
     }
   }
 
-  pub impl drop[T; Drop[T]]: Drop[List[T]] {
+  pub impl drop[T?]: Drop[List[T]] {
     fn .drop(self: List[T]) {
       let iter = self.into_iter();
       while iter.next() is Some(value) {

--- a/vine/std/data/Map.vi
+++ b/vine/std/data/Map.vi
@@ -240,7 +240,7 @@ pub mod Map {
         }
       }
 
-      fn .drop(&iter: &Iter[K, V]) {
+      fn .drop_iter(&iter: &Iter[K, V]) {
         let Iter(&_, stack) = move iter;
         while stack.pop_front() is Some(&_) {}
       }
@@ -273,7 +273,7 @@ pub mod Map {
         }
       }
 
-      fn .drop(self: &IntoIter[K, V]) {}
+      fn .drop_iter(self: &IntoIter[K, V]) {}
     }
   }
 

--- a/vine/std/data/Map.vi
+++ b/vine/std/data/Map.vi
@@ -317,6 +317,26 @@ pub mod Map {
       x && left.balanced() && right.balanced()
     }
   }
+
+  pub impl fork[K, V; Fork[K], Fork[V]]: Fork[Map[K, V]] {
+    fn .fork(&Map[K, V](len, data)) -> Map[K, V] {
+      if len == 0 {
+        Map::empty
+      } else {
+        Map(len, data.fork())
+      }
+    }
+  }
+
+  pub impl drop[K, V; Drop[K], Drop[V]]: Drop[Map[K, V]] {
+    fn .drop(Map[K, V](len, data)) {
+      if len == 0 {
+        Drop::erase(data);
+      } else {
+        data.drop();
+      }
+    }
+  }
 }
 
 fn balance_left[K, V](&data: &MapData[K, V]) {

--- a/vine/std/data/Map.vi
+++ b/vine/std/data/Map.vi
@@ -318,7 +318,7 @@ pub mod Map {
     }
   }
 
-  pub impl fork[K, V; Fork[K], Fork[V]]: Fork[Map[K, V]] {
+  pub impl fork[K+, V+]: Fork[Map[K, V]] {
     fn .fork(&Map[K, V](len, data)) -> Map[K, V] {
       if len == 0 {
         Map::empty
@@ -328,7 +328,7 @@ pub mod Map {
     }
   }
 
-  pub impl drop[K, V; Drop[K], Drop[V]]: Drop[Map[K, V]] {
+  pub impl drop[K?, V?]: Drop[Map[K, V]] {
     fn .drop(Map[K, V](len, data)) {
       if len == 0 {
         Drop::erase(data);

--- a/vine/std/logical/Bool.vi
+++ b/vine/std/logical/Bool.vi
@@ -6,6 +6,18 @@ use debug::Show;
 pub type Bool;
 
 pub mod Bool {
+  pub impl fork: Fork[Bool] {
+    fn .fork(&self: &Bool) -> Bool {
+      Fork::copy(&self)
+    }
+  }
+
+  pub impl drop: Drop[Bool] {
+    fn .drop(self: Bool) {
+      Drop::erase(self)
+    }
+  }
+
   pub impl and: And[Bool, Bool, Bool] {
     fn .and(a: Bool, b: Bool) -> Bool {
       inline_ivy! (a <- a, b <- b) -> Bool { out a = @n32_and(b out) }

--- a/vine/std/logical/Option.vi
+++ b/vine/std/logical/Option.vi
@@ -61,7 +61,7 @@ pub mod Option {
     }
   }
 
-  pub impl fork[T; Fork[T]]: Fork[Option[T]] {
+  pub impl fork[T+]: Fork[Option[T]] {
     fn .fork(&self: &Option[T]) -> Option[T] {
       match &self {
         &Some(value) { Some(value.fork()) }
@@ -70,7 +70,7 @@ pub mod Option {
     }
   }
 
-  pub impl drop[T; Drop[T]]: Drop[Option[T]] {
+  pub impl drop[T?]: Drop[Option[T]] {
     fn .drop(self: Option[T]) {
       match self {
         Some(value) { value.drop() }

--- a/vine/std/logical/Option.vi
+++ b/vine/std/logical/Option.vi
@@ -60,4 +60,22 @@ pub mod Option {
       }
     }
   }
+
+  pub impl fork[T; Fork[T]]: Fork[Option[T]] {
+    fn .fork(&self: &Option[T]) -> Option[T] {
+      match &self {
+        &Some(value) { Some(value.fork()) }
+        &None { None }
+      }
+    }
+  }
+
+  pub impl drop[T; Drop[T]]: Drop[Option[T]] {
+    fn .drop(self: Option[T]) {
+      match self {
+        Some(value) { value.drop() }
+        None {}
+      }
+    }
+  }
 }

--- a/vine/std/logical/Result.vi
+++ b/vine/std/logical/Result.vi
@@ -62,4 +62,22 @@ pub mod Result {
       }
     }
   }
+
+  pub impl fork[T, E; Fork[T], Fork[E]]: Fork[Result[T, E]] {
+    fn .fork(&self: &Result[T, E]) -> Result[T, E] {
+      match &self {
+        &Ok(value) { Ok(value.fork()) }
+        &Err(value) { Err(value.fork()) }
+      }
+    }
+  }
+
+  pub impl drop[T, E; Drop[T], Drop[E]]: Drop[Result[T, E]] {
+    fn .drop(self: Result[T, E]) {
+      match self {
+        Ok(value) { value.drop() }
+        Err(value) { value.drop() }
+      }
+    }
+  }
 }

--- a/vine/std/logical/Result.vi
+++ b/vine/std/logical/Result.vi
@@ -63,7 +63,7 @@ pub mod Result {
     }
   }
 
-  pub impl fork[T, E; Fork[T], Fork[E]]: Fork[Result[T, E]] {
+  pub impl fork[T+, E+]: Fork[Result[T, E]] {
     fn .fork(&self: &Result[T, E]) -> Result[T, E] {
       match &self {
         &Ok(value) { Ok(value.fork()) }
@@ -72,7 +72,7 @@ pub mod Result {
     }
   }
 
-  pub impl drop[T, E; Drop[T], Drop[E]]: Drop[Result[T, E]] {
+  pub impl drop[T?, E?]: Drop[Result[T, E]] {
     fn .drop(self: Result[T, E]) {
       match self {
         Ok(value) { value.drop() }

--- a/vine/std/numeric/F32.vi
+++ b/vine/std/numeric/F32.vi
@@ -10,6 +10,18 @@ pub mod F32 {
   pub const inf: F32 = inline_ivy! () -> F32 { +inf };
   pub const neg_inf: F32 = inline_ivy! () -> F32 { -inf };
 
+  pub impl fork: Fork[F32] {
+    fn .fork(&self: &F32) -> F32 {
+      Fork::copy(&self)
+    }
+  }
+
+  pub impl drop: Drop[F32] {
+    fn .drop(self: F32) {
+      Drop::erase(self)
+    }
+  }
+
   pub impl add: Add[F32, F32, F32] {
     fn .add(a: F32, b: F32) -> F32 {
       inline_ivy! (a <- a, b <- b) -> F32 { out a = @f32_add(b out) }

--- a/vine/std/numeric/I32.vi
+++ b/vine/std/numeric/I32.vi
@@ -14,6 +14,18 @@ pub mod I32 {
   pub const maximum: I32 = +0x7fffffff;
   pub const minimum: I32 = -0x7fffffff;
 
+  pub impl fork: Fork[I32] {
+    fn .fork(&self: &I32) -> I32 {
+      Fork::copy(&self)
+    }
+  }
+
+  pub impl drop: Drop[I32] {
+    fn .drop(self: I32) {
+      Drop::erase(self)
+    }
+  }
+
   pub impl add: Add[I32, I32, I32] {
     fn .add(a: I32, b: I32) -> I32 {
       inline_ivy! (a <- a, b <- b) -> I32 { out a = @n32_add(b out) }

--- a/vine/std/numeric/N32.vi
+++ b/vine/std/numeric/N32.vi
@@ -11,6 +11,18 @@ use debug::Show;
 pub type N32;
 
 pub mod N32 {
+  pub impl fork: Fork[N32] {
+    fn .fork(&self: &N32) -> N32 {
+      Fork::copy(&self)
+    }
+  }
+
+  pub impl drop: Drop[N32] {
+    fn .drop(self: N32) {
+      Drop::erase(self)
+    }
+  }
+
   pub const maximum: N32 = 0xffffffff;
 
   pub impl add: Add[N32, N32, N32] {

--- a/vine/std/numeric/N64.vi
+++ b/vine/std/numeric/N64.vi
@@ -14,6 +14,18 @@ pub mod N64 {
   pub const one: N64 = N64(1, 0);
   pub const maximum: N64 = N64(N32::maximum, N32::maximum);
 
+  pub impl fork: Fork[N64] {
+    fn .fork(&self: &N64) -> N64 {
+      Fork::copy(&self)
+    }
+  }
+
+  pub impl drop: Drop[N64] {
+    fn .drop(self: N64) {
+      Drop::erase(self)
+    }
+  }
+
   pub impl from_n32: Cast[N32, N64] {
     fn .cast(val: N32) -> N64 {
       N64(val, 0)

--- a/vine/std/ops/flex.vi
+++ b/vine/std/ops/flex.vi
@@ -1,0 +1,98 @@
+
+pub trait Fork[T] {
+  fn .fork(&self: &T) -> T;
+}
+
+pub trait Drop[T] {
+  fn .drop(self: T);
+}
+
+pub mod Fork {
+  pub fn copy[T](&value: &T) -> T {
+    inline_ivy! (x <- value, x1 -> value) -> T {
+      x2
+      x = copy(x1 x2)
+    }
+  }
+
+  pub impl ref[T]: Fork[&T] {
+    fn fork(&&value: &&T) -> &T {
+      &value
+    }
+  }
+
+  pub impl nil: Fork[()] {
+    fn fork(&()) -> () {}
+  }
+
+  pub impl unary[A; Fork[A]]: Fork[(A,)] {
+    fn fork(&(a: A,)) -> (A,) {
+      (a.fork(),)
+    }
+  }
+
+  pub impl pair[A, B; Fork[A], Fork[B]]: Fork[(A, B)] {
+    fn fork(&(a: A, b: B)) -> (A, B) {
+      (a.fork(), b.fork())
+    }
+  }
+
+  pub impl triple[A, B, C; Fork[A], Fork[B], Fork[C]]: Fork[(A, B, C)] {
+    fn fork(&(a: A, b: B, c: C)) -> (A, B, C) {
+      (a.fork(), b.fork(), c.fork())
+    }
+  }
+
+  pub impl quad[A, B, C, D; Fork[A], Fork[B], Fork[C], Fork[D]]: Fork[(A, B, C, D)] {
+    fn fork(&(a: A, b: B, c: C, d: D)) -> (A, B, C, D) {
+      (a.fork(), b.fork(), c.fork(), d.fork())
+    }
+  }
+}
+
+pub mod Drop {
+  pub fn erase[T](value: T) {
+    inline_ivy! (x <- value) -> () {
+      _
+      x = _
+    }
+  }
+
+  pub impl ref[T]: Drop[&T] {
+    fn drop(&_: &T) {}
+  }
+
+  pub impl nil: Drop[()] {
+    fn drop(()) {}
+  }
+
+  pub impl unary[A; Drop[A]]: Drop[(A,)] {
+    fn drop((a: A,)) {
+      a.drop();
+    }
+  }
+
+  pub impl pair[A, B; Drop[A], Drop[B]]: Drop[(A, B)] {
+    fn drop((a: A, b: B)) {
+      a.drop();
+      b.drop();
+    }
+  }
+
+  pub impl triple[A, B, C; Drop[A], Drop[B], Drop[C]]: Drop[(A, B, C)] {
+    fn drop((a: A, b: B, c: C)) {
+      a.drop();
+      b.drop();
+      c.drop();
+    }
+  }
+
+  pub impl quad[A, B, C, D; Drop[A], Drop[B], Drop[C], Drop[D]]: Drop[(A, B, C, D)] {
+    fn drop((a: A, b: B, c: C, d: D)) {
+      a.drop();
+      b.drop();
+      c.drop();
+      d.drop();
+    }
+  }
+}

--- a/vine/std/ops/flex.vi
+++ b/vine/std/ops/flex.vi
@@ -1,8 +1,10 @@
 
+#[builtin = "Fork"]
 pub trait Fork[T] {
   fn .fork(&self: &T) -> T;
 }
 
+#[builtin = "Drop"]
 pub trait Drop[T] {
   fn .drop(self: T);
 }
@@ -25,25 +27,25 @@ pub mod Fork {
     fn fork(&()) -> () {}
   }
 
-  pub impl unary[A; Fork[A]]: Fork[(A,)] {
+  pub impl unary[A+]: Fork[(A,)] {
     fn fork(&(a: A,)) -> (A,) {
       (a.fork(),)
     }
   }
 
-  pub impl pair[A, B; Fork[A], Fork[B]]: Fork[(A, B)] {
+  pub impl pair[A+, B+]: Fork[(A, B)] {
     fn fork(&(a: A, b: B)) -> (A, B) {
       (a.fork(), b.fork())
     }
   }
 
-  pub impl triple[A, B, C; Fork[A], Fork[B], Fork[C]]: Fork[(A, B, C)] {
+  pub impl triple[A+, B+, C+]: Fork[(A, B, C)] {
     fn fork(&(a: A, b: B, c: C)) -> (A, B, C) {
       (a.fork(), b.fork(), c.fork())
     }
   }
 
-  pub impl quad[A, B, C, D; Fork[A], Fork[B], Fork[C], Fork[D]]: Fork[(A, B, C, D)] {
+  pub impl quad[A+, B+, C+, D+]: Fork[(A, B, C, D)] {
     fn fork(&(a: A, b: B, c: C, d: D)) -> (A, B, C, D) {
       (a.fork(), b.fork(), c.fork(), d.fork())
     }
@@ -66,20 +68,20 @@ pub mod Drop {
     fn drop(()) {}
   }
 
-  pub impl unary[A; Drop[A]]: Drop[(A,)] {
+  pub impl unary[A?]: Drop[(A,)] {
     fn drop((a: A,)) {
       a.drop();
     }
   }
 
-  pub impl pair[A, B; Drop[A], Drop[B]]: Drop[(A, B)] {
+  pub impl pair[A?, B?]: Drop[(A, B)] {
     fn drop((a: A, b: B)) {
       a.drop();
       b.drop();
     }
   }
 
-  pub impl triple[A, B, C; Drop[A], Drop[B], Drop[C]]: Drop[(A, B, C)] {
+  pub impl triple[A?, B?, C?]: Drop[(A, B, C)] {
     fn drop((a: A, b: B, c: C)) {
       a.drop();
       b.drop();
@@ -87,7 +89,7 @@ pub mod Drop {
     }
   }
 
-  pub impl quad[A, B, C, D; Drop[A], Drop[B], Drop[C], Drop[D]]: Drop[(A, B, C, D)] {
+  pub impl quad[A?, B?, C?, D?]: Drop[(A, B, C, D)] {
     fn drop((a: A, b: B, c: C, d: D)) {
       a.drop();
       b.drop();

--- a/vine/std/ops/ops.vi
+++ b/vine/std/ops/ops.vi
@@ -2,6 +2,7 @@
 pub mod comparison = "./comparison.vi";
 pub mod arithmetic = "./arithmetic.vi";
 pub mod bitwise = "./bitwise.vi";
+pub mod flex = "./flex.vi";
 pub mod vectorized = "./vectorized.vi";
 
 pub trait Concat[A, B, O] {

--- a/vine/std/std.vi
+++ b/vine/std/std.vi
@@ -15,6 +15,7 @@ pub mod prelude {
     data::List,
     logical::{Bool, Option::{Option, None, Some}, Result::{Result, Err, Ok}},
     numeric::{F32, I32, N32},
+    ops::flex::{Drop, Fork},
     unicode::{Char, String},
   };
 

--- a/vine/std/unicode/Char.vi
+++ b/vine/std/unicode/Char.vi
@@ -6,6 +6,18 @@ use debug::Show;
 pub type Char;
 
 pub mod Char {
+  pub impl fork: Fork[Char] {
+    fn .fork(&self: &Char) -> Char {
+      Fork::copy(&self)
+    }
+  }
+
+  pub impl drop: Drop[Char] {
+    fn .drop(self: Char) {
+      Drop::erase(self)
+    }
+  }
+
   pub impl from_n32: Cast[N32, Char] {
     fn .cast(n: N32) -> Char {
       inline_ivy! (n <- n) -> Char { n }

--- a/vine/std/unicode/String.vi
+++ b/vine/std/unicode/String.vi
@@ -59,8 +59,8 @@ pub mod String {
         let List(_, _, end) = suffix as List;
         return (prefix, Some(List(len, move buf, end) as String));
       }
-      iter_a.drop();
-      iter_b.drop();
+      iter_a.drop_iter();
+      iter_b.drop_iter();
       if suffix!.pop_front() is Some(char) {
         prefix ++= String([char]);
       } else {
@@ -79,8 +79,8 @@ pub mod String {
     while prefix_iter.next() is Some(&a) {
       let &b = self_iter.next().unwrap();
       if a != b {
-        self_iter.drop()
-        prefix_iter.drop()
+        self_iter.drop_iter()
+        prefix_iter.drop_iter()
         return Err(self)
       }
     }
@@ -98,12 +98,12 @@ pub mod String {
     while prefix_iter.next() is Some(&a) {
       let &b = self_iter.next().unwrap();
       if a != b {
-        self_iter.drop()
-        prefix_iter.drop()
+        self_iter.drop_iter()
+        prefix_iter.drop_iter()
         return false
       }
     }
-    self_iter.drop();
+    self_iter.drop_iter();
     true
   }
 

--- a/vine/std/unicode/String.vi
+++ b/vine/std/unicode/String.vi
@@ -6,6 +6,18 @@ use debug::Show;
 pub struct String(pub List[Char]);
 
 pub mod String {
+  pub impl fork: Fork[String] {
+    fn .fork(&self: &String) -> String {
+      Fork::copy(&self)
+    }
+  }
+
+  pub impl drop: Drop[String] {
+    fn .drop(self: String) {
+      Drop::erase(self)
+    }
+  }
+
   pub fn .len(&String(List(len, _, _))) -> N32 {
     len
   }


### PR DESCRIPTION
Adds the `Fork` and `Drop` traits to the standard library, and implements them for all relevant types. Note that the compiler does not yet automatically call them.

I renamed the `Iterator::drop` method to `Iterator::drop_iter` to avoid a naming conflict for now. Ultimately this method will be removed and its role taken by `drop`, but I would like to leave it separate for now for simplicity / compatibility.