### PR TITLE
vine: rework `Chart` [fork/drop]

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -37,6 +37,7 @@
     "peekable",
     "primality",
     "primenesses",
+    "proto",
     "readback",
     "readline",
     "rels",

--- a/tests/snaps/vine/fail/atypical.txt
+++ b/tests/snaps/vine/fail/atypical.txt
@@ -6,17 +6,17 @@ error tests/programs/fail/atypical.vi:31:3 - cannot find label `stuff`
 error tests/programs/fail/atypical.vi:32:14 - cannot continue label `stuff`
 error tests/programs/fail/atypical.vi:3:19 - no type associated with `::atypical::foo`
 error tests/programs/fail/atypical.vi:3:24 - types in item signatures cannot be elided
+error tests/programs/fail/atypical.vi:5:12 - types in item signatures cannot be elided
 error tests/programs/fail/atypical.vi:4:8 - types in item signatures cannot be elided
 error tests/programs/fail/atypical.vi:4:14 - `::atypical::Foo` expects 1 type parameter; was passed 0
-error tests/programs/fail/atypical.vi:5:12 - types in item signatures cannot be elided
 error - expected type `fn(&IO)`; found `fn(IO)`
 error tests/programs/fail/atypical.vi:5:16 - no function to return from
 error tests/programs/fail/atypical.vi:7:16 - expected type `N32`; found `F32`
 error tests/programs/fail/atypical.vi:8:16 - expected type `F32`; found `N32`
-error tests/programs/fail/atypical.vi:9:23 - cannot find impl of trait `Add[(N32, N32), F32, ?20]`
-error tests/programs/fail/atypical.vi:10:16 - expected type `(?21, ?22)`; found `N32`
+error tests/programs/fail/atypical.vi:9:23 - cannot find impl of trait `Add[(N32, N32), F32, ?18]`
+error tests/programs/fail/atypical.vi:10:16 - expected type `(?19, ?20)`; found `N32`
 error tests/programs/fail/atypical.vi:12:3 - cannot call non-function type `N32`
-error tests/programs/fail/atypical.vi:13:14 - cannot find impl of trait `Add[N32, ~N32, ?36]`
+error tests/programs/fail/atypical.vi:13:14 - cannot find impl of trait `Add[N32, ~N32, ?34]`
 error tests/programs/fail/atypical.vi:14:3 - type `N32` has no method `noop`
 error tests/programs/fail/atypical.vi:15:6 - expected type `Bool`; found `F32`
 error tests/programs/fail/atypical.vi:15:21 - expected type `N32`; found `String`
@@ -24,15 +24,15 @@ error tests/programs/fail/atypical.vi:16:3 - function type `fn(IO)` expects 1 ar
 error tests/programs/fail/atypical.vi:17:3 - cannot compare `N32` and `F32`
 error tests/programs/fail/atypical.vi:17:3 - cannot compare `F32` and `N32`
 error tests/programs/fail/atypical.vi:17:3 - cannot compare `N32` and `F32`
-error tests/programs/fail/atypical.vi:18:13 - expected type `(N32, N32)`; found `(?59,)`
+error tests/programs/fail/atypical.vi:18:13 - expected type `(N32, N32)`; found `(?57,)`
 error tests/programs/fail/atypical.vi:20:14 - expected type `T`; found `N32`
 error tests/programs/fail/atypical.vi:21:14 - expected type `U`; found `T`
 error tests/programs/fail/atypical.vi:22:7 - expected a complete pattern
 error tests/programs/fail/atypical.vi:22:17 - expected type `Ay`; found `N32`
-error tests/programs/fail/atypical.vi:23:4 - cannot find impl of trait `Add[String, N32, ?79]`
-error tests/programs/fail/atypical.vi:24:7 - expected type `N32`; found `&?81`
+error tests/programs/fail/atypical.vi:23:4 - cannot find impl of trait `Add[String, N32, ?78]`
+error tests/programs/fail/atypical.vi:24:7 - expected type `N32`; found `&?80`
 error tests/programs/fail/atypical.vi:27:10 - expected type `()`; found `F32`
-error tests/programs/fail/atypical.vi:28:14 - cannot find impl of trait `Add[~N32, ~N32, ?90]`
+error tests/programs/fail/atypical.vi:28:14 - cannot find impl of trait `Add[~N32, ~N32, ?89]`
 error tests/programs/fail/atypical.vi:29:3 - cannot find impl of trait `Add[N32, F32, N32]`
 error tests/programs/fail/atypical.vi:30:3 - type `N32` has no method `parse`
 error tests/programs/fail/atypical.vi:6:27 - expected type `()`; found `N32`

--- a/tests/snaps/vine/fail/hallo_world.txt
+++ b/tests/snaps/vine/fail/hallo_world.txt
@@ -1,7 +1,7 @@
 error tests/programs/fail/hallo_world.vi:3:3 - duplicate definition of `println`
+error tests/programs/fail/hallo_world.vi:2:10 - cannot find `io` in `::std`
 error tests/programs/fail/hallo_world.vi:8:13 - cannot find `io` in `::std`
 error tests/programs/fail/hallo_world.vi:9:3 - cannot find `io` in `::hallo_world::main`
 error tests/programs/fail/hallo_world.vi:9:14 - cannot find `hallo` in `::hallo_world::main`
 error tests/programs/fail/hallo_world.vi:9:21 - cannot find `world` in `::hallo_world::main`
-error tests/programs/fail/hallo_world.vi:2:10 - cannot find `io` in `::std`
 error tests/programs/fail/hallo_world.vi:9:3 - type `??` has no method `println`

--- a/tests/snaps/vine/fail/informal.txt
+++ b/tests/snaps/vine/fail/informal.txt
@@ -5,7 +5,7 @@ error tests/programs/fail/informal.vi:6:3 - expected a space expression; found a
 error tests/programs/fail/informal.vi:6:8 - expected a value expression; found a space expression
 error tests/programs/fail/informal.vi:7:3 - expected a place expression; found a space expression
 error tests/programs/fail/informal.vi:7:8 - expected a value expression; found a space expression
-error tests/programs/fail/informal.vi:7:3 - cannot find impl of trait `Add[?14, ~N32, ?14]`
+error tests/programs/fail/informal.vi:7:3 - cannot find impl of trait `Add[?12, ~N32, ?12]`
 error tests/programs/fail/informal.vi:8:8 - `&` is invalid in a space pattern
 error tests/programs/fail/informal.vi:8:15 - expected a place expression; found a space expression
 error tests/programs/fail/informal.vi:8:13 - expected a value expression; found a space expression

--- a/tests/snaps/vine/fail/visibility.txt
+++ b/tests/snaps/vine/fail/visibility.txt
@@ -1,13 +1,14 @@
 error tests/programs/fail/visibility.vi:18:1 - subitems must be private
 error tests/programs/fail/visibility.vi:26:7 - invalid visibility; expected the name of an ancestor module
-error - `::visibility::main` is only visible within `::visibility`
-error tests/programs/fail/visibility.vi:20:24 - constructor expects data
-error tests/programs/fail/visibility.vi:20:7 - expected data subpattern
-error tests/programs/fail/visibility.vi:21:24 - `::visibility::lib::y` is only visible within `::visibility::lib`
-error tests/programs/fail/visibility.vi:21:7 - `::visibility::lib::y` is only visible within `::visibility::lib`
-error tests/programs/fail/visibility.vi:21:15 - `::visibility::lib::y` is only visible within `::visibility::lib`
 error tests/programs/fail/visibility.vi:27:8 - `::visibility::lib::a::b` is only visible within `::visibility::lib::a`
 error tests/programs/fail/visibility.vi:28:5 - `::visibility::lib::c` is only visible within `::visibility::lib`
 error tests/programs/fail/visibility.vi:29:8 - `::visibility::lib::d::e` is only visible within `::visibility::lib`
 error tests/programs/fail/visibility.vi:33:17 - circular import
+error - `::visibility::main` is only visible within `::visibility`
+error tests/programs/fail/visibility.vi:20:24 - the value `::visibility::lib::x` is only visible within `::visibility::lib`
+error tests/programs/fail/visibility.vi:20:7 - the pattern `::visibility::lib::x` is only visible within `::visibility::lib`
+error tests/programs/fail/visibility.vi:20:15 - the type `::visibility::lib::x` is only visible within `::visibility::lib`
+error tests/programs/fail/visibility.vi:21:24 - `::visibility::lib::y` is only visible within `::visibility::lib`
+error tests/programs/fail/visibility.vi:21:7 - `::visibility::lib::y` is only visible within `::visibility::lib`
+error tests/programs/fail/visibility.vi:21:15 - `::visibility::lib::y` is only visible within `::visibility::lib`
 error tests/programs/fail/visibility.vi:19:3 - type `IO` has no method `read_char`

--- a/tests/snaps/vine/repl/misc.repl.vi
+++ b/tests/snaps/vine/repl/misc.repl.vi
@@ -262,7 +262,7 @@ error input:1:1 - no function to return from
 
 io = #io
 > fn foo() -> N32 { Ok(123)? }
-error input:1:19 - cannot try `Result[N32, ?4]` in a function returning `N32`
+error input:1:19 - cannot try `Result[N32, ?3]` in a function returning `N32`
 
 io = #io
 > fn foo() -> Result[N32, String] { Ok(123)? }
@@ -270,7 +270,7 @@ error input:1:33 - expected type `Result[N32, String]`; found `N32`
 
 io = #io
 > fn foo() -> Result[N32, String] { Err(123)? }
-error input:1:35 - cannot try `Result[?5, N32]` in a function returning `Result[N32, String]`
+error input:1:35 - cannot try `Result[?4, N32]` in a function returning `Result[N32, String]`
 
 io = #io
 > let x = (1, 2.0, [Some(Ok(true)), Some(Err("hi")), None], ((), ((),), ((), ())));

--- a/tests/snaps/vine/repl/string_ops.repl.vi
+++ b/tests/snaps/vine/repl/string_ops.repl.vi
@@ -40,7 +40,7 @@ false
 io = #io
 s = "hello world!"
 > "" == ""
-::std::data::List::eq::eq::1::13
+::std::data::List::eq::eq::0::13
 
 io = #io
 s = "hello world!"
@@ -50,7 +50,7 @@ false
 io = #io
 s = "hello world!"
 > "hello" == "hello"
-::std::data::List::eq::eq::1::13
+::std::data::List::eq::eq::0::13
 
 io = #io
 s = "hello world!"
@@ -91,7 +91,7 @@ io = #io
 s = "hello world!"
 x = "hi"
 > x == "hi"
-::std::data::List::eq::eq::1::13
+::std::data::List::eq::eq::0::13
 
 io = #io
 s = "hello world!"

--- a/vine/src/ast.rs
+++ b/vine/src/ast.rs
@@ -10,9 +10,7 @@ use ivy::ast::Net;
 use vine_util::{idx, interner::Interned, new_idx};
 
 use crate::{
-  chart::{
-    ConstKind, EnumId, FnKind, ImplId, OpaqueTypeId, StructId, TraitId, TypeAliasId, VariantId,
-  },
+  chart::{ConstId, EnumId, FnId, ImplId, OpaqueTypeId, StructId, TraitId, TypeAliasId, VariantId},
   diag::ErrorGuaranteed,
   specializer::{ConstRelId, FnRelId},
 };
@@ -283,9 +281,9 @@ pub enum ExprKind<'core> {
   #[class(value)]
   Path(Path<'core>, Option<Vec<Expr<'core>>>),
   #[class(value, resolved)]
-  ConstDef(ConstKind, GenericArgs<'core>),
+  ConstDef(ConstId, GenericArgs<'core>),
   #[class(value, resolved)]
-  FnDef(FnKind, GenericArgs<'core>),
+  FnDef(FnId, GenericArgs<'core>),
   #[class(value, synthetic)]
   ConstRel(ConstRelId),
   #[class(value, synthetic)]

--- a/vine/src/ast.rs
+++ b/vine/src/ast.rs
@@ -10,9 +10,11 @@ use ivy::ast::Net;
 use vine_util::{idx, interner::Interned, new_idx};
 
 use crate::{
-  chart::{EnumId, ImplDefId, StructId, TraitDefId, TypeDefId, ValueDefId, VariantId},
+  chart::{
+    ConstKind, EnumId, FnKind, ImplId, OpaqueTypeId, StructId, TraitId, TypeAliasId, VariantId,
+  },
   diag::ErrorGuaranteed,
-  specializer::RelId,
+  specializer::{ConstRelId, FnRelId},
 };
 
 new_idx!(pub Local; n => ["l{n}"]);
@@ -281,9 +283,13 @@ pub enum ExprKind<'core> {
   #[class(value)]
   Path(Path<'core>, Option<Vec<Expr<'core>>>),
   #[class(value, resolved)]
-  Def(ValueDefId, GenericArgs<'core>),
+  ConstDef(ConstKind, GenericArgs<'core>),
+  #[class(value, resolved)]
+  FnDef(FnKind, GenericArgs<'core>),
   #[class(value, synthetic)]
-  Rel(RelId),
+  ConstRel(ConstRelId),
+  #[class(value, synthetic)]
+  FnRel(FnRelId),
   #[class(place, resolved)]
   Local(Local),
   #[class(value, resolved)]
@@ -490,7 +496,7 @@ pub struct Ty<'core> {
   pub kind: TyKind<'core>,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Classes)]
 pub enum TyKind<'core> {
   #[default]
   Hole,
@@ -501,8 +507,16 @@ pub enum TyKind<'core> {
   Ref(B<Ty<'core>>),
   Inverse(B<Ty<'core>>),
   Path(Path<'core>),
+  #[class(resolved)]
   Param(usize),
-  Def(TypeDefId, GenericArgs<'core>),
+  #[class(resolved)]
+  Opaque(OpaqueTypeId, GenericArgs<'core>),
+  #[class(resolved)]
+  Alias(TypeAliasId, GenericArgs<'core>),
+  #[class(resolved)]
+  Struct(StructId, GenericArgs<'core>),
+  #[class(resolved)]
+  Enum(EnumId, GenericArgs<'core>),
   Error(ErrorGuaranteed),
 }
 
@@ -517,7 +531,7 @@ pub enum ImplKind<'core> {
   Hole,
   Param(usize),
   Path(Path<'core>),
-  Def(ImplDefId, GenericArgs<'core>),
+  Def(ImplId, GenericArgs<'core>),
   Error(ErrorGuaranteed),
 }
 
@@ -530,7 +544,7 @@ pub struct Trait<'core> {
 #[derive(Debug, Clone)]
 pub enum TraitKind<'core> {
   Path(Path<'core>),
-  Def(TraitDefId, GenericArgs<'core>),
+  Def(TraitId, GenericArgs<'core>),
   Error(ErrorGuaranteed),
 }
 

--- a/vine/src/chart.rs
+++ b/vine/src/chart.rs
@@ -45,11 +45,11 @@ pub struct Builtins {
   pub string: Option<StructId>,
   pub result: Option<EnumId>,
 
-  pub neg: Option<FnKind>,
-  pub not: Option<FnKind>,
-  pub cast: Option<FnKind>,
-  pub binary_ops: IntMap<BinaryOp, Option<FnKind>>,
-  pub comparison_ops: IntMap<ComparisonOp, Option<FnKind>>,
+  pub neg: Option<FnId>,
+  pub not: Option<FnId>,
+  pub cast: Option<FnId>,
+  pub binary_ops: IntMap<BinaryOp, Option<FnId>>,
+  pub comparison_ops: IntMap<ComparisonOp, Option<FnId>>,
 
   pub bool_not: Option<ImplId>,
 
@@ -93,20 +93,20 @@ pub enum MemberKind {
 
 #[derive(Debug, Clone, Copy)]
 pub enum DefValueKind {
-  Const(ConstKind),
-  Fn(FnKind),
+  Const(ConstId),
+  Fn(FnId),
   Struct(StructId),
   Enum(EnumId, VariantId),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub enum ConstKind {
+pub enum ConstId {
   Concrete(ConcreteConstId),
   Abstract(TraitId, TraitConstId),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub enum FnKind {
+pub enum FnId {
   Concrete(ConcreteFnId),
   Abstract(TraitId, TraitFnId),
 }
@@ -298,24 +298,24 @@ impl<'core> Chart<'core> {
     vis == from || vis < from && self.defs[from].ancestors.binary_search(&vis).is_ok()
   }
 
-  pub fn fn_is_method(&self, fn_kind: FnKind) -> bool {
-    match fn_kind {
-      FnKind::Concrete(fn_id) => self.concrete_fns[fn_id].method,
-      FnKind::Abstract(trait_id, fn_id) => self.traits[trait_id].fns[fn_id].method,
+  pub fn fn_is_method(&self, fn_id: FnId) -> bool {
+    match fn_id {
+      FnId::Concrete(fn_id) => self.concrete_fns[fn_id].method,
+      FnId::Abstract(trait_id, fn_id) => self.traits[trait_id].fns[fn_id].method,
     }
   }
 
-  pub fn fn_generics(&self, fn_kind: FnKind) -> GenericsId {
-    match fn_kind {
-      FnKind::Concrete(fn_id) => self.concrete_fns[fn_id].generics,
-      FnKind::Abstract(trait_id, _) => self.traits[trait_id].subitem_generics,
+  pub fn fn_generics(&self, fn_id: FnId) -> GenericsId {
+    match fn_id {
+      FnId::Concrete(fn_id) => self.concrete_fns[fn_id].generics,
+      FnId::Abstract(trait_id, _) => self.traits[trait_id].subitem_generics,
     }
   }
 
-  pub fn const_generics(&self, const_kind: ConstKind) -> GenericsId {
-    match const_kind {
-      ConstKind::Concrete(const_id) => self.concrete_consts[const_id].generics,
-      ConstKind::Abstract(trait_id, _) => self.traits[trait_id].subitem_generics,
+  pub fn const_generics(&self, const_id: ConstId) -> GenericsId {
+    match const_id {
+      ConstId::Concrete(const_id) => self.concrete_consts[const_id].generics,
+      ConstId::Abstract(trait_id, _) => self.traits[trait_id].subitem_generics,
     }
   }
 }

--- a/vine/src/chart.rs
+++ b/vine/src/chart.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use vine_util::{
-  idx::{Counter, Idx, IdxVec, IntMap},
+  idx::{Counter, IdxVec, IntMap},
   new_idx,
 };
 
@@ -12,18 +12,21 @@ use crate::{
   diag::ErrorGuaranteed,
 };
 
+pub mod checkpoint;
+
 #[derive(Debug, Default)]
 pub struct Chart<'core> {
   pub defs: IdxVec<DefId, Def<'core>>,
-  pub values: IdxVec<ValueDefId, ValueDef<'core>>,
-  pub types: IdxVec<TypeDefId, TypeDef<'core>>,
-  pub patterns: IdxVec<PatternDefId, PatternDef>,
-  pub traits: IdxVec<TraitDefId, TraitDef<'core>>,
-  pub impls: IdxVec<ImplDefId, ImplDef<'core>>,
+  pub imports: IdxVec<ImportId, ImportDef<'core>>,
   pub generics: IdxVec<GenericsId, GenericsDef<'core>>,
+  pub concrete_consts: IdxVec<ConcreteConstId, ConcreteConstDef<'core>>,
+  pub concrete_fns: IdxVec<ConcreteFnId, ConcreteFnDef<'core>>,
+  pub opaque_types: IdxVec<OpaqueTypeId, OpaqueTypeDef<'core>>,
+  pub type_aliases: IdxVec<TypeAliasId, TypeAliasDef<'core>>,
   pub structs: IdxVec<StructId, StructDef<'core>>,
   pub enums: IdxVec<EnumId, EnumDef<'core>>,
-  pub imports: IdxVec<ImportId, Import<'core>>,
+  pub traits: IdxVec<TraitId, TraitDef<'core>>,
+  pub impls: IdxVec<ImplId, ImplDef<'core>>,
   pub builtins: Builtins,
 }
 
@@ -31,26 +34,27 @@ pub struct Chart<'core> {
 pub struct Builtins {
   pub prelude: Option<DefId>,
 
-  pub bool: Option<TypeDefId>,
-  pub n32: Option<TypeDefId>,
-  pub i32: Option<TypeDefId>,
-  pub f32: Option<TypeDefId>,
-  pub char: Option<TypeDefId>,
-  pub io: Option<TypeDefId>,
+  pub bool: Option<OpaqueTypeId>,
+  pub n32: Option<OpaqueTypeId>,
+  pub i32: Option<OpaqueTypeId>,
+  pub f32: Option<OpaqueTypeId>,
+  pub char: Option<OpaqueTypeId>,
+  pub io: Option<OpaqueTypeId>,
 
   pub list: Option<StructId>,
   pub string: Option<StructId>,
   pub result: Option<EnumId>,
 
-  pub neg: Option<ValueDefId>,
-  pub not: Option<ValueDefId>,
-  pub bool_not: Option<ImplDefId>,
-  pub cast: Option<ValueDefId>,
-  pub binary_ops: IntMap<BinaryOp, Option<ValueDefId>>,
-  pub comparison_ops: IntMap<ComparisonOp, Option<ValueDefId>>,
+  pub neg: Option<FnKind>,
+  pub not: Option<FnKind>,
+  pub cast: Option<FnKind>,
+  pub binary_ops: IntMap<BinaryOp, Option<FnKind>>,
+  pub comparison_ops: IntMap<ComparisonOp, Option<FnKind>>,
 
-  pub fork: Option<TraitDefId>,
-  pub drop: Option<TraitDefId>,
+  pub bool_not: Option<ImplId>,
+
+  pub fork: Option<TraitId>,
+  pub drop: Option<TraitId>,
 
   pub range: Option<StructId>,
   pub bound_exclusive: Option<StructId>,
@@ -59,46 +63,26 @@ pub struct Builtins {
 }
 
 new_idx!(pub DefId);
-new_idx!(pub ValueDefId);
-new_idx!(pub TypeDefId);
-new_idx!(pub PatternDefId);
-new_idx!(pub TraitDefId);
-new_idx!(pub ImplDefId);
-new_idx!(pub GenericsId);
-new_idx!(pub StructId);
-new_idx!(pub EnumId);
-new_idx!(pub VariantId);
-new_idx!(pub SubitemId);
-new_idx!(pub ImportId);
-
-impl DefId {
-  pub const ROOT: Self = Self(0);
-}
-
-impl GenericsId {
-  pub const NONE: Self = Self(0);
-}
-
 #[derive(Debug)]
 pub struct Def<'core> {
   pub name: Ident<'core>,
   pub path: &'core str,
 
-  pub members: HashMap<Ident<'core>, Member>,
+  pub members: HashMap<Ident<'core>, WithVis<MemberKind>>,
   pub parent: Option<DefId>,
   pub ancestors: Vec<DefId>,
 
-  pub value_def: Option<ValueDefId>,
-  pub type_def: Option<TypeDefId>,
-  pub pattern_def: Option<PatternDefId>,
-  pub trait_def: Option<TraitDefId>,
-  pub impl_def: Option<ImplDefId>,
+  pub value_kind: Option<WithVis<DefValueKind>>,
+  pub type_kind: Option<WithVis<DefTypeKind>>,
+  pub pattern_kind: Option<WithVis<DefPatternKind>>,
+  pub trait_kind: Option<WithVis<DefTraitKind>>,
+  pub impl_kind: Option<WithVis<DefImplKind>>,
 }
 
-#[derive(Debug)]
-pub struct Member {
+#[derive(Debug, Clone, Copy)]
+pub struct WithVis<T> {
   pub vis: DefId,
-  pub kind: MemberKind,
+  pub kind: T,
 }
 
 #[derive(Debug)]
@@ -108,7 +92,52 @@ pub enum MemberKind {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub struct Import<'core> {
+pub enum DefValueKind {
+  Const(ConstKind),
+  Fn(FnKind),
+  Struct(StructId),
+  Enum(EnumId, VariantId),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ConstKind {
+  Concrete(ConcreteConstId),
+  Abstract(TraitId, TraitConstId),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum FnKind {
+  Concrete(ConcreteFnId),
+  Abstract(TraitId, TraitFnId),
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum DefTypeKind {
+  Opaque(OpaqueTypeId),
+  Alias(TypeAliasId),
+  Struct(StructId),
+  Enum(EnumId),
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum DefPatternKind {
+  Struct(StructId),
+  Enum(EnumId, VariantId),
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum DefTraitKind {
+  Trait(TraitId),
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum DefImplKind {
+  Impl(ImplId),
+}
+
+new_idx!(pub ImportId);
+#[derive(Debug, Clone, Copy)]
+pub struct ImportDef<'core> {
   pub span: Span,
   pub def: DefId,
   pub parent: ImportParent,
@@ -130,125 +159,7 @@ pub enum ImportState {
   Resolving,
 }
 
-#[derive(Debug)]
-pub struct ValueDef<'core> {
-  pub span: Span,
-  pub def: DefId,
-  pub vis: DefId,
-  pub generics: GenericsId,
-  pub locals: Counter<Local>,
-  pub kind: ValueDefKind<'core>,
-  pub method: bool,
-}
-
-#[derive(Debug, Default)]
-pub enum ValueDefKind<'core> {
-  #[default]
-  Taken,
-  Const {
-    ty: Ty<'core>,
-    value: Expr<'core>,
-  },
-  Fn {
-    params: Vec<Pat<'core>>,
-    ret: Option<Ty<'core>>,
-    body: Block<'core>,
-  },
-  Struct(StructId),
-  Enum(EnumId, VariantId),
-  TraitSubitem(TraitDefId, SubitemId),
-}
-
-#[derive(Debug)]
-pub struct TypeDef<'core> {
-  pub span: Span,
-  pub def: DefId,
-  pub vis: DefId,
-  pub generics: GenericsId,
-  pub kind: TypeDefKind<'core>,
-}
-
-#[derive(Debug, Default)]
-pub enum TypeDefKind<'core> {
-  #[default]
-  Taken,
-  Opaque,
-  Alias(Ty<'core>),
-  Struct(StructId),
-  Enum(EnumId),
-}
-
-#[derive(Debug)]
-pub struct PatternDef {
-  pub span: Span,
-  pub def: DefId,
-  pub vis: DefId,
-  pub generics: GenericsId,
-  pub kind: PatternDefKind,
-}
-
-#[derive(Debug)]
-pub enum PatternDefKind {
-  Struct(StructId),
-  Enum(EnumId, VariantId),
-}
-
-#[derive(Debug)]
-pub struct TraitDef<'core> {
-  pub span: Span,
-  pub def: DefId,
-  pub vis: DefId,
-  pub generics: GenericsId,
-  pub kind: TraitDefKind<'core>,
-}
-
-#[derive(Debug, Default)]
-pub enum TraitDefKind<'core> {
-  #[default]
-  Taken,
-  Trait {
-    subitems: IdxVec<SubitemId, TraitSubitem<'core>>,
-  },
-}
-
-#[derive(Debug)]
-pub struct TraitSubitem<'core> {
-  pub name: Ident<'core>,
-  pub kind: TraitSubitemKind<'core>,
-}
-
-#[derive(Debug)]
-pub enum TraitSubitemKind<'core> {
-  Fn(Vec<Pat<'core>>, Option<Ty<'core>>),
-  Const(Ty<'core>),
-}
-
-#[derive(Debug)]
-pub struct ImplDef<'core> {
-  pub span: Span,
-  pub def: DefId,
-  pub vis: DefId,
-  pub generics: GenericsId,
-  pub kind: ImplDefKind<'core>,
-}
-
-#[derive(Debug, Default)]
-pub enum ImplDefKind<'core> {
-  #[default]
-  Taken,
-  Impl {
-    trait_: Trait<'core>,
-    subitems: IdxVec<SubitemId, ImplSubitem<'core>>,
-  },
-}
-
-#[derive(Debug)]
-pub struct ImplSubitem<'core> {
-  pub span: Span,
-  pub name: Ident<'core>,
-  pub value: ValueDefId,
-}
-
+new_idx!(pub GenericsId);
 #[derive(Debug, Default, Clone)]
 pub struct GenericsDef<'core> {
   pub span: Span,
@@ -257,8 +168,52 @@ pub struct GenericsDef<'core> {
   pub impl_params: Vec<ImplParam<'core>>,
 }
 
-#[derive(Debug)]
+new_idx!(pub ConcreteConstId);
+#[derive(Debug, Clone)]
+pub struct ConcreteConstDef<'core> {
+  pub span: Span,
+  pub def: DefId,
+  pub generics: GenericsId,
+  pub ty: Ty<'core>,
+  pub value: Expr<'core>,
+  pub locals: Counter<Local>,
+}
+
+new_idx!(pub ConcreteFnId);
+#[derive(Debug, Clone)]
+pub struct ConcreteFnDef<'core> {
+  pub span: Span,
+  pub def: DefId,
+  pub generics: GenericsId,
+  pub method: bool,
+  pub params: Vec<Pat<'core>>,
+  pub ret_ty: Option<Ty<'core>>,
+  pub body: Block<'core>,
+  pub locals: Counter<Local>,
+}
+
+new_idx!(pub OpaqueTypeId);
+#[derive(Debug, Clone)]
+pub struct OpaqueTypeDef<'core> {
+  pub span: Span,
+  pub def: DefId,
+  pub generics: GenericsId,
+  pub name: Ident<'core>,
+}
+
+new_idx!(pub TypeAliasId);
+#[derive(Debug, Clone)]
+pub struct TypeAliasDef<'core> {
+  pub span: Span,
+  pub def: DefId,
+  pub generics: GenericsId,
+  pub ty: Ty<'core>,
+}
+
+new_idx!(pub StructId);
+#[derive(Debug, Clone)]
 pub struct StructDef<'core> {
+  pub span: Span,
   pub def: DefId,
   pub generics: GenericsId,
   pub name: Ident<'core>,
@@ -266,136 +221,106 @@ pub struct StructDef<'core> {
   pub data: Ty<'core>,
 }
 
-#[derive(Debug)]
+new_idx!(pub EnumId);
+#[derive(Debug, Clone)]
 pub struct EnumDef<'core> {
+  pub span: Span,
   pub def: DefId,
   pub generics: GenericsId,
   pub name: Ident<'core>,
   pub variants: IdxVec<VariantId, EnumVariant<'core>>,
 }
 
-#[derive(Debug)]
+new_idx!(pub VariantId);
+#[derive(Debug, Clone)]
 pub struct EnumVariant<'core> {
+  pub span: Span,
   pub def: DefId,
   pub name: Ident<'core>,
   pub data: Option<Ty<'core>>,
 }
 
-#[derive(Default, Debug)]
-pub struct ChartCheckpoint {
-  pub defs: DefId,
-  pub values: ValueDefId,
-  pub types: TypeDefId,
-  pub patterns: PatternDefId,
-  pub traits: TraitDefId,
-  pub impls: ImplDefId,
+new_idx!(pub TraitId);
+#[derive(Debug, Clone)]
+pub struct TraitDef<'core> {
+  pub span: Span,
+  pub def: DefId,
+  pub name: Ident<'core>,
   pub generics: GenericsId,
-  pub structs: StructId,
-  pub enums: EnumId,
-  pub imports: ImportId,
+  pub subitem_generics: GenericsId,
+  pub consts: IdxVec<TraitConstId, TraitConst<'core>>,
+  pub fns: IdxVec<TraitFnId, TraitFn<'core>>,
 }
 
-impl<'core> Chart<'core> {
-  pub fn checkpoint(&self) -> ChartCheckpoint {
-    ChartCheckpoint {
-      defs: self.defs.next_index(),
-      values: self.values.next_index(),
-      types: self.types.next_index(),
-      patterns: self.patterns.next_index(),
-      traits: self.traits.next_index(),
-      impls: self.impls.next_index(),
-      generics: self.generics.next_index(),
-      structs: self.structs.next_index(),
-      enums: self.enums.next_index(),
-      imports: self.imports.next_index(),
-    }
-  }
-
-  pub fn revert(&mut self, checkpoint: &ChartCheckpoint) {
-    self.defs.truncate(checkpoint.defs.0);
-    self.values.truncate(checkpoint.values.0);
-    self.types.truncate(checkpoint.types.0);
-    self.patterns.truncate(checkpoint.patterns.0);
-    self.traits.truncate(checkpoint.traits.0);
-    self.impls.truncate(checkpoint.impls.0);
-    self.generics.truncate(checkpoint.generics.0);
-    self.structs.truncate(checkpoint.structs.0);
-    self.enums.truncate(checkpoint.enums.0);
-    self.imports.truncate(checkpoint.imports.0);
-
-    for def in self.defs.values_mut() {
-      def.revert(checkpoint);
-    }
-
-    self.builtins.revert(checkpoint);
-  }
+new_idx!(pub TraitConstId);
+#[derive(Debug, Clone)]
+pub struct TraitConst<'core> {
+  pub name: Ident<'core>,
+  pub ty: Ty<'core>,
 }
 
-impl<'core> Def<'core> {
-  fn revert(&mut self, checkpoint: &ChartCheckpoint) {
-    self.members.retain(|_, member| match member.kind {
-      MemberKind::Child(id) => id < checkpoint.defs,
-      MemberKind::Import(id) => id < checkpoint.imports,
-    });
-    revert_option(&mut self.value_def, checkpoint.values);
-    revert_option(&mut self.type_def, checkpoint.types);
-    revert_option(&mut self.pattern_def, checkpoint.patterns);
-    revert_option(&mut self.trait_def, checkpoint.traits);
-    revert_option(&mut self.impl_def, checkpoint.impls);
-  }
+new_idx!(pub TraitFnId);
+#[derive(Debug, Clone)]
+pub struct TraitFn<'core> {
+  pub method: bool,
+  pub name: Ident<'core>,
+  pub params: Vec<Pat<'core>>,
+  pub ret_ty: Option<Ty<'core>>,
 }
 
-impl Builtins {
-  fn revert(&mut self, checkpoint: &ChartCheckpoint) {
-    revert_option(&mut self.prelude, checkpoint.defs);
-    revert_option(&mut self.bool, checkpoint.types);
-    revert_option(&mut self.n32, checkpoint.types);
-    revert_option(&mut self.f32, checkpoint.types);
-    revert_option(&mut self.i32, checkpoint.types);
-    revert_option(&mut self.char, checkpoint.types);
-    revert_option(&mut self.io, checkpoint.types);
-    revert_option(&mut self.list, checkpoint.structs);
-    revert_option(&mut self.string, checkpoint.structs);
-    revert_option(&mut self.neg, checkpoint.values);
-    revert_option(&mut self.not, checkpoint.values);
-    revert_option(&mut self.bool_not, checkpoint.impls);
-    revert_option(&mut self.cast, checkpoint.values);
-    self.binary_ops.values_mut().for_each(|op| revert_option(op, checkpoint.values));
-    self.comparison_ops.values_mut().for_each(|op| revert_option(op, checkpoint.values));
-  }
+new_idx!(pub ImplId);
+#[derive(Debug, Clone)]
+pub struct ImplDef<'core> {
+  pub span: Span,
+  pub def: DefId,
+  pub generics: GenericsId,
+  pub trait_: Trait<'core>,
+  pub subitems: Vec<ImplSubitem<'core>>,
+  pub consts: IdxVec<TraitConstId, Result<ConcreteConstId, ErrorGuaranteed>>,
+  pub fns: IdxVec<TraitFnId, Result<ConcreteFnId, ErrorGuaranteed>>,
 }
 
-fn revert_option<T: Idx>(option: &mut Option<T>, checkpoint: T) {
-  if option.is_some_and(|id| id >= checkpoint) {
-    *option = None;
-  }
+#[derive(Debug, Clone)]
+pub struct ImplSubitem<'core> {
+  pub span: Span,
+  pub name: Ident<'core>,
+  pub kind: ImplSubitemKind,
 }
 
-impl<'core> TypeDefKind<'core> {
-  pub fn struct_id(&self) -> Option<StructId> {
-    if let TypeDefKind::Struct(struct_id) = self {
-      Some(*struct_id)
-    } else {
-      None
-    }
-  }
-
-  pub fn enum_id(&self) -> Option<EnumId> {
-    if let TypeDefKind::Enum(enum_id) = self {
-      Some(*enum_id)
-    } else {
-      None
-    }
-  }
+#[derive(Debug, Clone)]
+pub enum ImplSubitemKind {
+  Const(ConcreteConstId),
+  Fn(ConcreteFnId),
 }
 
 impl<'core> Chart<'core> {
   pub fn visible(&self, vis: DefId, from: DefId) -> bool {
     vis == from || vis < from && self.defs[from].ancestors.binary_search(&vis).is_ok()
   }
+
+  pub fn fn_is_method(&self, fn_kind: FnKind) -> bool {
+    match fn_kind {
+      FnKind::Concrete(fn_id) => self.concrete_fns[fn_id].method,
+      FnKind::Abstract(trait_id, fn_id) => self.traits[trait_id].fns[fn_id].method,
+    }
+  }
+
+  pub fn fn_generics(&self, fn_kind: FnKind) -> GenericsId {
+    match fn_kind {
+      FnKind::Concrete(fn_id) => self.concrete_fns[fn_id].generics,
+      FnKind::Abstract(trait_id, _) => self.traits[trait_id].subitem_generics,
+    }
+  }
+
+  pub fn const_generics(&self, const_kind: ConstKind) -> GenericsId {
+    match const_kind {
+      ConstKind::Concrete(const_id) => self.concrete_consts[const_id].generics,
+      ConstKind::Abstract(trait_id, _) => self.traits[trait_id].subitem_generics,
+    }
+  }
 }
 
-impl<'core> Import<'core> {
+impl<'core> ImportDef<'core> {
   pub fn resolved(&self) -> Option<DefId> {
     if let ImportState::Resolved(Ok(def_id)) = self.state {
       Some(def_id)
@@ -403,4 +328,12 @@ impl<'core> Import<'core> {
       None
     }
   }
+}
+
+impl DefId {
+  pub const ROOT: Self = Self(0);
+}
+
+impl GenericsId {
+  pub const NONE: Self = Self(0);
 }

--- a/vine/src/chart/checkpoint.rs
+++ b/vine/src/chart/checkpoint.rs
@@ -1,10 +1,10 @@
 use vine_util::idx::Idx;
 
-use crate::chart::ConstKind;
+use crate::chart::ConstId;
 
 use super::{
   Builtins, Chart, ConcreteConstId, ConcreteFnId, Def, DefId, DefImplKind, DefPatternKind,
-  DefTraitKind, DefTypeKind, DefValueKind, EnumId, FnKind, GenericsId, ImplId, ImportId,
+  DefTraitKind, DefTypeKind, DefValueKind, EnumId, FnId, GenericsId, ImplId, ImportId,
   MemberKind, OpaqueTypeId, StructId, TraitId, TypeAliasId,
 };
 
@@ -102,10 +102,10 @@ impl<'core> Def<'core> {
 impl DefValueKind {
   fn after(&self, checkpoint: &ChartCheckpoint) -> bool {
     match *self {
-      DefValueKind::Const(ConstKind::Concrete(const_id)) => const_id >= checkpoint.concrete_consts,
-      DefValueKind::Const(ConstKind::Abstract(trait_id, _)) => trait_id >= checkpoint.traits,
-      DefValueKind::Fn(FnKind::Concrete(fn_id)) => fn_id >= checkpoint.concrete_fns,
-      DefValueKind::Fn(FnKind::Abstract(trait_id, _)) => trait_id >= checkpoint.traits,
+      DefValueKind::Const(ConstId::Concrete(const_id)) => const_id >= checkpoint.concrete_consts,
+      DefValueKind::Const(ConstId::Abstract(trait_id, _)) => trait_id >= checkpoint.traits,
+      DefValueKind::Fn(FnId::Concrete(fn_id)) => fn_id >= checkpoint.concrete_fns,
+      DefValueKind::Fn(FnId::Abstract(trait_id, _)) => trait_id >= checkpoint.traits,
       DefValueKind::Struct(struct_id) => struct_id >= checkpoint.structs,
       DefValueKind::Enum(enum_id, _) => enum_id >= checkpoint.enums,
     }
@@ -205,10 +205,10 @@ fn revert_idx<T: Idx>(option: &mut Option<T>, checkpoint: T) {
   }
 }
 
-fn revert_fn(builtin: &mut Option<FnKind>, checkpoint: &ChartCheckpoint) {
+fn revert_fn(builtin: &mut Option<FnId>, checkpoint: &ChartCheckpoint) {
   match *builtin {
-    Some(FnKind::Concrete(fn_id)) if fn_id >= checkpoint.concrete_fns => *builtin = None,
-    Some(FnKind::Abstract(trait_id, _)) if trait_id >= checkpoint.traits => *builtin = None,
+    Some(FnId::Concrete(fn_id)) if fn_id >= checkpoint.concrete_fns => *builtin = None,
+    Some(FnId::Abstract(trait_id, _)) if trait_id >= checkpoint.traits => *builtin = None,
     _ => {}
   }
 }

--- a/vine/src/chart/checkpoint.rs
+++ b/vine/src/chart/checkpoint.rs
@@ -1,0 +1,214 @@
+use vine_util::idx::Idx;
+
+use crate::chart::ConstKind;
+
+use super::{
+  Builtins, Chart, ConcreteConstId, ConcreteFnId, Def, DefId, DefImplKind, DefPatternKind,
+  DefTraitKind, DefTypeKind, DefValueKind, EnumId, FnKind, GenericsId, ImplId, ImportId,
+  MemberKind, OpaqueTypeId, StructId, TraitId, TypeAliasId,
+};
+
+#[derive(Default, Debug)]
+pub struct ChartCheckpoint {
+  pub defs: DefId,
+  pub imports: ImportId,
+  pub generics: GenericsId,
+  pub concrete_consts: ConcreteConstId,
+  pub concrete_fns: ConcreteFnId,
+  pub opaque_types: OpaqueTypeId,
+  pub type_aliases: TypeAliasId,
+  pub structs: StructId,
+  pub enums: EnumId,
+  pub traits: TraitId,
+  pub impls: ImplId,
+}
+
+impl<'core> Chart<'core> {
+  pub fn checkpoint(&self) -> ChartCheckpoint {
+    ChartCheckpoint {
+      defs: self.defs.next_index(),
+      imports: self.imports.next_index(),
+      generics: self.generics.next_index(),
+      concrete_consts: self.concrete_consts.next_index(),
+      concrete_fns: self.concrete_fns.next_index(),
+      opaque_types: self.opaque_types.next_index(),
+      type_aliases: self.type_aliases.next_index(),
+      structs: self.structs.next_index(),
+      enums: self.enums.next_index(),
+      traits: self.traits.next_index(),
+      impls: self.impls.next_index(),
+    }
+  }
+
+  pub fn revert(&mut self, checkpoint: &ChartCheckpoint) {
+    let Chart {
+      defs,
+      imports,
+      generics,
+      concrete_consts: consts,
+      concrete_fns: fns,
+      opaque_types,
+      type_aliases,
+      structs,
+      enums,
+      traits,
+      impls,
+      builtins,
+    } = self;
+    defs.truncate(checkpoint.defs.0);
+    imports.truncate(checkpoint.imports.0);
+    generics.truncate(checkpoint.generics.0);
+    consts.truncate(checkpoint.concrete_consts.0);
+    fns.truncate(checkpoint.concrete_fns.0);
+    opaque_types.truncate(checkpoint.opaque_types.0);
+    type_aliases.truncate(checkpoint.type_aliases.0);
+    structs.truncate(checkpoint.structs.0);
+    enums.truncate(checkpoint.enums.0);
+    traits.truncate(checkpoint.traits.0);
+    impls.truncate(checkpoint.impls.0);
+
+    for def in defs.values_mut() {
+      def.revert(checkpoint);
+    }
+
+    builtins.revert(checkpoint);
+  }
+}
+
+impl<'core> Def<'core> {
+  fn revert(&mut self, checkpoint: &ChartCheckpoint) {
+    self.members.retain(|_, member| match member.kind {
+      MemberKind::Child(id) => id < checkpoint.defs,
+      MemberKind::Import(id) => id < checkpoint.imports,
+    });
+    if self.value_kind.is_some_and(|k| k.kind.after(checkpoint)) {
+      self.value_kind = None;
+    }
+    if self.type_kind.is_some_and(|k| k.kind.after(checkpoint)) {
+      self.type_kind = None;
+    }
+    if self.pattern_kind.is_some_and(|k| k.kind.after(checkpoint)) {
+      self.pattern_kind = None;
+    }
+    if self.trait_kind.is_some_and(|k| k.kind.after(checkpoint)) {
+      self.trait_kind = None;
+    }
+    if self.impl_kind.is_some_and(|k| k.kind.after(checkpoint)) {
+      self.impl_kind = None;
+    }
+  }
+}
+
+impl DefValueKind {
+  fn after(&self, checkpoint: &ChartCheckpoint) -> bool {
+    match *self {
+      DefValueKind::Const(ConstKind::Concrete(const_id)) => const_id >= checkpoint.concrete_consts,
+      DefValueKind::Const(ConstKind::Abstract(trait_id, _)) => trait_id >= checkpoint.traits,
+      DefValueKind::Fn(FnKind::Concrete(fn_id)) => fn_id >= checkpoint.concrete_fns,
+      DefValueKind::Fn(FnKind::Abstract(trait_id, _)) => trait_id >= checkpoint.traits,
+      DefValueKind::Struct(struct_id) => struct_id >= checkpoint.structs,
+      DefValueKind::Enum(enum_id, _) => enum_id >= checkpoint.enums,
+    }
+  }
+}
+
+impl DefTypeKind {
+  fn after(&self, checkpoint: &ChartCheckpoint) -> bool {
+    match *self {
+      DefTypeKind::Opaque(opaque_type_id) => opaque_type_id >= checkpoint.opaque_types,
+      DefTypeKind::Alias(type_alias_id) => type_alias_id >= checkpoint.type_aliases,
+      DefTypeKind::Struct(struct_id) => struct_id >= checkpoint.structs,
+      DefTypeKind::Enum(enum_id) => enum_id >= checkpoint.enums,
+    }
+  }
+}
+
+impl DefPatternKind {
+  fn after(&self, checkpoint: &ChartCheckpoint) -> bool {
+    match *self {
+      DefPatternKind::Struct(struct_id) => struct_id >= checkpoint.structs,
+      DefPatternKind::Enum(enum_id, _) => enum_id >= checkpoint.enums,
+    }
+  }
+}
+
+impl DefTraitKind {
+  fn after(&self, checkpoint: &ChartCheckpoint) -> bool {
+    match *self {
+      DefTraitKind::Trait(trait_id) => trait_id >= checkpoint.traits,
+    }
+  }
+}
+
+impl DefImplKind {
+  fn after(&self, checkpoint: &ChartCheckpoint) -> bool {
+    match *self {
+      DefImplKind::Impl(impl_id) => impl_id >= checkpoint.impls,
+    }
+  }
+}
+
+impl Builtins {
+  fn revert(&mut self, checkpoint: &ChartCheckpoint) {
+    let Builtins {
+      prelude,
+      bool,
+      n32,
+      i32,
+      f32,
+      char,
+      io,
+      list,
+      string,
+      result,
+      neg,
+      not,
+      bool_not,
+      cast,
+      binary_ops,
+      comparison_ops,
+      fork,
+      drop,
+      range,
+      bound_exclusive,
+      bound_inclusive,
+      bound_unbounded,
+    } = self;
+    revert_idx(prelude, checkpoint.defs);
+    revert_idx(bool, checkpoint.opaque_types);
+    revert_idx(n32, checkpoint.opaque_types);
+    revert_idx(f32, checkpoint.opaque_types);
+    revert_idx(i32, checkpoint.opaque_types);
+    revert_idx(char, checkpoint.opaque_types);
+    revert_idx(io, checkpoint.opaque_types);
+    revert_idx(list, checkpoint.structs);
+    revert_idx(string, checkpoint.structs);
+    revert_idx(result, checkpoint.enums);
+    revert_fn(neg, checkpoint);
+    revert_fn(not, checkpoint);
+    revert_idx(bool_not, checkpoint.impls);
+    revert_fn(cast, checkpoint);
+    binary_ops.values_mut().for_each(|op| revert_fn(op, checkpoint));
+    comparison_ops.values_mut().for_each(|op| revert_fn(op, checkpoint));
+    revert_idx(fork, checkpoint.traits);
+    revert_idx(drop, checkpoint.traits);
+    revert_idx(range, checkpoint.structs);
+    revert_idx(bound_exclusive, checkpoint.structs);
+    revert_idx(bound_inclusive, checkpoint.structs);
+    revert_idx(bound_unbounded, checkpoint.structs);
+  }
+}
+
+fn revert_idx<T: Idx>(option: &mut Option<T>, checkpoint: T) {
+  if option.is_some_and(|id| id >= checkpoint) {
+    *option = None;
+  }
+}
+
+fn revert_fn(builtin: &mut Option<FnKind>, checkpoint: &ChartCheckpoint) {
+  match *builtin {
+    Some(FnKind::Concrete(fn_id)) if fn_id >= checkpoint.concrete_fns => *builtin = None,
+    Some(FnKind::Abstract(trait_id, _)) if trait_id >= checkpoint.traits => *builtin = None,
+    _ => {}
+  }
+}

--- a/vine/src/chart/checkpoint.rs
+++ b/vine/src/chart/checkpoint.rs
@@ -4,8 +4,8 @@ use crate::chart::ConstId;
 
 use super::{
   Builtins, Chart, ConcreteConstId, ConcreteFnId, Def, DefId, DefImplKind, DefPatternKind,
-  DefTraitKind, DefTypeKind, DefValueKind, EnumId, FnId, GenericsId, ImplId, ImportId,
-  MemberKind, OpaqueTypeId, StructId, TraitId, TypeAliasId,
+  DefTraitKind, DefTypeKind, DefValueKind, EnumId, FnId, GenericsId, ImplId, ImportId, MemberKind,
+  OpaqueTypeId, StructId, TraitId, TypeAliasId,
 };
 
 #[derive(Default, Debug)]

--- a/vine/src/charter.rs
+++ b/vine/src/charter.rs
@@ -103,7 +103,7 @@ impl<'core> Charter<'core, '_> {
       ItemKind::Struct(struct_item) => {
         let def = self.chart_child(parent, struct_item.name, member_vis, true);
         let generics = self.chart_generics(def, struct_item.generics, false);
-        let data_vis = self.resolve_vis(def, struct_item.data_vis);
+        let data_vis = self.resolve_vis(parent, struct_item.data_vis);
         let struct_id = self.chart.structs.push(StructDef {
           span,
           def,

--- a/vine/src/charter.rs
+++ b/vine/src/charter.rs
@@ -80,7 +80,7 @@ impl<'core> Charter<'core, '_> {
           body,
           locals: Counter::default(),
         });
-        self.define_value(span, def, vis, DefValueKind::Fn(FnKind::Concrete(fn_id)));
+        self.define_value(span, def, vis, DefValueKind::Fn(FnId::Concrete(fn_id)));
         Some(def)
       }
 
@@ -96,7 +96,7 @@ impl<'core> Charter<'core, '_> {
           value,
           locals: Counter::default(),
         });
-        self.define_value(span, def, vis, DefValueKind::Const(ConstKind::Concrete(const_id)));
+        self.define_value(span, def, vis, DefValueKind::Const(ConstId::Concrete(const_id)));
         Some(def)
       }
 
@@ -191,7 +191,7 @@ impl<'core> Charter<'core, '_> {
               let trait_const_id =
                 consts.push(TraitConst { name: const_item.name, ty: const_item.ty });
               let def = self.chart_child(def, const_item.name, vis, true);
-              let kind = DefValueKind::Const(ConstKind::Abstract(trait_id, trait_const_id));
+              let kind = DefValueKind::Const(ConstId::Abstract(trait_id, trait_const_id));
               self.define_value(span, def, vis, kind);
               self.chart_attrs(Some(def), subitem.attrs);
             }
@@ -209,7 +209,7 @@ impl<'core> Charter<'core, '_> {
                 ret_ty: fn_item.ret,
               });
               let def = self.chart_child(def, fn_item.name, vis, true);
-              let kind = DefValueKind::Fn(FnKind::Abstract(trait_id, trait_fn_id));
+              let kind = DefValueKind::Fn(FnId::Abstract(trait_id, trait_fn_id));
               self.define_value(span, def, vis, kind);
               self.chart_attrs(Some(def), subitem.attrs);
             }
@@ -256,7 +256,7 @@ impl<'core> Charter<'core, '_> {
                 value,
                 locals: Counter::default(),
               });
-              self.define_value(span, def, vis, DefValueKind::Const(ConstKind::Concrete(const_id)));
+              self.define_value(span, def, vis, DefValueKind::Const(ConstId::Concrete(const_id)));
               self.chart_attrs(Some(def), subitem.attrs);
               subitems.push(ImplSubitem {
                 span,
@@ -280,7 +280,7 @@ impl<'core> Charter<'core, '_> {
                 body,
                 locals: Counter::default(),
               });
-              self.define_value(span, def, vis, DefValueKind::Fn(FnKind::Concrete(fn_id)));
+              self.define_value(span, def, vis, DefValueKind::Fn(FnId::Concrete(fn_id)));
               self.chart_attrs(Some(def), subitem.attrs);
               subitems.push(ImplSubitem {
                 span,
@@ -366,7 +366,7 @@ impl<'core> Charter<'core, '_> {
       Some(WithVis { kind: DefTypeKind::Enum(id), .. }) => Some(id),
       _ => None,
     };
-    let fn_kind = match def.value_kind {
+    let fn_id = match def.value_kind {
       Some(WithVis { kind: DefValueKind::Fn(kind), .. }) => Some(kind),
       _ => None,
     };
@@ -391,14 +391,14 @@ impl<'core> Charter<'core, '_> {
       Builtin::List => set(&mut builtins.list, struct_id),
       Builtin::String => set(&mut builtins.string, struct_id),
       Builtin::Result => set(&mut builtins.result, enum_id),
-      Builtin::Neg => set(&mut builtins.neg, fn_kind),
-      Builtin::Not => set(&mut builtins.not, fn_kind),
-      Builtin::Cast => set(&mut builtins.cast, fn_kind),
+      Builtin::Neg => set(&mut builtins.neg, fn_id),
+      Builtin::Not => set(&mut builtins.not, fn_id),
+      Builtin::Cast => set(&mut builtins.cast, fn_id),
       Builtin::Fork => set(&mut builtins.fork, trait_id),
       Builtin::Drop => set(&mut builtins.drop, trait_id),
       Builtin::BoolNot => set(&mut builtins.bool_not, impl_id),
-      Builtin::BinaryOp(op) => set(builtins.binary_ops.entry(op).or_default(), fn_kind),
-      Builtin::ComparisonOp(op) => set(builtins.comparison_ops.entry(op).or_default(), fn_kind),
+      Builtin::BinaryOp(op) => set(builtins.binary_ops.entry(op).or_default(), fn_id),
+      Builtin::ComparisonOp(op) => set(builtins.comparison_ops.entry(op).or_default(), fn_id),
       Builtin::Range => set(&mut builtins.range, struct_id),
       Builtin::BoundUnbounded => set(&mut builtins.bound_unbounded, struct_id),
       Builtin::BoundExclusive => set(&mut builtins.bound_exclusive, struct_id),

--- a/vine/src/checker/check_pat.rs
+++ b/vine/src/checker/check_pat.rs
@@ -41,18 +41,15 @@ impl<'core> Checker<'core, '_> {
       (PatKind::Struct(struct_id, generics, data), _) => {
         let type_params =
           self.check_generics(generics, self.chart.structs[*struct_id].generics, true);
-        let data_ty =
-          self.types.import(&self.sigs.structs[*struct_id], Some(&type_params), |t, sig| {
-            t.transfer(sig.data)
-          });
+        let data_ty = self.types.import(&self.sigs.structs[*struct_id], Some(&type_params)).data;
         self.check_pat_type(data, form, refutable, data_ty);
         self.types.new(TypeKind::Struct(*struct_id, type_params))
       }
       (PatKind::Enum(enum_id, variant, generics, data), _) => {
         let type_params = self.check_generics(generics, self.chart.enums[*enum_id].generics, true);
         let data_ty =
-          self.types.import(&self.sigs.enums[*enum_id], Some(&type_params), |t, sig| {
-            Some(t.transfer(sig.variant_data[*variant]?))
+          self.types.import_with(&self.sigs.enums[*enum_id], Some(&type_params), |t, sig| {
+            Some(t.transfer(&sig.variant_data[*variant]?))
           });
         match (data, data_ty) {
           (None, None) => {}

--- a/vine/src/diag.rs
+++ b/vine/src/diag.rs
@@ -104,8 +104,8 @@ diags! {
     ["invalid method; function type `{ty}` takes no parameters"]
   ExpectedTypeFound { expected: String, found: String }
     ["expected type `{expected}`; found `{found}`"]
-  PathNoAssociated { kind: &'static str, path: &'core str }
-    ["no {kind} associated with `{path}`"]
+  PathNoAssociated { desc: &'static str, path: &'core str }
+    ["no {desc} associated with `{path}`"]
   BadGenericCount { path: &'core str, expected: usize, got: usize, kind: &'static str }
     ["`{path}` expects {expected} {kind} parameter{}; was passed {got}", plural(*expected, "s", "")]
   MissingTupleField { ty: String, i: usize }
@@ -146,14 +146,8 @@ diags! {
     ["`{module}::{ident}` is only visible within `{vis}`"]
   BadVis
     ["invalid visibility; expected the name of an ancestor module"]
-  ValueInvisible { path: &'core str, vis: &'core str }
-    ["the value `{path}` is only visible within `{vis}`"]
-  TypeInvisible { path: &'core str, vis: &'core str }
-    ["the type `{path}` is only visible within `{vis}`"]
-  PatInvisible { path: &'core str, vis: &'core str }
-    ["the pattern `{path}` is only visible within `{vis}`"]
-  ImplInvisible { path: &'core str, vis: &'core str }
-    ["the impl `{path}` is only visible within `{vis}`"]
+  InvisibleAssociated { desc: &'static str, path: &'core str, vis: &'core str }
+    ["the {desc} `{path}` is only visible within `{vis}`"]
   VisibleSubitem
     ["subitems must be private"]
   DuplicateKey
@@ -182,8 +176,10 @@ diags! {
     ["no item `{name}` exists in trait"]
   UnspecifiedImpl
     ["impl parameters must be explicitly specified"]
-  IncompleteImpl
-    ["not all trait items implemented"]
+  IncompleteImpl { name: Ident<'core> }
+    ["missing implementation of `{name}`"]
+  WrongImplSubitemKind { expected: &'static str }
+    ["expected a {expected}"]
   DuplicateTypeParam
     ["duplicate type param"]
   DuplicateImplParam

--- a/vine/src/emitter.rs
+++ b/vine/src/emitter.rs
@@ -8,7 +8,7 @@ use crate::{
   ast::Local,
   chart::{Chart, ConcreteConstId, ConcreteFnId, EnumDef, VariantId},
   diag::ErrorGuaranteed,
-  specializer::{ProtoKind, Spec, SpecId, Specializations},
+  specializer::{ProtoId, Spec, SpecId, Specializations},
   vir::{
     Header, Interface, InterfaceId, InterfaceKind, Invocation, Port, Stage, StageId, Step,
     Transfer, VIR,
@@ -36,8 +36,8 @@ impl<'core, 'a> Emitter<'core, 'a> {
     let spec = self.specs.specs[spec].as_ref().unwrap();
     let path = self.chart.defs[spec.def].path;
     let vir = match spec.proto {
-      ProtoKind::Const(id) => &const_vir[id],
-      ProtoKind::Fn(id) => &fn_vir[id],
+      ProtoId::Const(id) => &const_vir[id],
+      ProtoId::Fn(id) => &fn_vir[id],
     };
     self.emit_vir(vir, path, spec)
   }

--- a/vine/src/emitter.rs
+++ b/vine/src/emitter.rs
@@ -6,8 +6,9 @@ use vine_util::idx::{Counter, IdxVec};
 use crate::{
   analyzer::usage::Usage,
   ast::Local,
-  chart::{Chart, EnumDef, ValueDefId, VariantId},
-  specializer::{Spec, SpecId, Specializations},
+  chart::{Chart, ConcreteConstId, ConcreteFnId, EnumDef, VariantId},
+  diag::ErrorGuaranteed,
+  specializer::{ProtoKind, Spec, SpecId, Specializations},
   vir::{
     Header, Interface, InterfaceId, InterfaceKind, Invocation, Port, Stage, StageId, Step,
     Transfer, VIR,
@@ -26,12 +27,18 @@ impl<'core, 'a> Emitter<'core, 'a> {
     Emitter { nets: Nets::default(), chart, specs, dup_labels: Counter::default() }
   }
 
-  pub fn emit_spec(&mut self, spec: SpecId, vir: &IdxVec<ValueDefId, Option<VIR>>) {
+  pub fn emit_spec(
+    &mut self,
+    spec: SpecId,
+    const_vir: &IdxVec<ConcreteConstId, VIR>,
+    fn_vir: &IdxVec<ConcreteFnId, VIR>,
+  ) {
     let spec = self.specs.specs[spec].as_ref().unwrap();
-    let value_id = spec.value;
-    let value = &self.chart.values[value_id];
-    let Some(vir) = &vir[value_id] else { return };
-    let path = self.chart.defs[value.def].path;
+    let path = self.chart.defs[spec.def].path;
+    let vir = match spec.proto {
+      ProtoKind::Const(id) => &const_vir[id],
+      ProtoKind::Fn(id) => &fn_vir[id],
+    };
     self.emit_vir(vir, path, spec)
   }
 
@@ -334,17 +341,26 @@ impl<'core, 'a> VirEmitter<'core, 'a> {
       Port::N32(n) => Tree::N32(*n),
       Port::F32(f) => Tree::F32(*f),
       Port::Wire(w) => Tree::Var(format!("w{}", wire_offset + w.0)),
-      Port::Def(id) => Tree::Global(chart.defs[chart.values[*id].def].path.into()),
-      Port::Rel(rel) => {
-        let spec_id = spec.rels[*rel];
-        let spec = specs.specs[spec_id].as_ref().unwrap();
-        let path = chart.defs[chart.values[spec.value].def].path;
-        Tree::Global(if spec.singular {
-          path.to_string()
-        } else {
-          format!("{}::{}", path, spec.index)
-        })
-      }
+      Port::ConstRel(rel) => Self::_emit_rel_spec(specs, chart, spec.rels.consts[*rel]),
+      Port::FnRel(rel) => Self::_emit_rel_spec(specs, chart, spec.rels.fns[*rel]),
+    }
+  }
+
+  fn _emit_rel_spec(
+    specs: &Specializations,
+    chart: &Chart,
+    spec_id: Result<SpecId, ErrorGuaranteed>,
+  ) -> Tree {
+    if let Ok(spec_id) = spec_id {
+      let spec = specs.specs[spec_id].as_ref().unwrap();
+      let path = chart.defs[spec.def].path;
+      Tree::Global(if spec.singular {
+        path.to_string()
+      } else {
+        format!("{}::{}", path, spec.index)
+      })
+    } else {
+      Tree::Erase
     }
   }
 

--- a/vine/src/emitter.rs
+++ b/vine/src/emitter.rs
@@ -8,7 +8,7 @@ use crate::{
   ast::Local,
   chart::{Chart, ConcreteConstId, ConcreteFnId, EnumDef, VariantId},
   diag::ErrorGuaranteed,
-  specializer::{ProtoId, Spec, SpecId, Specializations},
+  specializer::{Spec, SpecId, Specializations, TemplateId},
   vir::{
     Header, Interface, InterfaceId, InterfaceKind, Invocation, Port, Stage, StageId, Step,
     Transfer, VIR,
@@ -35,9 +35,9 @@ impl<'core, 'a> Emitter<'core, 'a> {
   ) {
     let spec = self.specs.specs[spec].as_ref().unwrap();
     let path = self.chart.defs[spec.def].path;
-    let vir = match spec.proto {
-      ProtoId::Const(id) => &const_vir[id],
-      ProtoId::Fn(id) => &fn_vir[id],
+    let vir = match spec.template {
+      TemplateId::Const(id) => &const_vir[id],
+      TemplateId::Fn(id) => &fn_vir[id],
     };
     self.emit_vir(vir, path, spec)
   }

--- a/vine/src/finder.rs
+++ b/vine/src/finder.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeSet, HashSet};
 use crate::{
   ast::{GenericArgs, Ident, Impl, ImplKind, Span},
   chart::{
-    Chart, Def, DefId, DefImplKind, DefTraitKind, DefValueKind, FnKind, GenericsId, ImplId,
+    Chart, Def, DefId, DefImplKind, DefTraitKind, DefValueKind, FnId, GenericsId, ImplId,
     MemberKind, WithVis,
   },
   core::Core,
@@ -49,7 +49,7 @@ impl<'core, 'a> Finder<'core, 'a> {
     types: &Types<'core>,
     receiver: Type,
     name: Ident,
-  ) -> Vec<(FnKind, TypeCtx<'core, Vec<Type>>)> {
+  ) -> Vec<(FnId, TypeCtx<'core, Vec<Type>>)> {
     let mut found = Vec::new();
 
     for candidate in self.find_method_candidates(types, receiver, name) {
@@ -79,7 +79,7 @@ impl<'core, 'a> Finder<'core, 'a> {
     types: &Types<'core>,
     receiver: Type,
     name: Ident,
-  ) -> BTreeSet<FnKind> {
+  ) -> BTreeSet<FnId> {
     let mut candidates = BTreeSet::new();
     let search = &mut CandidateSearch {
       modules: HashSet::new(),

--- a/vine/src/finder.rs
+++ b/vine/src/finder.rs
@@ -2,7 +2,10 @@ use std::collections::{BTreeSet, HashSet};
 
 use crate::{
   ast::{GenericArgs, Ident, Impl, ImplKind, Span},
-  chart::{Chart, Def, DefId, GenericsId, ImplDefId, MemberKind, ValueDefId},
+  chart::{
+    Chart, Def, DefId, DefImplKind, DefTraitKind, DefValueKind, FnKind, GenericsId, ImplId,
+    MemberKind, WithVis,
+  },
   core::Core,
   diag::{Diag, ErrorGuaranteed},
   signatures::Signatures,
@@ -46,26 +49,24 @@ impl<'core, 'a> Finder<'core, 'a> {
     types: &Types<'core>,
     receiver: Type,
     name: Ident,
-  ) -> Vec<(ValueDefId, TypeCtx<'core, Vec<Type>>)> {
+  ) -> Vec<(FnKind, TypeCtx<'core, Vec<Type>>)> {
     let mut found = Vec::new();
 
     for candidate in self.find_method_candidates(types, receiver, name) {
       let mut types = types.clone();
-      let generics = self.chart.values[candidate].generics;
-      let type_params = (0..self.chart.generics[generics].type_params.len())
-        .map(|_| types.new_var(self.span))
-        .collect::<Vec<_>>();
-      let candidate_ty =
-        types.import(&self.sigs.values[candidate], Some(&type_params), |t, sig| t.transfer(sig.ty));
-      if let Some((Inverted(false), TypeKind::Fn(params, _))) = types.kind(candidate_ty) {
-        if let [candidate_receiver, ..] = **params {
-          let candidate_receiver = match types.kind(candidate_receiver) {
-            Some((Inverted(false), TypeKind::Ref(t))) => *t,
-            _ => candidate_receiver,
-          };
-          if types.unify(receiver, candidate_receiver).is_success() {
-            found.push((candidate, TypeCtx { types, inner: type_params }));
-          }
+      let generics = self.chart.fn_generics(candidate);
+      let type_params = types.new_vars(self.span, self.chart.generics[generics].type_params.len());
+      let candidate_receiver =
+        types.import_with(self.sigs.fn_sig(candidate), Some(&type_params), |t, sig| {
+          sig.params.first().map(|&ty| t.transfer(&ty))
+        });
+      if let Some(candidate_receiver) = candidate_receiver {
+        let candidate_receiver = match types.kind(candidate_receiver) {
+          Some((Inverted(false), TypeKind::Ref(t))) => *t,
+          _ => candidate_receiver,
+        };
+        if types.unify(receiver, candidate_receiver).is_success() {
+          found.push((candidate, TypeCtx { types, inner: type_params }));
         }
       }
     }
@@ -78,16 +79,15 @@ impl<'core, 'a> Finder<'core, 'a> {
     types: &Types<'core>,
     receiver: Type,
     name: Ident,
-  ) -> BTreeSet<ValueDefId> {
+  ) -> BTreeSet<FnKind> {
     let mut candidates = BTreeSet::new();
     let search = &mut CandidateSearch {
       modules: HashSet::new(),
-      consider_candidate: |def: &Def| {
+      consider_candidate: |self_: &Self, def: &Def| {
         if def.name == name {
-          if let Some(value_id) = def.value_def {
-            let value = &self.chart.values[value_id];
-            if value.method {
-              candidates.insert(value_id);
+          if let Some(WithVis { kind: DefValueKind::Fn(fn_kind), vis }) = def.value_kind {
+            if self_.chart.visible(vis, self_.source) && self_.chart.fn_is_method(fn_kind) {
+              candidates.insert(fn_kind);
             }
           }
         }
@@ -105,8 +105,7 @@ impl<'core, 'a> Finder<'core, 'a> {
 
   pub fn find_impl(&mut self, types: &mut Types<'core>, query: &ImplType) -> Impl<'core> {
     let span = self.span;
-    let TypeCtx { types: sub_types, inner: sub_query } =
-      types.export(|t| t.transfer_impl_type(query));
+    let TypeCtx { types: sub_types, inner: sub_query } = types.export(|t| t.transfer(query));
 
     let show_ty = || types.show_impl_type(self.chart, query);
     let Ok(mut results) = self._find_impl(&sub_types, &sub_query) else {
@@ -123,7 +122,7 @@ impl<'core, 'a> Finder<'core, 'a> {
 
     let result = results.pop().unwrap();
 
-    let result_ty = types.import(&result, None, |t, _| t.transfer_impl_type(&sub_query));
+    let result_ty = types.import_with(&result, None, |t, _| t.transfer(&sub_query));
     let unify_result = types.unify_impl_type(query, &result_ty);
     assert!(!unify_result.is_failure());
 
@@ -143,7 +142,7 @@ impl<'core, 'a> Finder<'core, 'a> {
     for (i, ty) in generics.inner.impl_params.iter().enumerate() {
       if query.approx_eq(ty) {
         let mut types = types.clone();
-        let ty = types.import(generics, None, |t, _| t.transfer_impl_type(ty));
+        let ty = types.import_with(generics, None, |t, _| t.transfer(ty));
         if types.unify_impl_type(&ty, query).is_success() {
           found.push(TypeCtx { types, inner: Impl { span: self.span, kind: ImplKind::Param(i) } });
         }
@@ -156,13 +155,9 @@ impl<'core, 'a> Finder<'core, 'a> {
       let type_params = (0..self.chart.generics[generics].type_params.len())
         .map(|_| types.new_var(self.span))
         .collect::<Vec<_>>();
-      let ty = types.import(&self.sigs.impls[candidate], Some(&type_params), |t, sig| {
-        t.transfer_impl_type(&sig.ty)
-      });
+      let ty = types.import(&self.sigs.impls[candidate], Some(&type_params)).ty;
       if types.unify_impl_type(&ty, query).is_success() {
-        let queries = types.import(&self.sigs.generics[generics], Some(&type_params), |t, sig| {
-          sig.impl_params.iter().map(|ty| t.transfer_impl_type(ty)).collect::<Vec<_>>()
-        });
+        let queries = types.import(&self.sigs.generics[generics], Some(&type_params)).impl_params;
         let results = self.find_subimpls(types, &queries)?;
         for result in results {
           let mut impls = result.inner;
@@ -204,19 +199,17 @@ impl<'core, 'a> Finder<'core, 'a> {
     Ok(found)
   }
 
-  fn find_impl_candidates(
-    &mut self,
-    types: &Types<'core>,
-    query: &ImplType,
-  ) -> BTreeSet<ImplDefId> {
+  fn find_impl_candidates(&mut self, types: &Types<'core>, query: &ImplType) -> BTreeSet<ImplId> {
     let mut candidates = BTreeSet::new();
     let search = &mut CandidateSearch {
       modules: HashSet::new(),
-      consider_candidate: |def: &Def| {
-        if let Some(impl_id) = def.impl_def {
-          let impl_sig = &self.sigs.impls[impl_id];
-          if impl_sig.inner.ty.approx_eq(query) {
-            candidates.insert(impl_id);
+      consider_candidate: |self_: &Self, def: &Def| {
+        if let Some(WithVis { vis, kind: DefImplKind::Impl(impl_id) }) = def.impl_kind {
+          if self_.chart.visible(vis, self_.source) {
+            let impl_sig = &self_.sigs.impls[impl_id];
+            if impl_sig.inner.ty.approx_eq(query) {
+              candidates.insert(impl_id);
+            }
           }
         }
       },
@@ -236,7 +229,7 @@ impl<'core, 'a> Finder<'core, 'a> {
     candidates
   }
 
-  fn find_general_candidates(&mut self, search: &mut CandidateSearch<impl FnMut(&Def<'_>)>) {
+  fn find_general_candidates(&mut self, search: &mut CandidateSearch<impl FnMut(&Self, &Def<'_>)>) {
     for &ancestor in &self.chart.defs[self.source].ancestors {
       self.find_candidates_within(ancestor, search);
     }
@@ -245,7 +238,7 @@ impl<'core, 'a> Finder<'core, 'a> {
     }
   }
 
-  fn find_candidates_within<F: FnMut(&Def)>(
+  fn find_candidates_within<F: FnMut(&Self, &Def)>(
     &mut self,
     mod_id: DefId,
     search: &mut CandidateSearch<F>,
@@ -267,24 +260,21 @@ impl<'core, 'a> Finder<'core, 'a> {
 
       let def = &self.chart.defs[def_id];
 
-      (search.consider_candidate)(def);
+      (search.consider_candidate)(self, def);
 
-      if let Some(trait_id) = def.trait_def {
-        let trait_def = &self.chart.traits[trait_id];
-        if self.chart.visible(trait_def.vis, self.source) {
+      if let Some(WithVis { kind: DefTraitKind::Trait(trait_id), vis }) = def.trait_kind {
+        if self.chart.visible(vis, self.source) {
+          let trait_def = &self.chart.traits[trait_id];
           self.find_candidates_within(trait_def.def, search);
         }
       }
 
-      if let Some(impl_id) = def.impl_def {
-        let impl_def = &self.chart.impls[impl_id];
-        if self.chart.visible(impl_def.vis, self.source) {
+      if let Some(WithVis { kind: DefImplKind::Impl(impl_id), vis }) = def.impl_kind {
+        if self.chart.visible(vis, self.source) {
           let impl_sig = &self.sigs.impls[impl_id];
           if let ImplType::Trait(trait_id, _) = impl_sig.inner.ty {
             let trait_def = &self.chart.traits[trait_id];
-            if self.chart.visible(trait_def.vis, self.source) {
-              self.find_candidates_within(trait_def.def, search);
-            }
+            self.find_candidates_within(trait_def.def, search);
           }
         }
       }

--- a/vine/src/fmt.rs
+++ b/vine/src/fmt.rs
@@ -597,6 +597,7 @@ impl<'core: 'src, 'src> Formatter<'src> {
 
   fn fmt_ty(&self, ty: &Ty<'core>) -> Doc<'src> {
     match &ty.kind {
+      TyKind::Error(_) | TyKind![resolved] => unreachable!(),
       TyKind::Hole => Doc("_"),
       TyKind::Paren(p) => Doc::paren(self.fmt_ty(p)),
       TyKind::Fn(a, r) => Doc::concat([
@@ -611,7 +612,6 @@ impl<'core: 'src, 'src> Formatter<'src> {
       TyKind::Object(o) => Doc::brace_comma_space(
         o.iter().map(|(k, t)| Doc::concat([Doc(k.ident), Doc(": "), self.fmt_ty(t)])),
       ),
-      TyKind::Param(_) | TyKind::Def(..) | TyKind::Error(_) => unreachable!(),
     }
   }
 

--- a/vine/src/repl.rs
+++ b/vine/src/repl.rs
@@ -29,7 +29,7 @@ use crate::{
   normalizer::normalize,
   parser::VineParser,
   resolver::Resolver,
-  specializer::{ProtoId, Spec, SpecRels, Specializer},
+  specializer::{Spec, SpecRels, Specializer, TemplateId},
   types::{Type, TypeKind, Types},
   vir::{InterfaceId, StageId},
   visit::VisitMut,
@@ -215,7 +215,7 @@ impl<'core, 'ctx, 'ivm, 'ext> Repl<'core, 'ctx, 'ivm, 'ext> {
           self.name,
           &Spec {
             def: DefId(0),
-            proto: ProtoId::Const(ConcreteConstId(0)),
+            template: TemplateId::Const(ConcreteConstId(0)),
             index: 0,
             singular: true,
             rels: self.rels.take().unwrap(),

--- a/vine/src/repl.rs
+++ b/vine/src/repl.rs
@@ -29,7 +29,7 @@ use crate::{
   normalizer::normalize,
   parser::VineParser,
   resolver::Resolver,
-  specializer::{ProtoKind, Spec, SpecRels, Specializer},
+  specializer::{ProtoId, Spec, SpecRels, Specializer},
   types::{Type, TypeKind, Types},
   vir::{InterfaceId, StageId},
   visit::VisitMut,
@@ -215,7 +215,7 @@ impl<'core, 'ctx, 'ivm, 'ext> Repl<'core, 'ctx, 'ivm, 'ext> {
           self.name,
           &Spec {
             def: DefId(0),
-            proto: ProtoKind::Const(ConcreteConstId(0)),
+            proto: ProtoId::Const(ConcreteConstId(0)),
             index: 0,
             singular: true,
             rels: self.rels.take().unwrap(),

--- a/vine/src/repl.rs
+++ b/vine/src/repl.rs
@@ -1,7 +1,7 @@
 use std::{
   collections::{BTreeMap, HashMap},
   fmt::Write,
-  mem::{replace, take},
+  mem::replace,
   path::PathBuf,
 };
 
@@ -11,14 +11,14 @@ use ivm::{
 };
 use ivy::{ast::Tree, host::Host};
 use vine_util::{
-  idx::{Counter, IdxVec, IntMap},
+  idx::{Counter, IntMap},
   parser::{Parser, ParserState},
 };
 
 use crate::{
   analyzer::{analyze, usage::Usage},
   ast::{Block, Ident, Local, Span, Stmt},
-  chart::{DefId, ValueDefId, VariantId},
+  chart::{ConcreteConstId, DefId, VariantId},
   charter::{Charter, ExtractItems},
   checker::Checker,
   compiler::{Compiler, Hooks},
@@ -29,7 +29,7 @@ use crate::{
   normalizer::normalize,
   parser::VineParser,
   resolver::Resolver,
-  specializer::{RelId, Spec, SpecId, Specializer},
+  specializer::{ProtoKind, Spec, SpecRels, Specializer},
   types::{Type, TypeKind, Types},
   vir::{InterfaceId, StageId},
   visit::VisitMut,
@@ -134,7 +134,7 @@ impl<'core, 'ctx, 'ivm, 'ext> Repl<'core, 'ctx, 'ivm, 'ext> {
       ty: &mut ty,
       local_count: &mut self.local_count,
       line: &mut self.line,
-      rels: IdxVec::new(),
+      rels: None,
       name: &mut name,
     })?;
 
@@ -149,7 +149,7 @@ impl<'core, 'ctx, 'ivm, 'ext> Repl<'core, 'ctx, 'ivm, 'ext> {
       ty: &'a mut Type,
       local_count: &'a mut Counter<Local>,
       line: &'a mut usize,
-      rels: IdxVec<RelId, SpecId>,
+      rels: Option<SpecRels>,
       name: &'a mut String,
     }
 
@@ -190,7 +190,7 @@ impl<'core, 'ctx, 'ivm, 'ext> Repl<'core, 'ctx, 'ivm, 'ext> {
       }
 
       fn specialize(&mut self, specializer: &mut Specializer<'core, '_>) {
-        self.rels = specializer._specialize_custom(&mut *self.block);
+        self.rels = Some(specializer._specialize_custom(&mut *self.block));
       }
 
       fn emit(&mut self, distiller: &mut Distiller<'core, '_>, emitter: &mut Emitter<'core, '_>) {
@@ -213,7 +213,13 @@ impl<'core, 'ctx, 'ivm, 'ext> Repl<'core, 'ctx, 'ivm, 'ext> {
         emitter.emit_vir(
           &vir,
           self.name,
-          &Spec { value: ValueDefId(0), index: 0, singular: true, rels: take(&mut self.rels) },
+          &Spec {
+            def: DefId(0),
+            proto: ProtoKind::Const(ConcreteConstId(0)),
+            index: 0,
+            singular: true,
+            rels: self.rels.take().unwrap(),
+          },
         );
       }
     }
@@ -344,10 +350,7 @@ impl<'core, 'ctx, 'ivm, 'ext> Repl<'core, 'ctx, 'ivm, 'ext> {
       (TypeKind::Struct(struct_id, args), tree) => {
         let name = self.compiler.chart.structs[*struct_id].name;
         let args = args.clone();
-        let data =
-          self.types.import(&self.compiler.sigs.structs[*struct_id], Some(&args), |t, sig| {
-            t.transfer(sig.data)
-          });
+        let data = self.types.import(&self.compiler.sigs.structs[*struct_id], Some(&args)).data;
         let data = self.show(data, tree);
         if data.starts_with("(") {
           format!("{name}{}", data)
@@ -380,9 +383,10 @@ impl<'core, 'ctx, 'ivm, 'ext> Repl<'core, 'ctx, 'ivm, 'ext> {
         let name = variant.name;
         let enum_id = *enum_id;
         let args = args.clone();
-        let data = self.types.import(&self.compiler.sigs.enums[enum_id], Some(&args), |t, sig| {
-          Some(t.transfer(sig.variant_data[variant_id]?))
-        });
+        let data =
+          self.types.import_with(&self.compiler.sigs.enums[enum_id], Some(&args), |t, sig| {
+            Some(t.transfer(&sig.variant_data[variant_id]?))
+          });
         let data = if let Some(ty) = data {
           let Tree::Comb(c, l, r) = tree else { None? };
           let "enum" = &**c else { None? };

--- a/vine/src/signatures.rs
+++ b/vine/src/signatures.rs
@@ -1,51 +1,44 @@
-use std::collections::HashMap;
-
 use vine_util::idx::IdxVec;
 
 use crate::{
-  ast::Ident,
   chart::{
-    ChartCheckpoint, EnumId, GenericsId, ImplDefId, StructId, SubitemId, TraitDefId, TypeDefId,
-    ValueDefId, VariantId,
+    checkpoint::ChartCheckpoint, ConcreteConstId, ConcreteFnId, ConstKind, EnumId, FnKind,
+    GenericsId, ImplId, StructId, TraitConstId, TraitFnId, TraitId, TypeAliasId, VariantId,
   },
-  types::{ImplType, Type, TypeCtx},
+  types::{ImplType, TransferTypes, Type, TypeCtx, TypeTransfer},
 };
 
 #[derive(Debug, Default)]
 pub struct Signatures<'core> {
-  pub values: IdxVec<ValueDefId, TypeCtx<'core, ValueSig>>,
-  pub types: IdxVec<TypeDefId, Option<TypeCtx<'core, TypeSig>>>,
-  pub traits: IdxVec<TraitDefId, TypeCtx<'core, TraitSig<'core>>>,
-  pub impls: IdxVec<ImplDefId, TypeCtx<'core, ImplSig>>,
   pub generics: IdxVec<GenericsId, TypeCtx<'core, GenericsSig>>,
+  pub concrete_consts: IdxVec<ConcreteConstId, TypeCtx<'core, ConstSig>>,
+  pub concrete_fns: IdxVec<ConcreteFnId, TypeCtx<'core, FnSig>>,
+  pub type_aliases: IdxVec<TypeAliasId, Option<TypeCtx<'core, TypeAliasSig>>>,
   pub structs: IdxVec<StructId, TypeCtx<'core, StructSig>>,
   pub enums: IdxVec<EnumId, TypeCtx<'core, EnumSig>>,
-}
-
-#[derive(Debug)]
-pub struct ValueSig {
-  pub ty: Type,
-}
-
-#[derive(Debug)]
-pub struct TypeSig {
-  pub ty: Type,
-}
-
-#[derive(Debug)]
-pub struct TraitSig<'core> {
-  pub lookup: HashMap<Ident<'core>, SubitemId>,
-  pub subitem_types: IdxVec<SubitemId, Type>,
-}
-
-#[derive(Debug)]
-pub struct ImplSig {
-  pub ty: ImplType,
+  pub impls: IdxVec<ImplId, TypeCtx<'core, ImplSig>>,
+  pub traits: IdxVec<TraitId, TraitSig<'core>>,
 }
 
 #[derive(Debug)]
 pub struct GenericsSig {
   pub impl_params: Vec<ImplType>,
+}
+
+#[derive(Debug)]
+pub struct ConstSig {
+  pub ty: Type,
+}
+
+#[derive(Debug)]
+pub struct FnSig {
+  pub params: Vec<Type>,
+  pub ret_ty: Type,
+}
+
+#[derive(Debug)]
+pub struct TypeAliasSig {
+  pub ty: Type,
 }
 
 #[derive(Debug)]
@@ -58,14 +51,86 @@ pub struct EnumSig {
   pub variant_data: IdxVec<VariantId, Option<Type>>,
 }
 
+#[derive(Debug)]
+pub struct TraitSig<'core> {
+  pub consts: IdxVec<TraitConstId, TypeCtx<'core, ConstSig>>,
+  pub fns: IdxVec<TraitFnId, TypeCtx<'core, FnSig>>,
+}
+
+#[derive(Debug)]
+pub struct ImplSig {
+  pub ty: ImplType,
+}
+
 impl<'core> Signatures<'core> {
+  pub fn const_sig(&self, const_kind: ConstKind) -> &TypeCtx<'core, ConstSig> {
+    match const_kind {
+      ConstKind::Concrete(const_id) => &self.concrete_consts[const_id],
+      ConstKind::Abstract(trait_id, const_id) => &self.traits[trait_id].consts[const_id],
+    }
+  }
+
+  pub fn fn_sig(&self, fn_kind: FnKind) -> &TypeCtx<'core, FnSig> {
+    match fn_kind {
+      FnKind::Concrete(fn_id) => &self.concrete_fns[fn_id],
+      FnKind::Abstract(trait_id, fn_id) => &self.traits[trait_id].fns[fn_id],
+    }
+  }
+
   pub fn revert(&mut self, checkpoint: &ChartCheckpoint) {
-    self.values.truncate(checkpoint.values.0);
-    self.types.truncate(checkpoint.types.0);
-    self.traits.truncate(checkpoint.traits.0);
-    self.impls.truncate(checkpoint.impls.0);
-    self.generics.truncate(checkpoint.generics.0);
-    self.structs.truncate(checkpoint.structs.0);
-    self.enums.truncate(checkpoint.enums.0);
+    let Signatures {
+      generics,
+      concrete_consts,
+      concrete_fns,
+      type_aliases,
+      structs,
+      enums,
+      traits,
+      impls,
+    } = self;
+    generics.truncate(checkpoint.generics.0);
+    concrete_consts.truncate(checkpoint.concrete_consts.0);
+    concrete_fns.truncate(checkpoint.concrete_fns.0);
+    type_aliases.truncate(checkpoint.type_aliases.0);
+    structs.truncate(checkpoint.structs.0);
+    enums.truncate(checkpoint.enums.0);
+    traits.truncate(checkpoint.traits.0);
+    impls.truncate(checkpoint.impls.0);
+  }
+}
+
+impl<'core> TransferTypes<'core> for GenericsSig {
+  fn transfer(&self, t: &mut TypeTransfer<'core, '_>) -> Self {
+    Self { impl_params: t.transfer(&self.impl_params) }
+  }
+}
+
+impl<'core> TransferTypes<'core> for ConstSig {
+  fn transfer(&self, t: &mut TypeTransfer<'core, '_>) -> Self {
+    Self { ty: t.transfer(&self.ty) }
+  }
+}
+
+impl<'core> TransferTypes<'core> for FnSig {
+  fn transfer(&self, t: &mut TypeTransfer<'core, '_>) -> Self {
+    Self { params: t.transfer(&self.params), ret_ty: t.transfer(&self.ret_ty) }
+  }
+}
+
+impl<'core> TransferTypes<'core> for TypeAliasSig {
+  fn transfer(&self, t: &mut TypeTransfer<'core, '_>) -> Self {
+    Self { ty: t.transfer(&self.ty) }
+  }
+}
+
+impl<'core> TransferTypes<'core> for StructSig {
+  fn transfer(&self, t: &mut TypeTransfer<'core, '_>) -> Self {
+    Self { data: t.transfer(&self.data) }
+  }
+}
+
+impl<'core> TransferTypes<'core> for ImplSig {
+  fn transfer(&self, t: &mut TypeTransfer<'core, '_>) -> Self {
+    Self { ty: t.transfer(&self.ty) }
   }
 }

--- a/vine/src/signatures.rs
+++ b/vine/src/signatures.rs
@@ -2,8 +2,8 @@ use vine_util::idx::IdxVec;
 
 use crate::{
   chart::{
-    checkpoint::ChartCheckpoint, ConcreteConstId, ConcreteFnId, ConstKind, EnumId, FnKind,
-    GenericsId, ImplId, StructId, TraitConstId, TraitFnId, TraitId, TypeAliasId, VariantId,
+    checkpoint::ChartCheckpoint, ConcreteConstId, ConcreteFnId, ConstId, EnumId, FnId, GenericsId,
+    ImplId, StructId, TraitConstId, TraitFnId, TraitId, TypeAliasId, VariantId,
   },
   types::{ImplType, TransferTypes, Type, TypeCtx, TypeTransfer},
 };
@@ -63,17 +63,17 @@ pub struct ImplSig {
 }
 
 impl<'core> Signatures<'core> {
-  pub fn const_sig(&self, const_kind: ConstKind) -> &TypeCtx<'core, ConstSig> {
-    match const_kind {
-      ConstKind::Concrete(const_id) => &self.concrete_consts[const_id],
-      ConstKind::Abstract(trait_id, const_id) => &self.traits[trait_id].consts[const_id],
+  pub fn const_sig(&self, const_id: ConstId) -> &TypeCtx<'core, ConstSig> {
+    match const_id {
+      ConstId::Concrete(const_id) => &self.concrete_consts[const_id],
+      ConstId::Abstract(trait_id, const_id) => &self.traits[trait_id].consts[const_id],
     }
   }
 
-  pub fn fn_sig(&self, fn_kind: FnKind) -> &TypeCtx<'core, FnSig> {
-    match fn_kind {
-      FnKind::Concrete(fn_id) => &self.concrete_fns[fn_id],
-      FnKind::Abstract(trait_id, fn_id) => &self.traits[trait_id].fns[fn_id],
+  pub fn fn_sig(&self, fn_id: FnId) -> &TypeCtx<'core, FnSig> {
+    match fn_id {
+      FnId::Concrete(fn_id) => &self.concrete_fns[fn_id],
+      FnId::Abstract(trait_id, fn_id) => &self.traits[trait_id].fns[fn_id],
     }
   }
 

--- a/vine/src/specializer.rs
+++ b/vine/src/specializer.rs
@@ -23,8 +23,8 @@ pub struct Specializer<'core, 'a> {
 
 #[derive(Debug, Default)]
 pub struct Specializations<'core> {
-  consts: IdxVec<ConcreteConstId, ProtoInfo<'core>>,
-  fns: IdxVec<ConcreteFnId, ProtoInfo<'core>>,
+  consts: IdxVec<ConcreteConstId, TemplateInfo<'core>>,
+  fns: IdxVec<ConcreteFnId, TemplateInfo<'core>>,
   pub specs: IdxVec<SpecId, Option<Spec>>,
 }
 
@@ -38,18 +38,18 @@ impl<'core, 'a> Specializer<'core, 'a> {
     for const_id in self.chart.concrete_consts.keys_from(checkpoint.concrete_consts) {
       let mut const_def = self.chart.concrete_consts[const_id].clone();
       let mut extractor = RelExtractor::default();
-      extractor.proto.impl_params = impl_param_count(&self.chart.generics[const_def.generics]);
+      extractor.template.impl_params = impl_param_count(&self.chart.generics[const_def.generics]);
       extractor.visit_expr(&mut const_def.value);
-      self.specs.consts.push(extractor.proto);
+      self.specs.consts.push(extractor.template);
       self.chart.concrete_consts[const_id] = const_def;
     }
 
     for fn_id in self.chart.concrete_fns.keys_from(checkpoint.concrete_fns) {
       let mut fn_def = self.chart.concrete_fns[fn_id].clone();
       let mut extractor = RelExtractor::default();
-      extractor.proto.impl_params = impl_param_count(&self.chart.generics[fn_def.generics]);
+      extractor.template.impl_params = impl_param_count(&self.chart.generics[fn_def.generics]);
       extractor.visit_block(&mut fn_def.body);
-      self.specs.fns.push(extractor.proto);
+      self.specs.fns.push(extractor.template);
       self.chart.concrete_fns[fn_id] = fn_def;
     }
   }
@@ -57,46 +57,46 @@ impl<'core, 'a> Specializer<'core, 'a> {
   fn specialize_roots(&mut self, checkpoint: &ChartCheckpoint) {
     for const_id in self.specs.consts.keys_from(checkpoint.concrete_consts) {
       if self.specs.consts[const_id].impl_params == 0 {
-        self.specialize(ProtoId::Const(const_id), Vec::new());
+        self.specialize(TemplateId::Const(const_id), Vec::new());
       }
     }
     for fn_id in self.specs.fns.keys_from(checkpoint.concrete_fns) {
       if self.specs.fns[fn_id].impl_params == 0 {
-        self.specialize(ProtoId::Fn(fn_id), Vec::new());
+        self.specialize(TemplateId::Fn(fn_id), Vec::new());
       }
     }
   }
 
-  fn specialize(&mut self, id: ProtoId, impl_args: Vec<ImplTree>) -> SpecId {
+  fn specialize(&mut self, id: TemplateId, impl_args: Vec<ImplTree>) -> SpecId {
     let spec_id = self.specs.specs.next_index();
-    let proto = &mut self.proto_mut(id);
-    let index = proto.specs.len();
-    let entry = match proto.specs.entry(impl_args) {
+    let template = &mut self.template_mut(id);
+    let index = template.specs.len();
+    let entry = match template.specs.entry(impl_args) {
       Entry::Occupied(e) => return *e.get(),
       Entry::Vacant(e) => e,
     };
     let impl_args = entry.key().clone();
     entry.insert(spec_id);
-    let fn_rel_ids = proto.fn_rels.keys();
-    let const_rel_ids = proto.const_rels.keys();
+    let fn_rel_ids = template.fn_rels.keys();
+    let const_rel_ids = template.const_rels.keys();
     self.specs.specs.push(None);
     let rels = SpecRels {
       fns: IdxVec::from(Vec::from_iter(fn_rel_ids.map(|rel_id| {
-        let rel = &self.proto(id).fn_rels[rel_id];
+        let rel = &self.template(id).fn_rels[rel_id];
         let (fn_id, args) = self.instantiate_fn_rel(rel, &impl_args)?;
-        Ok(self.specialize(ProtoId::Fn(fn_id), args))
+        Ok(self.specialize(TemplateId::Fn(fn_id), args))
       }))),
       consts: IdxVec::from(Vec::from_iter(const_rel_ids.map(|rel_id| {
-        let rel = &self.proto(id).const_rels[rel_id];
+        let rel = &self.template(id).const_rels[rel_id];
         let (const_id, args) = self.instantiate_const_rel(rel, &impl_args)?;
-        Ok(self.specialize(ProtoId::Const(const_id), args))
+        Ok(self.specialize(TemplateId::Const(const_id), args))
       }))),
     };
     let def = match id {
-      ProtoId::Const(id) => self.chart.concrete_consts[id].def,
-      ProtoId::Fn(id) => self.chart.concrete_fns[id].def,
+      TemplateId::Const(id) => self.chart.concrete_consts[id].def,
+      TemplateId::Fn(id) => self.chart.concrete_fns[id].def,
     };
-    let spec = Spec { def, proto: id, index, singular: impl_args.is_empty(), rels };
+    let spec = Spec { def, template: id, index, singular: impl_args.is_empty(), rels };
     self.specs.specs[spec_id] = Some(spec);
     spec_id
   }
@@ -132,30 +132,30 @@ impl<'core, 'a> Specializer<'core, 'a> {
   pub(crate) fn _specialize_custom<'t>(&mut self, visitee: impl Visitee<'core, 't>) -> SpecRels {
     let mut extractor = RelExtractor::default();
     extractor.visit(visitee);
-    let proto = extractor.proto;
+    let template = extractor.template;
     SpecRels {
-      fns: IdxVec::from(Vec::from_iter(proto.fn_rels.values().map(|rel| {
+      fns: IdxVec::from(Vec::from_iter(template.fn_rels.values().map(|rel| {
         let (fn_id, args) = self.instantiate_fn_rel(rel, &[])?;
-        Ok(self.specialize(ProtoId::Fn(fn_id), args))
+        Ok(self.specialize(TemplateId::Fn(fn_id), args))
       }))),
-      consts: IdxVec::from(Vec::from_iter(proto.const_rels.values().map(|rel| {
+      consts: IdxVec::from(Vec::from_iter(template.const_rels.values().map(|rel| {
         let (const_id, args) = self.instantiate_const_rel(rel, &[])?;
-        Ok(self.specialize(ProtoId::Const(const_id), args))
+        Ok(self.specialize(TemplateId::Const(const_id), args))
       }))),
     }
   }
 
-  fn proto(&self, id: ProtoId) -> &ProtoInfo<'core> {
+  fn template(&self, id: TemplateId) -> &TemplateInfo<'core> {
     match id {
-      ProtoId::Const(const_id) => &self.specs.consts[const_id],
-      ProtoId::Fn(fn_id) => &self.specs.fns[fn_id],
+      TemplateId::Const(const_id) => &self.specs.consts[const_id],
+      TemplateId::Fn(fn_id) => &self.specs.fns[fn_id],
     }
   }
 
-  fn proto_mut(&mut self, id: ProtoId) -> &mut ProtoInfo<'core> {
+  fn template_mut(&mut self, id: TemplateId) -> &mut TemplateInfo<'core> {
     match id {
-      ProtoId::Const(const_id) => &mut self.specs.consts[const_id],
-      ProtoId::Fn(fn_id) => &mut self.specs.fns[fn_id],
+      TemplateId::Const(const_id) => &mut self.specs.consts[const_id],
+      TemplateId::Fn(fn_id) => &mut self.specs.fns[fn_id],
     }
   }
 }
@@ -170,14 +170,14 @@ fn impl_param_count(generics: &GenericsDef) -> usize {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub enum ProtoId {
+pub enum TemplateId {
   Const(ConcreteConstId),
   Fn(ConcreteFnId),
 }
 
 #[derive(Debug, Default)]
 struct RelExtractor<'core> {
-  proto: ProtoInfo<'core>,
+  template: TemplateInfo<'core>,
 }
 
 impl<'core> VisitMut<'core, '_> for RelExtractor<'core> {
@@ -185,14 +185,14 @@ impl<'core> VisitMut<'core, '_> for RelExtractor<'core> {
     match &mut expr.kind {
       ExprKind::ConstDef(const_id, generics) => {
         let mut impls = take(&mut generics.impls);
-        expr.kind = ExprKind::ConstRel(self.proto.const_rels.push(match *const_id {
+        expr.kind = ExprKind::ConstRel(self.template.const_rels.push(match *const_id {
           ConstId::Concrete(const_id) => Rel::Def(const_id, impls),
           ConstId::Abstract(_, const_id) => Rel::Subitem(impls.pop().unwrap(), const_id),
         }));
       }
       ExprKind::FnDef(fn_id, generics) => {
         let mut impls = take(&mut generics.impls);
-        expr.kind = ExprKind::FnRel(self.proto.fn_rels.push(match *fn_id {
+        expr.kind = ExprKind::FnRel(self.template.fn_rels.push(match *fn_id {
           FnId::Concrete(fn_id) => Rel::Def(fn_id, impls),
           FnId::Abstract(_, fn_id) => Rel::Subitem(impls.pop().unwrap(), fn_id),
         }));
@@ -204,7 +204,7 @@ impl<'core> VisitMut<'core, '_> for RelExtractor<'core> {
 }
 
 #[derive(Debug, Default)]
-struct ProtoInfo<'core> {
+struct TemplateInfo<'core> {
   impl_params: usize,
   fn_rels: IdxVec<FnRelId, Rel<'core, ConcreteFnId, TraitFnId>>,
   const_rels: IdxVec<ConstRelId, Rel<'core, ConcreteConstId, TraitConstId>>,
@@ -218,7 +218,7 @@ new_idx!(pub SpecId);
 #[derive(Debug)]
 pub struct Spec {
   pub def: DefId,
-  pub proto: ProtoId,
+  pub template: TemplateId,
   pub index: usize,
   pub singular: bool,
   pub rels: SpecRels,

--- a/vine/src/vir.rs
+++ b/vine/src/vir.rs
@@ -10,8 +10,8 @@ use vine_util::{
 use crate::{
   analyzer::{usage::Usage, UsageVar},
   ast::Local,
-  chart::{EnumId, ValueDefId, VariantId},
-  specializer::RelId,
+  chart::{EnumId, VariantId},
+  specializer::{ConstRelId, FnRelId},
 };
 
 new_idx!(pub LayerId; n => ["L{n}"]);
@@ -185,8 +185,8 @@ impl Invocation {
 #[derive(Debug, Clone)]
 pub enum Port {
   Erase,
-  Def(ValueDefId),
-  Rel(RelId),
+  ConstRel(ConstRelId),
+  FnRel(FnRelId),
   N32(u32),
   F32(f32),
   Wire(WireId),

--- a/vine/src/visit.rs
+++ b/vine/src/visit.rs
@@ -65,7 +65,8 @@ pub trait VisitMut<'core, 'a> {
       | ExprKind::Break(_, None)
       | ExprKind::SetLocal(_)
       | ExprKind::HedgeLocal(_)
-      | ExprKind::Rel(..) => {}
+      | ExprKind::FnRel(_)
+      | ExprKind::ConstRel(_) => {}
       ExprKind::Paren(a)
       | ExprKind::Ref(a, _)
       | ExprKind::Deref(a, _)
@@ -95,7 +96,7 @@ pub trait VisitMut<'core, 'a> {
         self.visit(&mut path.generics);
         self.visit(args);
       }
-      ExprKind::Def(_, g) => self.visit(g),
+      ExprKind::ConstDef(_, g) | ExprKind::FnDef(_, g) => self.visit(g),
       ExprKind::Do(_, b) | ExprKind::Loop(_, b) => self.visit_block(b),
       ExprKind::Match(a, b) => {
         self.visit_expr(a);
@@ -232,7 +233,9 @@ pub trait VisitMut<'core, 'a> {
       TyKind::Hole | TyKind::Param(_) => {}
       TyKind::Paren(t) | TyKind::Ref(t) | TyKind::Inverse(t) => self.visit_type(t),
       TyKind::Path(p) => self.visit(&mut p.generics),
-      TyKind::Def(_, a) => self.visit(a),
+      TyKind::Opaque(_, a) | TyKind::Alias(_, a) | TyKind::Struct(_, a) | TyKind::Enum(_, a) => {
+        self.visit(a)
+      }
       TyKind::Tuple(a) => {
         for t in a {
           self.visit_type(t);

--- a/vine/std/data/List.vi
+++ b/vine/std/data/List.vi
@@ -4,9 +4,9 @@ use ops::{Cast, Concat, comparison::{Eq, Ord}, range::{Bound, Range}};
 use debug::Show;
 
 #[builtin = "List"]
-pub struct List[T]((N32, Buf[T], ~Buf[T]));
+pub struct List[T](pub.std (N32, Buf[T], ~Buf[T]));
 
-pub.std struct Buf[T]((T, Buf[T]));
+pub.std struct Buf[T](pub.std (T, Buf[T]));
 
 pub mod List {
   pub fn .len[T](&self: &List[T]) -> N32 {
@@ -173,7 +173,7 @@ pub mod List {
     self = output;
   }
 
-  pub struct Iter[T]((N32, &Buf[T]));
+  pub struct Iter[T](pub.std (N32, &Buf[T]));
 
   pub fn .iter[T](&List[T](len, buf, _)) -> Iter[T] {
     Iter(len, &buf)
@@ -199,7 +199,7 @@ pub mod List {
     }
   }
 
-  pub struct IntoIter[T]((N32, Buf[T]));
+  pub struct IntoIter[T](pub.std (N32, Buf[T]));
 
   pub fn .into_iter[T](List[T](len, buf, _)) -> IntoIter[T] {
     IntoIter(len, buf)
@@ -279,8 +279,13 @@ pub mod List {
       ord
     }
 
-    const lt: fn(&List[T], &List[T]) -> Bool = Ord::lt_from_cmp[List[T]];
-    const le: fn(&List[T], &List[T]) -> Bool = Ord::le_from_cmp[List[T]];
+    fn lt(a: &List[T], b: &List[T]) -> Bool {
+      Ord::lt_from_cmp[List[T]](a, b)
+    }
+
+    fn le(a: &List[T], b: &List[T]) -> Bool {
+      Ord::le_from_cmp[List[T]](a, b)
+    }
   }
 
   pub impl fork[T+]: Fork[List[T]] {

--- a/vine/std/logical/Bool.vi
+++ b/vine/std/logical/Bool.vi
@@ -62,7 +62,9 @@ pub mod Bool {
       inline_ivy! (a <- a, b <- b) -> Bool { out a = @n32_le(b out) }
     }
 
-    const cmp: fn(&Bool, &Bool) -> Ord = Ord::cmp_from_lt[Bool];
+    fn .cmp(a: &Bool, b: &Bool) -> Ord {
+      Ord::cmp_from_lt[Bool](a, b)
+    }
   }
 
   pub impl to_string: Cast[Bool, String] {

--- a/vine/std/numeric/I32.vi
+++ b/vine/std/numeric/I32.vi
@@ -158,7 +158,9 @@ pub mod I32 {
       inline_ivy! (a <- a, b <- b) -> Bool { out a = @i32_le(b out) }
     }
 
-    const cmp: fn(&I32, &I32) -> Ord = Ord::cmp_from_lt[I32];
+    fn cmp(a: &I32, b: &I32) -> Ord {
+      Ord::cmp_from_lt[I32](a, b)
+    }
   }
 
   pub impl eq: Eq[I32] {

--- a/vine/std/numeric/N32.vi
+++ b/vine/std/numeric/N32.vi
@@ -169,7 +169,9 @@ pub mod N32 {
       inline_ivy! (a <- a, b <- b) -> Bool { out a = @n32_le(b out) }
     }
 
-    const cmp: fn(&N32, &N32) -> Ord = Ord::cmp_from_lt[N32];
+    fn cmp(a: &N32, b: &N32) -> Ord {
+      Ord::cmp_from_lt[N32](a, b)
+    }
   }
 
   pub impl eq: Eq[N32] {

--- a/vine/std/numeric/N64.vi
+++ b/vine/std/numeric/N64.vi
@@ -7,7 +7,7 @@ use ops::{
 };
 use debug::Show;
 
-pub struct N64((N32, N32));
+pub struct N64(pub (N32, N32));
 
 pub mod N64 {
   pub const zero: N64 = N64(0, 0);
@@ -178,7 +178,9 @@ pub mod N64 {
       ah < bh || ah == bh && al <= bl
     }
 
-    const cmp: fn(&N64, &N64) -> Ord = Ord::cmp_from_lt[N64];
+    fn cmp(a: &N64, b: &N64) -> Ord {
+      Ord::cmp_from_lt[N64](a, b)
+    }
   }
 
   pub fn .min(a: N64, b: N64) -> N64 {

--- a/vine/std/ops/comparison.vi
+++ b/vine/std/ops/comparison.vi
@@ -41,8 +41,13 @@ pub mod Ord {
       }
     }
 
-    const lt: fn(&(A, B), &(A, B)) -> Bool = Ord::lt_from_cmp[(A, B)];
-    const le: fn(&(A, B), &(A, B)) -> Bool = Ord::le_from_cmp[(A, B)];
+    fn lt(x: &(A, B), y: &(A, B)) -> Bool {
+      Ord::lt_from_cmp[(A, B)](x, y)
+    }
+
+    fn le(x: &(A, B), y: &(A, B)) -> Bool {
+      Ord::le_from_cmp[(A, B)](x, y)
+    }
   }
 
   pub fn .gt[T; Ord[T]](&a: &T, &b: &T) -> Bool {
@@ -79,7 +84,9 @@ pub trait Lt[T] {
 
 pub mod Lt {
   pub impl from_ord[T; Ord[T]]: Lt[T] {
-    const lt: fn(&T, &T) -> Bool = Ord::lt[T];
+    fn lt(a: &T, b: &T) -> Bool {
+      Ord::lt[T](a, b)
+    }
   }
 
   #[builtin = "gt"]
@@ -95,7 +102,9 @@ pub trait Le[T] {
 
 pub mod Le {
   pub impl from_ord[T; Ord[T]]: Le[T] {
-    const le: fn(&T, &T) -> Bool = Ord::le[T];
+    fn le(a: &T, b: &T) -> Bool {
+      Ord::le[T](a, b)
+    }
   }
 
   #[builtin = "ge"]

--- a/vine/std/unicode/Char.vi
+++ b/vine/std/unicode/Char.vi
@@ -49,7 +49,9 @@ pub mod Char {
       inline_ivy! (a <- a, b <- b) -> Bool { out a = @n32_le(b out) }
     }
 
-    const cmp: fn(&Char, &Char) -> Ord = Ord::cmp_from_lt[Char];
+    fn cmp(a: &Char, b: &Char) -> Ord {
+      Ord::cmp_from_lt[Char](a, b)
+    }
   }
 
   pub fn .is_whitespace(char: Char) -> Bool {

--- a/vine/std/unicode/String.vi
+++ b/vine/std/unicode/String.vi
@@ -162,8 +162,13 @@ pub mod String {
       a!.cmp(&b!)
     }
 
-    const lt: fn(&String, &String) -> Bool = Ord::lt_from_cmp[String];
-    const le: fn(&String, &String) -> Bool = Ord::le_from_cmp[String];
+    fn lt(a: &String, b: &String) -> Bool {
+      Ord::lt_from_cmp[String](a, b)
+    }
+
+    fn le(a: &String, b: &String) -> Bool {
+      Ord::le_from_cmp[String](a, b)
+    }
   }
 
   pub impl concat: Concat[String, String, String] {


### PR DESCRIPTION
Reworks the `Chart` struct in the compiler to have distinct ids for different kinds of items, so e.g. instead of having a general `ValueDefId`, it is now split into `FnId` and `ConstId`. This simplifies the compiler overall, as it allows it to treat these different kinds of entities differently.

Introduces a greater distinction between `const`s and `fn`s, as a precursor to #172.

Fixes #265. Also changes the minimum visibility of struct data from being visible only within the struct to being visible within the module containing the struct.

The `Chart` is one of the core data structures of the compiler, so this PR diffs almost every file in the compiler, and might thus be difficult to review comprehensively.