### PR TITLE
vine: disallow marking impl fns as methods

### DIFF
--- a/tests/programs/aoc_2024/day_12.vi
+++ b/tests/programs/aoc_2024/day_12.vi
@@ -88,7 +88,7 @@ enum Region {
 
 mod Region {
   pub impl show: Show[Region] {
-    fn .show(&self: &Region) -> Show {
+    fn show(&self: &Region) -> Show {
       match self {
         Region::Root(x) { Show::Constructor("Root", x.show()) }
         Region::Child(x) { Show::Constructor("Child", x.show()) }
@@ -99,7 +99,7 @@ mod Region {
 
 mod Regions {
   pub impl to_string: Cast[Regions, String] {
-    fn .cast(Regions(array)) -> String {
+    fn cast(Regions(array)) -> String {
       (array.as[List]; _).show() as String
     }
   }

--- a/tests/programs/par.vi
+++ b/tests/programs/par.vi
@@ -57,7 +57,7 @@ enum Move {
 
 mod Move {
   pub impl to_string: Cast[Move, String] {
-    fn .cast(self: Move) -> String {
+    fn cast(self: Move) -> String {
       match self {
         Up { "Up" }
         Down { "Down" }

--- a/tests/programs/the_greatest_show.vi
+++ b/tests/programs/the_greatest_show.vi
@@ -28,7 +28,7 @@ pub fn main(&io: &IO) {
 }
 
 impl show_obj[A, B, C; Show[A], Show[B], Show[C]]: Show[{ a: A, b: B, c: C }] {
-  fn .show(&{ a:: A, b:: B, c:: C }) -> Show {
+  fn show(&{ a:: A, b:: B, c:: C }) -> Show {
     Show::Object([("a", a.show()), ("b", b.show()), ("c", c.show())])
   }
 }

--- a/vine/src/charter.rs
+++ b/vine/src/charter.rs
@@ -268,6 +268,9 @@ impl<'core> Charter<'core, '_> {
               if !fn_item.generics.impls.is_empty() || !fn_item.generics.types.is_empty() {
                 self.core.report(Diag::ImplItemGen { span });
               }
+              if fn_item.method {
+                self.core.report(Diag::ImplItemMethod { span });
+              }
               let def = self.chart_child(def, fn_item.name, vis, false);
               let body = self.ensure_implemented(span, fn_item.body);
               let fn_id = self.chart.concrete_fns.push(ConcreteFnDef {

--- a/vine/src/diag.rs
+++ b/vine/src/diag.rs
@@ -168,6 +168,8 @@ diags! {
     ["trait items cannot have generics"]
   ImplItemGen
     ["impl items cannot have generics"]
+  ImplItemMethod
+    ["impl fns cannot be marked as methods; this is done at the trait level"]
   ImplementedTraitItem
     ["trait items cannot have implementations"]
   UnexpectedImplArgs

--- a/vine/std/data/Array.vi
+++ b/vine/std/data/Array.vi
@@ -15,7 +15,7 @@ pub mod Array {
   }
 
   pub impl from_list[T]: Cast[List[T], Array[T]] {
-    fn .cast(List[T](len, buf, _)) -> Array[T] {
+    fn cast(List[T](len, buf, _)) -> Array[T] {
       Array::from_fn(
         len,
         &buf,
@@ -29,7 +29,7 @@ pub mod Array {
   }
 
   pub impl to_list[T]: Cast[Array[T], List[T]] {
-    fn .cast(self: Array[T]) -> List[T] {
+    fn cast(self: Array[T]) -> List[T] {
       let end;
       List(self.len(), self.fold_back(move ~end, fn(a, b) { List::Buf(b, a) }), end)
     }
@@ -195,7 +195,7 @@ pub mod Array {
   }
 
   pub impl fork[T+]: Fork[Array[T]] {
-    fn .fork(&Array[T](len, node)) -> Array[T] {
+    fn fork(&Array[T](len, node)) -> Array[T] {
       if len == 0 {
         Array::empty
       } else {
@@ -205,7 +205,7 @@ pub mod Array {
   }
 
   pub impl drop[T?]: Drop[Array[T]] {
-    fn .drop(Array[T](len, node)) {
+    fn drop(Array[T](len, node)) {
       if len == 0 {
         unsafe::erase(node)
       } else {
@@ -219,13 +219,13 @@ struct Node[T]((Node[T], Node[T]));
 
 mod Node {
   pub impl leaf_to_node[T]: Cast[T, Node[T]] {
-    fn .cast(value: T) -> Node[T] {
+    fn cast(value: T) -> Node[T] {
       inline_ivy! (x <- value) -> Node[T] { x }
     }
   }
 
   pub impl node_to_leaf[T]: Cast[Node[T], T] {
-    fn .cast(value: Node[T]) -> T {
+    fn cast(value: Node[T]) -> T {
       inline_ivy! (x <- value) -> T { x }
     }
   }

--- a/vine/std/data/List.vi
+++ b/vine/std/data/List.vi
@@ -102,7 +102,7 @@ pub mod List {
   }
 
   pub impl concat[T]: Concat[List[T], List[T], List[T]] {
-    fn .concat(a: List[T], b: List[T]) -> List[T] {
+    fn concat(a: List[T], b: List[T]) -> List[T] {
       let List(a_len, a_buf, ~a_end) = a;
       let List(b_len, b_buf, ~b_end) = b;
       a_end = b_buf;
@@ -156,7 +156,7 @@ pub mod List {
   }
 
   pub impl show[T; Show[T]]: Show[List[T]] {
-    fn .show(&self: &List[T]) -> Show {
+    fn show(&self: &List[T]) -> Show {
       let entries = [];
       let iter = self.iter();
       while iter.next() is Some(&value) {
@@ -191,7 +191,7 @@ pub mod List {
 
   pub mod Iter {
     pub impl iterator[T]: Iterator[Iter[T], &T] {
-      fn .next(&Iter[T](len, buf)) -> Option[&T] {
+      fn next(&Iter[T](len, buf)) -> Option[&T] {
         if len != 0 {
           len -= 1;
           let &Buf(*head, *tail) = buf;
@@ -203,7 +203,7 @@ pub mod List {
         }
       }
 
-      fn .drop_iter(&iter: &Iter[T]) {
+      fn drop_iter(&iter: &Iter[T]) {
         let Iter(_, &_) = move iter;
       }
     }
@@ -217,7 +217,7 @@ pub mod List {
 
   pub mod IntoIter {
     pub impl iterator[T]: Iterator[IntoIter[T], T] {
-      fn .next(&IntoIter[T](len, buf)) -> Option[T] {
+      fn next(&IntoIter[T](len, buf)) -> Option[T] {
         if len != 0 {
           len -= 1;
           let Buf(head, tail) = buf;
@@ -228,7 +228,7 @@ pub mod List {
         }
       }
 
-      fn .drop_iter(iter: &IntoIter[T]) {}
+      fn drop_iter(iter: &IntoIter[T]) {}
     }
   }
 
@@ -299,7 +299,7 @@ pub mod List {
   }
 
   pub impl fork[T+]: Fork[List[T]] {
-    fn .fork(&self: &List[T]) -> List[T] {
+    fn fork(&self: &List[T]) -> List[T] {
       let iter = self.iter();
       let out = [];
       while iter.next() is Some(&value) {
@@ -310,7 +310,7 @@ pub mod List {
   }
 
   pub impl drop[T?]: Drop[List[T]] {
-    fn .drop(self: List[T]) {
+    fn drop(self: List[T]) {
       let iter = self.into_iter();
       while iter.next() is Some(value) {
         value.drop();

--- a/vine/std/data/Map.vi
+++ b/vine/std/data/Map.vi
@@ -14,7 +14,7 @@ pub mod Map {
   }
 
   pub impl from_list[K, V; Ord[K]]: Cast[List[(K, V)], Map[K, V]] {
-    fn .cast(entries: List[(K, V)]) -> Map[K, V] {
+    fn cast(entries: List[(K, V)]) -> Map[K, V] {
       let map = Map::empty[K, V];
       while entries.pop_front() is Some(key, value) {
         map.insert(key, value);
@@ -221,7 +221,7 @@ pub mod Map {
 
   pub mod Iter {
     pub impl iterator[K, V]: Iterator[Iter[K, V], &(K, V)] {
-      fn .next(&Iter[K, V](node, stack)) -> Option[&(K, V)] {
+      fn next(&Iter[K, V](node, stack)) -> Option[&(K, V)] {
         loop {
           let &Map(len, data) = move node;
           if len == 0 {
@@ -240,7 +240,7 @@ pub mod Map {
         }
       }
 
-      fn .drop_iter(&iter: &Iter[K, V]) {
+      fn drop_iter(&iter: &Iter[K, V]) {
         let Iter(&_, stack) = move iter;
         while stack.pop_front() is Some(&_) {}
       }
@@ -255,7 +255,7 @@ pub mod Map {
 
   pub mod IntoIter {
     pub impl iterator[K, V]: Iterator[IntoIter[K, V], (K, V)] {
-      fn .next(&IntoIter[K, V](node, stack)) -> Option[(K, V)] {
+      fn next(&IntoIter[K, V](node, stack)) -> Option[(K, V)] {
         loop {
           let Map(len, data) = move node;
           if len == 0 {
@@ -273,12 +273,12 @@ pub mod Map {
         }
       }
 
-      fn .drop_iter(self: &IntoIter[K, V]) {}
+      fn drop_iter(self: &IntoIter[K, V]) {}
     }
   }
 
   pub impl to_list[K, V]: Cast[Map[K, V], List[(K, V)]] {
-    fn .cast(Map[K, V](len, data)) -> List[(K, V)] {
+    fn cast(Map[K, V](len, data)) -> List[(K, V)] {
       if len == 0 {
         []
       } else {
@@ -289,7 +289,7 @@ pub mod Map {
   }
 
   pub impl to_string[K, V; Cast[K, String], Cast[V, String]]: Cast[Map[K, V], String] {
-    fn .cast(map: Map[K, V]) -> String {
+    fn cast(map: Map[K, V]) -> String {
       let string = "";
       let iter = map.into_iter();
       let first = true;
@@ -319,7 +319,7 @@ pub mod Map {
   }
 
   pub impl fork[K+, V+]: Fork[Map[K, V]] {
-    fn .fork(&Map[K, V](len, data)) -> Map[K, V] {
+    fn fork(&Map[K, V](len, data)) -> Map[K, V] {
       if len == 0 {
         Map::empty
       } else {
@@ -329,7 +329,7 @@ pub mod Map {
   }
 
   pub impl drop[K?, V?]: Drop[Map[K, V]] {
-    fn .drop(Map[K, V](len, data)) {
+    fn drop(Map[K, V](len, data)) {
       if len == 0 {
         unsafe::erase(data);
       } else {

--- a/vine/std/debug/Show.vi
+++ b/vine/std/debug/Show.vi
@@ -16,7 +16,7 @@ pub enum Show {
 
 pub mod Show {
   pub impl to_string: Cast[Show, String] {
-    fn .cast(self: Show) -> String {
+    fn cast(self: Show) -> String {
       self.format(80)
     }
   }
@@ -116,31 +116,31 @@ pub mod Show {
 }
 
 pub impl show_nil: Show[()] {
-  fn .show(&()) -> Show {
+  fn show(&()) -> Show {
     Show::Tuple([])
   }
 }
 
 pub impl show_singleton[A; Show[A]]: Show[(A,)] {
-  fn .show(&(a: A,)) -> Show {
+  fn show(&(a: A,)) -> Show {
     Show::Tuple([a.show()])
   }
 }
 
 pub impl show_pair[A, B; Show[A], Show[B]]: Show[(A, B)] {
-  fn .show(&(a: A, b: B)) -> Show {
+  fn show(&(a: A, b: B)) -> Show {
     Show::Tuple([a.show(), b.show()])
   }
 }
 
 pub impl show_triple[A, B, C; Show[A], Show[B], Show[C]]: Show[(A, B, C)] {
-  fn .show(&(a: A, b: B, c: C)) -> Show {
+  fn show(&(a: A, b: B, c: C)) -> Show {
     Show::Tuple([a.show(), b.show(), c.show()])
   }
 }
 
 pub impl show_quad[A, B, C, D; Show[A], Show[B], Show[C], Show[D]]: Show[(A, B, C, D)] {
-  fn .show(&(a: A, b: B, c: C, d: D)) -> Show {
+  fn show(&(a: A, b: B, c: C, d: D)) -> Show {
     Show::Tuple([a.show(), b.show(), c.show(), d.show()])
   }
 }

--- a/vine/std/logical/Bool.vi
+++ b/vine/std/logical/Bool.vi
@@ -7,68 +7,68 @@ pub type Bool;
 
 pub mod Bool {
   pub impl fork: Fork[Bool] {
-    fn .fork(&self: &Bool) -> Bool {
+    fn fork(&self: &Bool) -> Bool {
       unsafe::copy(&self)
     }
   }
 
   pub impl drop: Drop[Bool] {
-    fn .drop(self: Bool) {
+    fn drop(self: Bool) {
       unsafe::erase(self)
     }
   }
 
   pub impl and: And[Bool, Bool, Bool] {
-    fn .and(a: Bool, b: Bool) -> Bool {
+    fn and(a: Bool, b: Bool) -> Bool {
       inline_ivy! (a <- a, b <- b) -> Bool { out a = @n32_and(b out) }
     }
   }
 
   pub impl or: Or[Bool, Bool, Bool] {
-    fn .or(a: Bool, b: Bool) -> Bool {
+    fn or(a: Bool, b: Bool) -> Bool {
       inline_ivy! (a <- a, b <- b) -> Bool { out a = @n32_or(b out) }
     }
   }
 
   pub impl xor: Xor[Bool, Bool, Bool] {
-    fn .xor(a: Bool, b: Bool) -> Bool {
+    fn xor(a: Bool, b: Bool) -> Bool {
       inline_ivy! (a <- a, b <- b) -> Bool { out a = @n32_xor(b out) }
     }
   }
 
   #[builtin = "bool_not"]
   pub impl not: Not[Bool, Bool] {
-    fn .not(a: Bool) -> Bool {
+    fn not(a: Bool) -> Bool {
       inline_ivy! (a <- a) -> Bool { out a = @n32_eq(0 out) }
     }
   }
 
   pub impl eq: Eq[Bool] {
-    fn .eq(&a: &Bool, &b: &Bool) -> Bool {
+    fn eq(&a: &Bool, &b: &Bool) -> Bool {
       inline_ivy! (a <- a, b <- b) -> Bool { out a = @n32_eq(b out) }
     }
 
-    fn .ne(&a: &Bool, &b: &Bool) -> Bool {
+    fn ne(&a: &Bool, &b: &Bool) -> Bool {
       inline_ivy! (a <- a, b <- b) -> Bool { out a = @n32_ne(b out) }
     }
   }
 
   pub impl ord: Ord[Bool] {
-    fn .lt(&a: &Bool, &b: &Bool) -> Bool {
+    fn lt(&a: &Bool, &b: &Bool) -> Bool {
       inline_ivy! (a <- a, b <- b) -> Bool { out a = @n32_lt(b out) }
     }
 
-    fn .le(&a: &Bool, &b: &Bool) -> Bool {
+    fn le(&a: &Bool, &b: &Bool) -> Bool {
       inline_ivy! (a <- a, b <- b) -> Bool { out a = @n32_le(b out) }
     }
 
-    fn .cmp(a: &Bool, b: &Bool) -> Ord {
+    fn cmp(a: &Bool, b: &Bool) -> Ord {
       Ord::cmp_from_lt[Bool](a, b)
     }
   }
 
   pub impl to_string: Cast[Bool, String] {
-    fn .cast(self: Bool) -> String {
+    fn cast(self: Bool) -> String {
       if self {
         "true"
       } else {
@@ -78,7 +78,7 @@ pub mod Bool {
   }
 
   pub impl show: Show[Bool] {
-    fn .show(&self: &Bool) -> Show {
+    fn show(&self: &Bool) -> Show {
       Show::Literal("{self}")
     }
   }

--- a/vine/std/logical/Option.vi
+++ b/vine/std/logical/Option.vi
@@ -53,7 +53,7 @@ pub mod Option {
   }
 
   pub impl show[T; Show[T]]: Show[Option[T]] {
-    fn .show(&self: &Option[T]) -> Show {
+    fn show(&self: &Option[T]) -> Show {
       match &self {
         &Some(value) { Show::Constructor("Some", value.show()) }
         &None { Show::Literal("None") }
@@ -62,7 +62,7 @@ pub mod Option {
   }
 
   pub impl fork[T+]: Fork[Option[T]] {
-    fn .fork(&self: &Option[T]) -> Option[T] {
+    fn fork(&self: &Option[T]) -> Option[T] {
       match &self {
         &Some(value) { Some(value.fork()) }
         &None { None }
@@ -71,7 +71,7 @@ pub mod Option {
   }
 
   pub impl drop[T?]: Drop[Option[T]] {
-    fn .drop(self: Option[T]) {
+    fn drop(self: Option[T]) {
       match self {
         Some(value) { value.drop() }
         None {}

--- a/vine/std/logical/Result.vi
+++ b/vine/std/logical/Result.vi
@@ -55,7 +55,7 @@ pub mod Result {
   }
 
   pub impl show[T, E; Show[T], Show[E]]: Show[Result[T, E]] {
-    fn .show(&self: &Result[T, E]) -> Show {
+    fn show(&self: &Result[T, E]) -> Show {
       match &self {
         &Ok(value) { Show::Constructor("Ok", value.show()) }
         &Err(value) { Show::Constructor("Err", value.show()) }
@@ -64,7 +64,7 @@ pub mod Result {
   }
 
   pub impl fork[T+, E+]: Fork[Result[T, E]] {
-    fn .fork(&self: &Result[T, E]) -> Result[T, E] {
+    fn fork(&self: &Result[T, E]) -> Result[T, E] {
       match &self {
         &Ok(value) { Ok(value.fork()) }
         &Err(value) { Err(value.fork()) }
@@ -73,7 +73,7 @@ pub mod Result {
   }
 
   pub impl drop[T?, E?]: Drop[Result[T, E]] {
-    fn .drop(self: Result[T, E]) {
+    fn drop(self: Result[T, E]) {
       match self {
         Ok(value) { value.drop() }
         Err(value) { value.drop() }

--- a/vine/std/numeric/F32.vi
+++ b/vine/std/numeric/F32.vi
@@ -11,43 +11,43 @@ pub mod F32 {
   pub const neg_inf: F32 = inline_ivy! () -> F32 { -inf };
 
   pub impl fork: Fork[F32] {
-    fn .fork(&self: &F32) -> F32 {
+    fn fork(&self: &F32) -> F32 {
       unsafe::copy(&self)
     }
   }
 
   pub impl drop: Drop[F32] {
-    fn .drop(self: F32) {
+    fn drop(self: F32) {
       unsafe::erase(self)
     }
   }
 
   pub impl add: Add[F32, F32, F32] {
-    fn .add(a: F32, b: F32) -> F32 {
+    fn add(a: F32, b: F32) -> F32 {
       inline_ivy! (a <- a, b <- b) -> F32 { out a = @f32_add(b out) }
     }
   }
 
   pub impl sub: Sub[F32, F32, F32] {
-    fn .sub(a: F32, b: F32) -> F32 {
+    fn sub(a: F32, b: F32) -> F32 {
       inline_ivy! (a <- a, b <- b) -> F32 { out a = @f32_sub(b out) }
     }
   }
 
   pub impl mul: Mul[F32, F32, F32] {
-    fn .mul(a: F32, b: F32) -> F32 {
+    fn mul(a: F32, b: F32) -> F32 {
       inline_ivy! (a <- a, b <- b) -> F32 { out a = @f32_mul(b out) }
     }
   }
 
   pub impl pow_n32: Pow[F32, N32, F32] {
-    fn .pow(base: F32, exp: N32) -> F32 {
+    fn pow(base: F32, exp: N32) -> F32 {
       Pow::pow_by_squaring[F32](base, exp)
     }
   }
 
   pub impl pow_i32: Pow[F32, I32, F32] {
-    fn .pow(base: F32, exp: I32) -> F32 {
+    fn pow(base: F32, exp: I32) -> F32 {
       if exp < +0 {
         1.0 / (base ** (-exp as N32))
       } else {
@@ -57,53 +57,53 @@ pub mod F32 {
   }
 
   pub impl div: Div[F32, F32, F32] {
-    fn .div(a: F32, b: F32) -> F32 {
+    fn div(a: F32, b: F32) -> F32 {
       inline_ivy! (a <- a, b <- b) -> F32 { out a = @f32_div(b out) }
     }
   }
 
   pub impl rem: Rem[F32, F32, F32] {
-    fn .rem(a: F32, b: F32) -> F32 {
+    fn rem(a: F32, b: F32) -> F32 {
       inline_ivy! (a <- a, b <- b) -> F32 { out a = @f32_rem(b out) }
     }
   }
 
   pub impl neg: Neg[F32, F32] {
-    fn .neg(a: F32) -> F32 {
+    fn neg(a: F32) -> F32 {
       inline_ivy! (a <- a) -> F32 { out a = @f32_sub$(-0.0 out) }
     }
   }
 
   pub impl eq: Eq[F32] {
-    fn .eq(&a: &F32, &b: &F32) -> Bool {
+    fn eq(&a: &F32, &b: &F32) -> Bool {
       inline_ivy! (a <- a, b <- b) -> Bool { out a = @f32_eq(b out) }
     }
 
-    fn .ne(&a: &F32, &b: &F32) -> Bool {
+    fn ne(&a: &F32, &b: &F32) -> Bool {
       inline_ivy! (a <- a, b <- b) -> Bool { out a = @f32_ne(b out) }
     }
   }
 
   pub impl lt: Lt[F32] {
-    fn .lt(&a: &F32, &b: &F32) -> Bool {
+    fn lt(&a: &F32, &b: &F32) -> Bool {
       inline_ivy! (a <- a, b <- b) -> Bool { out a = @f32_lt(b out) }
     }
   }
 
   pub impl le: Le[F32] {
-    fn .le(&a: &F32, &b: &F32) -> Bool {
+    fn le(&a: &F32, &b: &F32) -> Bool {
       inline_ivy! (a <- a, b <- b) -> Bool { out a = @f32_le(b out) }
     }
   }
 
   pub impl from_n32: Cast[N32, F32] {
-    fn .cast(n: N32) -> F32 {
+    fn cast(n: N32) -> F32 {
       inline_ivy! (n <- n) -> F32 { out n = @n32_to_f32(0 out) }
     }
   }
 
   pub impl to_n32: Cast[F32, N32] {
-    fn .cast(n: F32) -> N32 {
+    fn cast(n: F32) -> N32 {
       inline_ivy! (n <- n) -> N32 { out n = @f32_to_n32(0 out) }
     }
   }
@@ -121,7 +121,7 @@ pub mod F32 {
   }
 
   pub impl to_string: Cast[F32, String] {
-    fn .cast(f: F32) -> String {
+    fn cast(f: F32) -> String {
       if f.is_nan() {
         "NaN"
       } else if f == F32::inf {
@@ -168,7 +168,7 @@ pub mod F32 {
   }
 
   pub impl show: Show[F32] {
-    fn .show(&self: &F32) -> Show {
+    fn show(&self: &F32) -> Show {
       Show::Literal("{self}")
     }
   }

--- a/vine/std/numeric/I32.vi
+++ b/vine/std/numeric/I32.vi
@@ -15,91 +15,91 @@ pub mod I32 {
   pub const minimum: I32 = -0x7fffffff;
 
   pub impl fork: Fork[I32] {
-    fn .fork(&self: &I32) -> I32 {
+    fn fork(&self: &I32) -> I32 {
       unsafe::copy(&self)
     }
   }
 
   pub impl drop: Drop[I32] {
-    fn .drop(self: I32) {
+    fn drop(self: I32) {
       unsafe::erase(self)
     }
   }
 
   pub impl add: Add[I32, I32, I32] {
-    fn .add(a: I32, b: I32) -> I32 {
+    fn add(a: I32, b: I32) -> I32 {
       inline_ivy! (a <- a, b <- b) -> I32 { out a = @n32_add(b out) }
     }
   }
 
   pub impl sub: Sub[I32, I32, I32] {
-    fn .sub(a: I32, b: I32) -> I32 {
+    fn sub(a: I32, b: I32) -> I32 {
       inline_ivy! (a <- a, b <- b) -> I32 { out a = @n32_sub(b out) }
     }
   }
 
   pub impl mul: Mul[I32, I32, I32] {
-    fn .mul(a: I32, b: I32) -> I32 {
+    fn mul(a: I32, b: I32) -> I32 {
       inline_ivy! (a <- a, b <- b) -> I32 { out a = @n32_mul(b out) }
     }
   }
 
   pub impl pow: Pow[I32, N32, I32] {
-    fn .pow(base: I32, exp: N32) -> I32 {
+    fn pow(base: I32, exp: N32) -> I32 {
       Pow::pow_by_squaring[I32](base, exp)
     }
   }
 
   pub impl div: Div[I32, I32, I32] {
-    fn .div(a: I32, b: I32) -> I32 {
+    fn div(a: I32, b: I32) -> I32 {
       inline_ivy! (a <- a, b <- b) -> I32 { out a = @i32_div(b out) }
     }
   }
 
   pub impl rem: Rem[I32, I32, I32] {
-    fn .rem(a: I32, b: I32) -> I32 {
+    fn rem(a: I32, b: I32) -> I32 {
       inline_ivy! (a <- a, b <- b) -> I32 { out a = @i32_rem(b out) }
     }
   }
 
   pub impl neg: Neg[I32, I32] {
-    fn .neg(a: I32) -> I32 {
+    fn neg(a: I32) -> I32 {
       inline_ivy! (a <- a) -> I32 { out a = @n32_sub$(0 out) }
     }
   }
 
   pub impl and: And[I32, I32, I32] {
-    fn .and(a: I32, b: I32) -> I32 {
+    fn and(a: I32, b: I32) -> I32 {
       inline_ivy! (a <- a, b <- b) -> I32 { out a = @n32_and(b out) }
     }
   }
 
   pub impl or: Or[I32, I32, I32] {
-    fn .or(a: I32, b: I32) -> I32 {
+    fn or(a: I32, b: I32) -> I32 {
       inline_ivy! (a <- a, b <- b) -> I32 { out a = @n32_or(b out) }
     }
   }
 
   pub impl xor: Xor[I32, I32, I32] {
-    fn .xor(a: I32, b: I32) -> I32 {
+    fn xor(a: I32, b: I32) -> I32 {
       inline_ivy! (a <- a, b <- b) -> I32 { out a = @n32_xor(b out) }
     }
   }
 
   pub impl shl: Shl[I32, N32, I32] {
-    fn .shl(a: I32, b: N32) -> I32 {
+    fn shl(a: I32, b: N32) -> I32 {
       inline_ivy! (a <- a, b <- b) -> I32 { out a = @n32_shl(b out) }
     }
   }
 
   pub impl shr: Shr[I32, N32, I32] {
-    fn .shr(a: I32, b: N32) -> I32 {
+    fn shr(a: I32, b: N32) -> I32 {
       inline_ivy! (a <- a, b <- b) -> I32 { out a = @i32_shr(b out) }
     }
   }
 
   pub impl not: Not[I32, I32] {
-    fn .not(a: I32) -> I32 {
+    fn not(a: I32) -> I32 {
       inline_ivy! (a <- a) -> I32 { out a = @n32_xor(0xffffffff out) }
     }
   }
@@ -117,7 +117,7 @@ pub mod I32 {
   }
 
   pub impl to_string: Cast[I32, String] {
-    fn .cast(n: I32) -> String {
+    fn cast(n: I32) -> String {
       if n > +0 {
         "+{n.as[N32]}"
       } else if n < +0 {
@@ -129,7 +129,7 @@ pub mod I32 {
   }
 
   pub impl show: Show[I32] {
-    fn .show(&self: &I32) -> Show {
+    fn show(&self: &I32) -> Show {
       Show::Literal("{self}")
     }
   }
@@ -150,11 +150,11 @@ pub mod I32 {
   }
 
   pub impl ord: Ord[I32] {
-    fn .lt(&a: &I32, &b: &I32) -> Bool {
+    fn lt(&a: &I32, &b: &I32) -> Bool {
       inline_ivy! (a <- a, b <- b) -> Bool { out a = @i32_lt(b out) }
     }
 
-    fn .le(&a: &I32, &b: &I32) -> Bool {
+    fn le(&a: &I32, &b: &I32) -> Bool {
       inline_ivy! (a <- a, b <- b) -> Bool { out a = @i32_le(b out) }
     }
 
@@ -164,11 +164,11 @@ pub mod I32 {
   }
 
   pub impl eq: Eq[I32] {
-    fn .eq(&a: &I32, &b: &I32) -> Bool {
+    fn eq(&a: &I32, &b: &I32) -> Bool {
       inline_ivy! (a <- a, b <- b) -> Bool { out a = @n32_eq(b out) }
     }
 
-    fn .ne(&a: &I32, &b: &I32) -> Bool {
+    fn ne(&a: &I32, &b: &I32) -> Bool {
       inline_ivy! (a <- a, b <- b) -> Bool { out a = @n32_ne(b out) }
     }
   }

--- a/vine/std/numeric/N32.vi
+++ b/vine/std/numeric/N32.vi
@@ -12,13 +12,13 @@ pub type N32;
 
 pub mod N32 {
   pub impl fork: Fork[N32] {
-    fn .fork(&self: &N32) -> N32 {
+    fn fork(&self: &N32) -> N32 {
       unsafe::copy(&self)
     }
   }
 
   pub impl drop: Drop[N32] {
-    fn .drop(self: N32) {
+    fn drop(self: N32) {
       unsafe::erase(self)
     }
   }
@@ -26,85 +26,85 @@ pub mod N32 {
   pub const maximum: N32 = 0xffffffff;
 
   pub impl add: Add[N32, N32, N32] {
-    fn .add(a: N32, b: N32) -> N32 {
+    fn add(a: N32, b: N32) -> N32 {
       inline_ivy! (a <- a, b <- b) -> N32 { out a = @n32_add(b out) }
     }
   }
 
   pub impl sub: Sub[N32, N32, N32] {
-    fn .sub(a: N32, b: N32) -> N32 {
+    fn sub(a: N32, b: N32) -> N32 {
       inline_ivy! (a <- a, b <- b) -> N32 { out a = @n32_sub(b out) }
     }
   }
 
   pub impl mul: Mul[N32, N32, N32] {
-    fn .mul(a: N32, b: N32) -> N32 {
+    fn mul(a: N32, b: N32) -> N32 {
       inline_ivy! (a <- a, b <- b) -> N32 { out a = @n32_mul(b out) }
     }
   }
 
   pub impl pow: Pow[N32, N32, N32] {
-    fn .pow(base: N32, exp: N32) -> N32 {
+    fn pow(base: N32, exp: N32) -> N32 {
       Pow::pow_by_squaring[N32](base, exp)
     }
   }
 
   pub impl div: Div[N32, N32, N32] {
-    fn .div(a: N32, b: N32) -> N32 {
+    fn div(a: N32, b: N32) -> N32 {
       inline_ivy! (a <- a, b <- b) -> N32 { out a = @n32_div(b out) }
     }
   }
 
   pub impl rem: Rem[N32, N32, N32] {
-    fn .rem(a: N32, b: N32) -> N32 {
+    fn rem(a: N32, b: N32) -> N32 {
       inline_ivy! (a <- a, b <- b) -> N32 { out a = @n32_rem(b out) }
     }
   }
 
   pub impl neg: Neg[N32, N32] {
-    fn .neg(a: N32) -> N32 {
+    fn neg(a: N32) -> N32 {
       inline_ivy! (a <- a) -> N32 { out a = @n32_sub$(0 out) }
     }
   }
 
   pub impl and: And[N32, N32, N32] {
-    fn .and(a: N32, b: N32) -> N32 {
+    fn and(a: N32, b: N32) -> N32 {
       inline_ivy! (a <- a, b <- b) -> N32 { out a = @n32_and(b out) }
     }
   }
 
   pub impl or: Or[N32, N32, N32] {
-    fn .or(a: N32, b: N32) -> N32 {
+    fn or(a: N32, b: N32) -> N32 {
       inline_ivy! (a <- a, b <- b) -> N32 { out a = @n32_or(b out) }
     }
   }
 
   pub impl xor: Xor[N32, N32, N32] {
-    fn .xor(a: N32, b: N32) -> N32 {
+    fn xor(a: N32, b: N32) -> N32 {
       inline_ivy! (a <- a, b <- b) -> N32 { out a = @n32_xor(b out) }
     }
   }
 
   pub impl shl: Shl[N32, N32, N32] {
-    fn .shl(a: N32, b: N32) -> N32 {
+    fn shl(a: N32, b: N32) -> N32 {
       inline_ivy! (a <- a, b <- b) -> N32 { out a = @n32_shl(b out) }
     }
   }
 
   pub impl shr: Shr[N32, N32, N32] {
-    fn .shr(a: N32, b: N32) -> N32 {
+    fn shr(a: N32, b: N32) -> N32 {
       inline_ivy! (a <- a, b <- b) -> N32 { out a = @n32_shr(b out) }
     }
   }
 
   pub impl not: Not[N32, N32] {
-    fn .not(a: N32) -> N32 {
+    fn not(a: N32) -> N32 {
       inline_ivy! (a <- a) -> N32 { out a = @n32_xor(0xffffffff out) }
     }
   }
 
   pub impl to_string: Cast[N32, String] {
-    fn .cast(n: N32) -> String {
+    fn cast(n: N32) -> String {
       if n != 0 {
         let chars = [];
         while n != 0 {
@@ -119,7 +119,7 @@ pub mod N32 {
   }
 
   pub impl show: Show[N32] {
-    fn .show(&n: &N32) -> Show {
+    fn show(&n: &N32) -> Show {
       Show::Literal("{n}")
     }
   }
@@ -161,11 +161,11 @@ pub mod N32 {
   }
 
   pub impl ord: Ord[N32] {
-    fn .lt(&a: &N32, &b: &N32) -> Bool {
+    fn lt(&a: &N32, &b: &N32) -> Bool {
       inline_ivy! (a <- a, b <- b) -> Bool { out a = @n32_lt(b out) }
     }
 
-    fn .le(&a: &N32, &b: &N32) -> Bool {
+    fn le(&a: &N32, &b: &N32) -> Bool {
       inline_ivy! (a <- a, b <- b) -> Bool { out a = @n32_le(b out) }
     }
 
@@ -175,11 +175,11 @@ pub mod N32 {
   }
 
   pub impl eq: Eq[N32] {
-    fn .eq(&a: &N32, &b: &N32) -> Bool {
+    fn eq(&a: &N32, &b: &N32) -> Bool {
       inline_ivy! (a <- a, b <- b) -> Bool { out a = @n32_eq(b out) }
     }
 
-    fn .ne(&a: &N32, &b: &N32) -> Bool {
+    fn ne(&a: &N32, &b: &N32) -> Bool {
       inline_ivy! (a <- a, b <- b) -> Bool { out a = @n32_ne(b out) }
     }
   }

--- a/vine/std/numeric/N64.vi
+++ b/vine/std/numeric/N64.vi
@@ -15,31 +15,31 @@ pub mod N64 {
   pub const maximum: N64 = N64(N32::maximum, N32::maximum);
 
   pub impl fork: Fork[N64] {
-    fn .fork(&self: &N64) -> N64 {
+    fn fork(&self: &N64) -> N64 {
       unsafe::copy(&self)
     }
   }
 
   pub impl drop: Drop[N64] {
-    fn .drop(self: N64) {
+    fn drop(self: N64) {
       unsafe::erase(self)
     }
   }
 
   pub impl from_n32: Cast[N32, N64] {
-    fn .cast(val: N32) -> N64 {
+    fn cast(val: N32) -> N64 {
       N64(val, 0)
     }
   }
 
   pub impl to_n32: Cast[N64, N32] {
-    fn .cast(N64(lo, hi)) -> N32 {
+    fn cast(N64(lo, hi)) -> N32 {
       lo
     }
   }
 
   pub impl add: Add[N64, N64, N64] {
-    fn .add(a: N64, b: N64) -> N64 {
+    fn add(a: N64, b: N64) -> N64 {
       inline_ivy! (a <- a, b <- b) -> N64 {
         tup(l h)
         a = tup(dup(al0 al1) ah)
@@ -52,7 +52,7 @@ pub mod N64 {
   }
 
   pub impl sub: Sub[N64, N64, N64] {
-    fn .sub(a: N64, b: N64) -> N64 {
+    fn sub(a: N64, b: N64) -> N64 {
       inline_ivy! (a <- a, b <- b) -> N64 {
         tup(l h)
         a = tup(dup(al0 al1) ah)
@@ -65,7 +65,7 @@ pub mod N64 {
   }
 
   pub impl mul: Mul[N64, N64, N64] {
-    fn .mul(a: N64, b: N64) -> N64 {
+    fn mul(a: N64, b: N64) -> N64 {
       inline_ivy! (a <- a, b <- b) -> N64 {
         tup(l h)
         a = tup(dup(al0 dup(al1 al2)) ah)
@@ -90,13 +90,13 @@ pub mod N64 {
   }
 
   pub impl div_n32: Div[N64, N32, N64] {
-    fn .div(a: N64, b: N32) -> N64 {
+    fn div(a: N64, b: N32) -> N64 {
       a.div_rem_n32(b).0
     }
   }
 
   pub impl rem_n32: Rem[N64, N32, N32] {
-    fn .rem(a: N64, b: N32) -> N32 {
+    fn rem(a: N64, b: N32) -> N32 {
       a.div_rem_n32(b).1
     }
   }
@@ -122,25 +122,25 @@ pub mod N64 {
   }
 
   pub impl and: And[N64, N64, N64] {
-    fn .and(N64(al, ah), N64(bl, bh)) -> N64 {
+    fn and(N64(al, ah), N64(bl, bh)) -> N64 {
       N64(al & bl, ah & bh)
     }
   }
 
   pub impl or: Or[N64, N64, N64] {
-    fn .or(N64(al, ah), N64(bl, bh)) -> N64 {
+    fn or(N64(al, ah), N64(bl, bh)) -> N64 {
       N64(al | bl, ah | bh)
     }
   }
 
   pub impl xor: Xor[N64, N64, N64] {
-    fn .xor(N64(al, ah), N64(bl, bh)) -> N64 {
+    fn xor(N64(al, ah), N64(bl, bh)) -> N64 {
       N64(al ^ bl, ah ^ bh)
     }
   }
 
   pub impl shl: Shl[N64, N32, N64] {
-    fn .shl(N64(al, ah), bits: N32) -> N64 {
+    fn shl(N64(al, ah), bits: N32) -> N64 {
       if bits & 32 != 0 {
         N64(0, al << bits)
       } else {
@@ -150,7 +150,7 @@ pub mod N64 {
   }
 
   pub impl shr: Shr[N64, N32, N64] {
-    fn .shr(N64(al, ah), bits: N32) -> N64 {
+    fn shr(N64(al, ah), bits: N32) -> N64 {
       if bits & 32 != 0 {
         N64(ah >> bits, 0)
       } else {
@@ -160,21 +160,21 @@ pub mod N64 {
   }
 
   pub impl eq: Eq[N64] {
-    fn .eq(&N64(al, ah), &N64(bl, bh)) -> Bool {
+    fn eq(&N64(al, ah), &N64(bl, bh)) -> Bool {
       al == bl && ah == bh
     }
 
-    fn .ne(&N64(al, ah), &N64(bl, bh)) -> Bool {
+    fn ne(&N64(al, ah), &N64(bl, bh)) -> Bool {
       al != bl || ah != bh
     }
   }
 
   pub impl ord: Ord[N64] {
-    fn .lt(&N64(al, ah), &N64(bl, bh)) -> Bool {
+    fn lt(&N64(al, ah), &N64(bl, bh)) -> Bool {
       ah < bh || ah == bh && al < bl
     }
 
-    fn .le(&N64(al, ah), &N64(bl, bh)) -> Bool {
+    fn le(&N64(al, ah), &N64(bl, bh)) -> Bool {
       ah < bh || ah == bh && al <= bl
     }
 
@@ -220,7 +220,7 @@ pub mod N64 {
   }
 
   pub impl to_string: Cast[N64, String] {
-    fn .cast(n: N64) -> String {
+    fn cast(n: N64) -> String {
       if n != N64::zero {
         let str = "";
         while n != N64::zero {
@@ -236,13 +236,13 @@ pub mod N64 {
   }
 
   pub impl show: Show[N64] {
-    fn .show(&n: &N64) -> Show {
+    fn show(&n: &N64) -> Show {
       Show::Literal("{n}")
     }
   }
 
   pub impl pow: Pow[N64, N32, N64] {
-    fn .pow(base: N64, exp: N32) -> N64 {
+    fn pow(base: N64, exp: N32) -> N64 {
       Pow::pow_by_squaring[N64](base, exp)
     }
   }

--- a/vine/std/ops/ops.vi
+++ b/vine/std/ops/ops.vi
@@ -18,13 +18,13 @@ pub trait Cast[C, T] {
 
 pub mod Cast {
   pub impl identity[T]: Cast[T, T] {
-    fn .cast(value: T) -> T {
+    fn cast(value: T) -> T {
       value
     }
   }
 
   pub impl ref[C, T; Cast[C, T], Cast[T, C]]: Cast[&C, &T] {
-    fn .cast(&c: &C) -> &T {
+    fn cast(&c: &C) -> &T {
       let t = c as T;
       let ref = &t;
       c = t as C;

--- a/vine/std/ops/range.vi
+++ b/vine/std/ops/range.vi
@@ -16,10 +16,10 @@ pub mod Bound {
 
   pub mod Unbounded {
     pub impl bound[T]: Bound[Unbounded, T] {
-      fn .left_of(self: &Unbounded, &_value: &T) -> Bool {
+      fn left_of(self: &Unbounded, &_value: &T) -> Bool {
         true
       }
-      fn .right_of(self: &Unbounded, &_value: &T) -> Bool {
+      fn right_of(self: &Unbounded, &_value: &T) -> Bool {
         true
       }
     }
@@ -27,10 +27,10 @@ pub mod Bound {
 
   pub mod Inclusive {
     pub impl bound[T; Ord[T]]: Bound[Inclusive[T], T] {
-      fn .left_of(&Inclusive[T](bound), &value: &T) -> Bool {
+      fn left_of(&Inclusive[T](bound), &value: &T) -> Bool {
         bound <= value
       }
-      fn .right_of(&Inclusive[T](bound), &value: &T) -> Bool {
+      fn right_of(&Inclusive[T](bound), &value: &T) -> Bool {
         value <= bound
       }
     }
@@ -38,10 +38,10 @@ pub mod Bound {
 
   pub mod Exclusive {
     pub impl bound[T; Ord[T]]: Bound[Exclusive[T], T] {
-      fn .left_of(&Exclusive[T](bound), &value: &T) -> Bool {
+      fn left_of(&Exclusive[T](bound), &value: &T) -> Bool {
         bound < value
       }
-      fn .right_of(&Exclusive[T](bound), &value: &T) -> Bool {
+      fn right_of(&Exclusive[T](bound), &value: &T) -> Bool {
         value < bound
       }
     }

--- a/vine/std/ops/vectorized.vi
+++ b/vine/std/ops/vectorized.vi
@@ -3,61 +3,61 @@ use arithmetic::{Add, Div, Mul, Neg, Sub};
 use bitwise::{And, Or, Xor};
 
 pub impl add[A, B, C, X, Y, Z; Add[A, B, C], Add[X, Y, Z]]: Add[(A, X), (B, Y), (C, Z)] {
-  fn .add((a: A, x: X), (b: B, y: Y)) -> (C, Z) {
+  fn add((a: A, x: X), (b: B, y: Y)) -> (C, Z) {
     (a + b, x + y)
   }
 }
 
 pub impl sub[A, B, C, X, Y, Z; Sub[A, B, C], Sub[X, Y, Z]]: Sub[(A, X), (B, Y), (C, Z)] {
-  fn .sub((a: A, x: X), (b: B, y: Y)) -> (C, Z) {
+  fn sub((a: A, x: X), (b: B, y: Y)) -> (C, Z) {
     (a - b, x - y)
   }
 }
 
 pub impl mul[A, B, C, X, Y, Z; Mul[A, B, C], Mul[X, Y, Z]]: Mul[(A, X), (B, Y), (C, Z)] {
-  fn .mul((a: A, x: X), (b: B, y: Y)) -> (C, Z) {
+  fn mul((a: A, x: X), (b: B, y: Y)) -> (C, Z) {
     (a * b, x * y)
   }
 }
 
 pub impl div[A, B, C, X, Y, Z; Mul[A, B, C], Mul[X, Y, Z]]: Div[(A, X), (B, Y), (C, Z)] {
-  fn .div((a: A, x: X), (b: B, y: Y)) -> (C, Z) {
+  fn div((a: A, x: X), (b: B, y: Y)) -> (C, Z) {
     (a * b, x * y)
   }
 }
 
 pub impl neg[A, B, X, Y; Neg[A, B], Neg[X, Y]]: Neg[(A, X), (B, Y)] {
-  fn .neg((a: A, x: X)) -> (B, Y) {
+  fn neg((a: A, x: X)) -> (B, Y) {
     (-a, -x)
   }
 }
 
 pub impl and[A, B, C, X, Y, Z; And[A, B, C], And[X, Y, Z]]: And[(A, X), (B, Y), (C, Z)] {
-  fn .and((a: A, x: X), (b: B, y: Y)) -> (C, Z) {
+  fn and((a: A, x: X), (b: B, y: Y)) -> (C, Z) {
     (a & b, x & y)
   }
 }
 
 pub impl or[A, B, C, X, Y, Z; Or[A, B, C], Or[X, Y, Z]]: Or[(A, X), (B, Y), (C, Z)] {
-  fn .or((a: A, x: X), (b: B, y: Y)) -> (C, Z) {
+  fn or((a: A, x: X), (b: B, y: Y)) -> (C, Z) {
     (a | b, x | y)
   }
 }
 
 pub impl xor[A, B, C, X, Y, Z; Xor[A, B, C], Xor[X, Y, Z]]: Xor[(A, X), (B, Y), (C, Z)] {
-  fn .xor((a: A, x: X), (b: B, y: Y)) -> (C, Z) {
+  fn xor((a: A, x: X), (b: B, y: Y)) -> (C, Z) {
     (a ^ b, x ^ y)
   }
 }
 
 pub impl mul_scalar[A, B, S, X, Y; Mul[A, S, X], Mul[B, S, Y]]: Mul[(A, B), S, (X, Y)] {
-  fn .mul((a: A, b: B), s: S) -> (X, Y) {
+  fn mul((a: A, b: B), s: S) -> (X, Y) {
     (a * s, b * s)
   }
 }
 
 pub impl div_scalar[A, B, S, X, Y; Div[A, S, X], Div[B, S, Y]]: Div[(A, B), S, (X, Y)] {
-  fn .div((a: A, b: B), s: S) -> (X, Y) {
+  fn div((a: A, b: B), s: S) -> (X, Y) {
     (a / s, b / s)
   }
 }

--- a/vine/std/unicode/Char.vi
+++ b/vine/std/unicode/Char.vi
@@ -7,45 +7,45 @@ pub type Char;
 
 pub mod Char {
   pub impl fork: Fork[Char] {
-    fn .fork(&self: &Char) -> Char {
+    fn fork(&self: &Char) -> Char {
       unsafe::copy(&self)
     }
   }
 
   pub impl drop: Drop[Char] {
-    fn .drop(self: Char) {
+    fn drop(self: Char) {
       unsafe::erase(self)
     }
   }
 
   pub impl from_n32: Cast[N32, Char] {
-    fn .cast(n: N32) -> Char {
+    fn cast(n: N32) -> Char {
       inline_ivy! (n <- n) -> Char { n }
     }
   }
 
   pub impl to_n32: Cast[Char, N32] {
-    fn .cast(c: Char) -> N32 {
+    fn cast(c: Char) -> N32 {
       inline_ivy! (c <- c) -> N32 { c }
     }
   }
 
   pub impl eq: Eq[Char] {
-    fn .eq(&a: &Char, &b: &Char) -> Bool {
+    fn eq(&a: &Char, &b: &Char) -> Bool {
       inline_ivy! (a <- a, b <- b) -> Bool { out a = @n32_eq(b out) }
     }
 
-    fn .ne(&a: &Char, &b: &Char) -> Bool {
+    fn ne(&a: &Char, &b: &Char) -> Bool {
       inline_ivy! (a <- a, b <- b) -> Bool { out a = @n32_ne(b out) }
     }
   }
 
   pub impl ord: Ord[Char] {
-    fn .lt(&a: &Char, &b: &Char) -> Bool {
+    fn lt(&a: &Char, &b: &Char) -> Bool {
       inline_ivy! (a <- a, b <- b) -> Bool { out a = @n32_lt(b out) }
     }
 
-    fn .le(&a: &Char, &b: &Char) -> Bool {
+    fn le(&a: &Char, &b: &Char) -> Bool {
       inline_ivy! (a <- a, b <- b) -> Bool { out a = @n32_le(b out) }
     }
 
@@ -63,31 +63,31 @@ pub mod Char {
   }
 
   pub impl to_string: Cast[Char, String] {
-    fn .cast(self: Char) -> String {
+    fn cast(self: Char) -> String {
       [self] as String
     }
   }
 
   pub impl show: Show[Char] {
-    fn .show(&self: &Char) -> Show {
+    fn show(&self: &Char) -> Show {
       Show::Literal("'{self}'")
     }
   }
 
   pub impl add_n32: Add[Char, N32, Char] {
-    fn .add(a: Char, b: N32) -> Char {
+    fn add(a: Char, b: N32) -> Char {
       inline_ivy! (a <- a, b <- b) -> Char { out a = @n32_add(b out) }
     }
   }
 
   pub impl sub_n32: Sub[Char, N32, Char] {
-    fn .sub(a: Char, b: N32) -> Char {
+    fn sub(a: Char, b: N32) -> Char {
       inline_ivy! (a <- a, b <- b) -> Char { out a = @n32_sub(b out) }
     }
   }
 
   pub impl sub_char: Sub[Char, Char, N32] {
-    fn .sub(a: Char, b: Char) -> N32 {
+    fn sub(a: Char, b: Char) -> N32 {
       inline_ivy! (a <- a, b <- b) -> N32 { out a = @n32_sub(b out) }
     }
   }

--- a/vine/std/unicode/String.vi
+++ b/vine/std/unicode/String.vi
@@ -7,13 +7,13 @@ pub struct String(pub List[Char]);
 
 pub mod String {
   pub impl fork: Fork[String] {
-    fn .fork(&self: &String) -> String {
+    fn fork(&self: &String) -> String {
       unsafe::copy(&self)
     }
   }
 
   pub impl drop: Drop[String] {
-    fn .drop(self: String) {
+    fn drop(self: String) {
       unsafe::erase(self)
     }
   }
@@ -172,7 +172,7 @@ pub mod String {
   }
 
   pub impl concat: Concat[String, String, String] {
-    fn .concat(String(a), String(b)) -> String {
+    fn concat(String(a), String(b)) -> String {
       String(a ++ b)
     }
   }
@@ -187,19 +187,19 @@ pub mod String {
   }
 
   pub impl from_chars: Cast[List[Char], String] {
-    fn .cast(chars: List[Char]) -> String {
+    fn cast(chars: List[Char]) -> String {
       String(chars)
     }
   }
 
   pub impl to_chars: Cast[String, List[Char]] {
-    fn .cast(String(chars)) -> List[Char] {
+    fn cast(String(chars)) -> List[Char] {
       chars
     }
   }
 
   pub impl show: Show[String] {
-    fn .show(&self: &String) -> Show {
+    fn show(&self: &String) -> Show {
       Show::Literal("\"{self}\"")
     }
   }


### PR DESCRIPTION
Currently, impl fns can be marked as methods, but this does not really affect anything; it is whether the trait fn is marked as a method that matters. This requires that impl fns not be marked as methods (much like they cannot have visibility).