### PR TITLE
vine: fix checker bug re fork/drop impl param shorthand

### DIFF
--- a/tests/programs/repl/misc.vi
+++ b/tests/programs/repl/misc.vi
@@ -67,6 +67,6 @@ Ok(true)?
 fn foo() -> N32 { Ok(123)? }
 fn foo() -> Result[N32, String] { Ok(123)? }
 fn foo() -> Result[N32, String] { Err(123)? }
-let x = (1, 2.0, [Some(Ok(true)), Some(Err("hi")), None], ((), ((),), ((), ())));
+let x = (1, 2.0, ([Some(Ok(true)), Some(Err("hi")), None], [1, 2, 3] as Array), ((), ((),), ((), ())));
 x.fork()
 x.drop(); let x;

--- a/tests/snaps/vine/repl/misc.repl.vi
+++ b/tests/snaps/vine/repl/misc.repl.vi
@@ -285,15 +285,15 @@ io = #io
 error input:1:35 - cannot try `Result[?4, N32]` in a function returning `Result[N32, String]`
 
 io = #io
-> let x = (1, 2.0, [Some(Ok(true)), Some(Err("hi")), None], ((), ((),), ((), ())));
+> let x = (1, 2.0, ([Some(Ok(true)), Some(Err("hi")), None], [1, 2, 3] as Array), ((), ((),), ((), ())));
 
 io = #io
-x = (1, 2.0, [Some(Ok(true)), Some(Err("hi")), None], ((), ((),), ((), ())))
+x = (1, 2.0, ([Some(Ok(true)), Some(Err("hi")), None], Array(3, Node(Node(Node(#ivy(1)), Node(#ivy(3))), Node(#ivy(2))))), ((), ((),), ((), ())))
 > x.fork()
-(1, 2.0, [Some(Ok(true)), Some(Err("hi")), None], ((), ((),), ((), ())))
+(1, 2.0, ([Some(Ok(true)), Some(Err("hi")), None], Array(3, Node(Node(Node(#ivy(1)), Node(#ivy(3))), Node(#ivy(2))))), ((), ((),), ((), ())))
 
 io = #io
-x = (1, 2.0, [Some(Ok(true)), Some(Err("hi")), None], ((), ((),), ((), ())))
+x = (1, 2.0, ([Some(Ok(true)), Some(Err("hi")), None], Array(3, Node(Node(Node(#ivy(1)), Node(#ivy(3))), Node(#ivy(2))))), ((), ((),), ((), ())))
 > x.drop(); let x;
 
 io = #io

--- a/vine/src/checker.rs
+++ b/vine/src/checker.rs
@@ -611,10 +611,14 @@ impl<'core, 'a> Checker<'core, 'a> {
     if !inference || !args.types.is_empty() {
       check_count(args.types.len(), params.type_params.len(), "type");
     }
+    let impl_param_count =
+      // Things with no inference cannot have implementation parameters; skip
+      // checking the `GenericsSig` as this may not have been resolved yet.
+      if !inference { 0 } else { self.sigs.generics[params_id].inner.impl_params.len() };
     if !args.impls.is_empty() {
-      check_count(args.impls.len(), params.impl_params.len(), "impl");
+      check_count(args.impls.len(), impl_param_count, "impl");
     }
-    let has_impl_params = !params.impl_params.is_empty();
+    let has_impl_params = impl_param_count != 0;
     let type_param_count = params.type_params.len();
     let type_params = if let Some(type_params) = type_params {
       for (a, b) in type_params.iter().zip(args.types.iter_mut()) {


### PR DESCRIPTION
The checker was previously looking at the number of implementation parameters declared in the AST, and thus failing to account for the impl parameters from the `+`/`?`/`*` annotation. This was not being caught before as it would only be encountered for functions with these impl parameters.