### PR TITLE
std: standardize container get and at methods

### DIFF
--- a/tests/programs/aoc_2024/day_04.vi
+++ b/tests/programs/aoc_2024/day_04.vi
@@ -5,7 +5,7 @@ pub fn main(&io: &IO) {
     lines ++= [chars];
   }
 
-  let matches = diamond(
+  let matches = diamond[Char, Char, N32](
     lines,
     fn(char: Char, Neighbors[Char](nw, n, ne, w, e, sw, s, se), &matches: &N32) {
       if char == 'X' {
@@ -39,7 +39,7 @@ pub fn main(&io: &IO) {
 
   io.println("XMAS: {matches}");
 
-  let matches = diamond(
+  let matches = diamond[Char, Char, N32](
     lines,
     fn(char: Char, Neighbors[Char](nw, _, ne, _, _, sw, _, se), &matches: &N32) {
       if char == 'A' {
@@ -110,8 +110,8 @@ struct Neighbors[M]((
   Channel[M],
 ));
 
-fn diamond[T, M, X](grid: List[List[T]], f: fn(T, Neighbors[M], &X), d: M, state: X) -> X {
-  let width = (*grid.get(0)).len();
+fn diamond[T, M, X; Fork[T]](grid: List[List[T]], f: fn(T, Neighbors[M], &X), d: M, state: X) -> X {
+  let width = (grid.get(0).unwrap(); _).len();
   let north = List::new(width, neglect_channel(d));
   let north_west = List::new(width, neglect_channel(d));
   let north_east = List::new(width, neglect_channel(d));

--- a/tests/programs/aoc_2024/day_04.vi
+++ b/tests/programs/aoc_2024/day_04.vi
@@ -110,7 +110,7 @@ struct Neighbors[M]((
   Channel[M],
 ));
 
-fn diamond[T, M, X; Fork[T]](grid: List[List[T]], f: fn(T, Neighbors[M], &X), d: M, state: X) -> X {
+fn diamond[T+, M, X](grid: List[List[T]], f: fn(T, Neighbors[M], &X), d: M, state: X) -> X {
   let width = (*grid.at(0).unwrap()).len();
   let north = List::new(width, neglect_channel(d));
   let north_west = List::new(width, neglect_channel(d));

--- a/tests/programs/aoc_2024/day_04.vi
+++ b/tests/programs/aoc_2024/day_04.vi
@@ -111,7 +111,7 @@ struct Neighbors[M]((
 ));
 
 fn diamond[T, M, X; Fork[T]](grid: List[List[T]], f: fn(T, Neighbors[M], &X), d: M, state: X) -> X {
-  let width = (grid.get(0).unwrap(); _).len();
+  let width = (*grid.at(0).unwrap()).len();
   let north = List::new(width, neglect_channel(d));
   let north_west = List::new(width, neglect_channel(d));
   let north_east = List::new(width, neglect_channel(d));

--- a/tests/programs/aoc_2024/day_05.vi
+++ b/tests/programs/aoc_2024/day_05.vi
@@ -8,7 +8,7 @@ pub fn main(&io: &IO) {
     let (left, right) = line.split_once("|");
     let a = N32::parse(left).unwrap();
     let b = N32::parse(right.unwrap()).unwrap();
-    set_bit(masks.get(b), a, true);
+    set_bit(masks.at(b).unwrap(), a, true);
   }
 
   let part1 = 0;
@@ -16,12 +16,12 @@ pub fn main(&io: &IO) {
   while io.read_line() is Some(line) {
     let nums = line.split(",").map(fn(x) { N32::parse(x).unwrap() });
     let good = true;
-    let middle = *nums.get(nums.len() / 2);
+    let middle = nums.get(nums.len() / 2).unwrap();
     let mask = ((0, 0), (0, 0));
     let iter = nums.iter();
     while iter.next() is Some(&num) {
       good &= !get_bit(mask, num);
-      mask |= *masks.get(num);
+      mask |= masks.get(num).unwrap();
     }
     iter.drop_iter();
     if good {
@@ -35,14 +35,14 @@ pub fn main(&io: &IO) {
       let out = [];
       let pending = [];
       while nums.pop_front() is Some(num) {
-        let mask = *masks.get(num) & nums_mask;
+        let mask = masks.get(num).unwrap() & nums_mask;
         if is_empty(mask) {
           process(num, &(out, pending, nums_mask));
         } else {
           pending ++= [(num, mask)];
         }
       }
-      part2 += *out.get(out.len() / 2);
+      part2 += out.get(out.len() / 2).unwrap();
 
       fn process(num: N32, &(out: List[N32], pending: List[(N32, Mask)], nums_mask: Mask)) {
         out ++= [num];

--- a/tests/programs/aoc_2024/day_06.vi
+++ b/tests/programs/aoc_2024/day_06.vi
@@ -50,7 +50,7 @@ pub fn main(&io: &IO) {
 
 fn clear(&grid: &Array[Array[Char]], &spaces: &List[(N32, N32)]) {
   let height = grid.len();
-  let width = (grid.get(0).unwrap(); _).len();
+  let width = (*grid.at(0).unwrap()).len();
   let y = 0;
   while y < height {
     let &row = grid.at(y).unwrap();
@@ -69,7 +69,7 @@ fn clear(&grid: &Array[Array[Char]], &spaces: &List[(N32, N32)]) {
 
 fn walk(&grid: &Array[Array[Char]], pos: (N32, N32)) -> (Bool, N32) {
   let height = grid.len();
-  let width = (grid.get(0).unwrap(); _).len();
+  let width = (*grid.at(0).unwrap()).len();
   let dir = (0, -(1));
   let distinct = 1;
   let repeat = 0;

--- a/tests/programs/aoc_2024/day_06.vi
+++ b/tests/programs/aoc_2024/day_06.vi
@@ -36,7 +36,7 @@ pub fn main(&io: &IO) {
   let loops = 0;
   while spaces.pop_front() is Some(x, y) {
     let grid = grid;
-    *(*grid.get(y)).get(x) = '#';
+    *(*grid.at(y).unwrap()).at(x).unwrap() = '#';
     let (looped, _) = walk(&grid, guard_pos);
     if looped {
       loops += 1;
@@ -50,13 +50,13 @@ pub fn main(&io: &IO) {
 
 fn clear(&grid: &Array[Array[Char]], &spaces: &List[(N32, N32)]) {
   let height = grid.len();
-  let width = (*grid.get(0)).len();
+  let width = (grid.get(0).unwrap(); _).len();
   let y = 0;
   while y < height {
-    let &row = grid.get(y);
+    let &row = grid.at(y).unwrap();
     let x = 0;
     while x < width {
-      let &cell = row.get(x);
+      let &cell = row.at(x).unwrap();
       if cell == 'X' {
         spaces ++= [(x, y)];
         cell = '.';
@@ -69,7 +69,7 @@ fn clear(&grid: &Array[Array[Char]], &spaces: &List[(N32, N32)]) {
 
 fn walk(&grid: &Array[Array[Char]], pos: (N32, N32)) -> (Bool, N32) {
   let height = grid.len();
-  let width = (*grid.get(0)).len();
+  let width = (grid.get(0).unwrap(); _).len();
   let dir = (0, -(1));
   let distinct = 1;
   let repeat = 0;
@@ -80,7 +80,7 @@ fn walk(&grid: &Array[Array[Char]], pos: (N32, N32)) -> (Bool, N32) {
     if x >= width || y >= height {
       return (false, distinct);
     }
-    let &cell = (*grid.get(y)).get(x);
+    let &cell = (*grid.at(y).unwrap()).at(x).unwrap();
     if cell == '#' {
       let (x, y) = dir;
       dir = (-y, x);

--- a/tests/programs/aoc_2024/day_08.vi
+++ b/tests/programs/aoc_2024/day_08.vi
@@ -10,7 +10,7 @@ pub fn main(&io: &IO) {
 
   let grid = input.split_trim("\n");
 
-  let width = (grid.get(0).unwrap(); _).len();
+  let width = (*grid.at(0).unwrap()).len();
   let height = grid.len();
 
   let fn check_antinode((x: N32, y: N32)) {

--- a/tests/programs/aoc_2024/day_08.vi
+++ b/tests/programs/aoc_2024/day_08.vi
@@ -10,7 +10,7 @@ pub fn main(&io: &IO) {
 
   let grid = input.split_trim("\n");
 
-  let width = (*grid.get(0)).len();
+  let width = (grid.get(0).unwrap(); _).len();
   let height = grid.len();
 
   let fn check_antinode((x: N32, y: N32)) {
@@ -31,7 +31,7 @@ pub fn main(&io: &IO) {
     let x = 0;
     while row!.pop_front() is Some(frequency) {
       if frequency != '.' {
-        let &antennas = antennas.get_or_insert(frequency, []);
+        let &antennas = antennas.at_or_insert(frequency, []);
         let pos = (x, y);
         let iter = antennas.into_iter();
         while iter.next() is Some(other_pos) {

--- a/tests/programs/aoc_2024/day_09.vi
+++ b/tests/programs/aoc_2024/day_09.vi
@@ -41,7 +41,7 @@ fn part1(input: String) -> N64 {
     let empty = empty.min(remaining);
     remaining -= empty;
     while empty != 0 {
-      let &(id, file) = backward.get(0);
+      let &(id, file) = backward.at(0).unwrap();
       let truncated = file.min(empty);
       file -= truncated;
       if file == 0 {

--- a/tests/programs/aoc_2024/day_10.vi
+++ b/tests/programs/aoc_2024/day_10.vi
@@ -136,7 +136,7 @@ fn check(Channel[Char](i, ~o), recv: Char) -> N32 {
 struct Neighbors[M]((Channel[M], Channel[M], Channel[M], Channel[M]));
 
 fn cross[M, X](grid: List[List[Char]], f: fn(Char, Neighbors[M], &X), d: M, &state: &X) {
-  let width = (grid.get(0).unwrap(); _).len();
+  let width = (*grid.at(0).unwrap()).len();
   let north = List::new(width, neglect_channel(d));
   while grid.pop_front() is Some(row) {
     let west = neglect_channel(d);

--- a/tests/programs/aoc_2024/day_10.vi
+++ b/tests/programs/aoc_2024/day_10.vi
@@ -135,8 +135,8 @@ fn check(Channel[Char](i, ~o), recv: Char) -> N32 {
 
 struct Neighbors[M]((Channel[M], Channel[M], Channel[M], Channel[M]));
 
-fn cross[T, M, X](grid: List[List[T]], f: fn(T, Neighbors[M], &X), d: M, &state: &X) {
-  let width = (*grid.get(0)).len();
+fn cross[M, X](grid: List[List[Char]], f: fn(Char, Neighbors[M], &X), d: M, &state: &X) {
+  let width = (grid.get(0).unwrap(); _).len();
   let north = List::new(width, neglect_channel(d));
   while grid.pop_front() is Some(row) {
     let west = neglect_channel(d);

--- a/tests/programs/aoc_2024/day_11.vi
+++ b/tests/programs/aoc_2024/day_11.vi
@@ -25,7 +25,7 @@ fn blink(&io: &IO, old: Map[N64, N64]) -> Map[N64, N64] {
   let new = Map::empty[N64, _];
   let iter = old.into_iter();
   let fn add_stones(number: N64, count: N64) {
-    let &c = new.get_or_insert(number, N64::zero);
+    let &c = new.at_or_insert(number, N64::zero);
     c += count;
   }
   while iter.next() is Some(number, count) {

--- a/tests/programs/aoc_2024/day_12.vi
+++ b/tests/programs/aoc_2024/day_12.vi
@@ -32,11 +32,11 @@ pub fn main(&io: &IO) {
   let i = 0;
   let &Regions(array) = &regions;
   while i < array.len() {
-    match array.get(i).unwrap() {
-      Region::Root(a, p) {
+    match array.at(i).unwrap() {
+      &Region::Root(a, p) {
         price += a * (a * 4 - p * 2);
       }
-      _ {}
+      &_ {}
     }
     i += 1;
   }
@@ -129,8 +129,8 @@ mod Regions {
   pub fn .get_area(&self: &Regions, i: N32) -> N32 {
     let i = self.find(i);
     let &Regions(array) = &self;
-    match array.get(i).unwrap() {
-      Region::Root(a, _) { a }
+    match array.at(i).unwrap() {
+      &Region::Root(a, _) { a }
     }
   }
 

--- a/tests/programs/aoc_2024/day_12.vi
+++ b/tests/programs/aoc_2024/day_12.vi
@@ -32,7 +32,7 @@ pub fn main(&io: &IO) {
   let i = 0;
   let &Regions(array) = &regions;
   while i < array.len() {
-    match *array.get(i) {
+    match array.get(i).unwrap() {
       Region::Root(a, p) {
         price += a * (a * 4 - p * 2);
       }
@@ -95,6 +95,12 @@ mod Region {
       }
     }
   }
+
+  pub impl fork: Fork[Region] {
+    fn fork(&self: &Region) -> Region {
+      unsafe::copy(&self)
+    }
+  }
 }
 
 mod Regions {
@@ -112,7 +118,7 @@ mod Regions {
 
   pub fn .find(&Regions(array), i: N32) -> N32 {
     let ~root;
-    while array.get(i) is &Region::Child(p) {
+    while array.at(i) is Some(&Region::Child(p)) {
       i = p;
       p = ~root;
     }
@@ -123,22 +129,22 @@ mod Regions {
   pub fn .get_area(&self: &Regions, i: N32) -> N32 {
     let i = self.find(i);
     let &Regions(array) = &self;
-    match *array.get(i) {
+    match array.get(i).unwrap() {
       Region::Root(a, _) { a }
     }
   }
 
   pub fn .union_found(&Regions(array), i: N32, j: N32) -> N32 {
     if i == j {
-      match array.get(i) {
+      match array.at(i).unwrap() {
         &Region::Root(_, p) {
           p += 1;
         }
       }
       i
     } else {
-      let &r = array.get(i);
-      let &s = array.get(j);
+      let &r = array.at(i).unwrap();
+      let &s = array.at(j).unwrap();
       match (r, s) {
         (Region::Root(ra, rp), Region::Root(sa, sp)) {
           let a = ra + sa;

--- a/tests/programs/aoc_2024/day_14.vi
+++ b/tests/programs/aoc_2024/day_14.vi
@@ -17,7 +17,7 @@ pub fn main(&io: &IO) {
     let px = N32::parse(px).unwrap();
     let py = N32::parse(py).unwrap();
     let fn parse_signed(x: String, m: N32) {
-      if *x!.get(0) == '-' {
+      if x!.get(0).unwrap() == '-' {
         x!.pop_front();
         m - N32::parse(x).unwrap()
       } else {
@@ -68,7 +68,7 @@ pub fn main(&io: &IO) {
     while iter.next() is Some(px, py, vx, vy) {
       let x = (px + vx * i) % width;
       let y = (py + vy * i) % height;
-      *(*grid.get(y)).get(x) = '#';
+      *(*grid.at(y).unwrap()).at(x).unwrap() = '#';
     }
     let lines = grid as List;
     while lines.pop_front() is Some(line) {

--- a/tests/programs/aoc_2024/day_15.vi
+++ b/tests/programs/aoc_2024/day_15.vi
@@ -150,7 +150,7 @@ pub fn main(&io: &IO) {
             new_front.push_back((pos_x, '['));
             new_front.push_back((pos_x + 1, ']'));
             let carry = '.';
-            if front.len() != 0 && front.get(0) is Some(p, c) && p == pos_x + 1 {
+            if front.len() != 0 && front.at(0) is Some(&(p, c)) && p == pos_x + 1 {
               front.pop_front();
               carry = c;
             }
@@ -176,7 +176,7 @@ pub fn main(&io: &IO) {
     }
   }
 
-  let width = (grid.get(0).unwrap(); _).len();
+  let width = (*grid.at(0).unwrap()).len();
   let height = grid.len();
 
   let part2 = 0;

--- a/tests/programs/aoc_2024/day_15.vi
+++ b/tests/programs/aoc_2024/day_15.vi
@@ -24,7 +24,7 @@ pub fn main(&io: &IO) {
   let initial_grid = grid;
 
   let fn get((x, y)) {
-    (*grid.get(y)).get(x)
+    (*grid.at(y).unwrap()).at(x).unwrap()
   }
 
   let fn show_grid() {
@@ -150,7 +150,7 @@ pub fn main(&io: &IO) {
             new_front.push_back((pos_x, '['));
             new_front.push_back((pos_x + 1, ']'));
             let carry = '.';
-            if front.len() != 0 && front.get(0) is &(p, c) && p == pos_x + 1 {
+            if front.len() != 0 && front.get(0) is Some(p, c) && p == pos_x + 1 {
               front.pop_front();
               carry = c;
             }
@@ -176,7 +176,7 @@ pub fn main(&io: &IO) {
     }
   }
 
-  let width = (*grid.get(0)).len();
+  let width = (grid.get(0).unwrap(); _).len();
   let height = grid.len();
 
   let part2 = 0;

--- a/tests/programs/aoc_2024/day_16.vi
+++ b/tests/programs/aoc_2024/day_16.vi
@@ -24,13 +24,13 @@ pub fn main(&io: &IO) {
 
   let fn try_insert(dist: N32, pos: (N32, N32), dir) {
     let (x, y) = pos;
-    let &(passable, dirs, _) = (*grid.get(y)).get(x);
+    let &(passable, dirs, _) = (*grid.at(y).unwrap()).at(x).unwrap();
     if passable {
-      let &(min_dist, used) = dirs.get(dir);
+      let &(min_dist, used) = dirs.at(dir).unwrap();
       if dist < min_dist {
         ~used = false;
         min_dist = dist;
-        (*pq.get_or_insert(dist, [])).push_back((pos, dir))
+        (*pq.at_or_insert(dist, [])).push_back((pos, dir))
       }
       if dist == min_dist {
         ~used
@@ -48,8 +48,8 @@ pub fn main(&io: &IO) {
   while !done && pq.remove_min() is Some(dist, heads) {
     while heads.pop_front() is Some(pos, dir) {
       let (px, py) = pos;
-      let &(_, dirs, counted) = (*grid.get(py)).get(px);
-      let &(min_dist, ~used) = dirs.get(dir);
+      let &(_, dirs, counted) = (*grid.at(py).unwrap()).at(px).unwrap();
+      let &(min_dist, ~used) = dirs.at(dir).unwrap();
       if dist <= min_dist {
         min_dist = dist;
         let (ex, ey) = end;

--- a/tests/programs/aoc_2024/day_17.vi
+++ b/tests/programs/aoc_2024/day_17.vi
@@ -24,8 +24,8 @@ pub fn main(&io: &IO) {
   let steps = 100;
   while ip < program.len() && steps != 0 {
     steps -= 1;
-    let opcode = program.get(ip).unwrap();
-    let operand = program.get(ip + 1).unwrap();
+    let &opcode = program.at(ip).unwrap();
+    let &operand = program.at(ip + 1).unwrap();
     let fn combo() {
       if operand == 4 {
         a

--- a/tests/programs/aoc_2024/day_17.vi
+++ b/tests/programs/aoc_2024/day_17.vi
@@ -24,8 +24,8 @@ pub fn main(&io: &IO) {
   let steps = 100;
   while ip < program.len() && steps != 0 {
     steps -= 1;
-    let opcode = *program.get(ip);
-    let operand = *program.get(ip + 1);
+    let opcode = program.get(ip).unwrap();
+    let operand = program.get(ip + 1).unwrap();
     let fn combo() {
       if operand == 4 {
         a

--- a/tests/programs/aoc_2024/day_18.vi
+++ b/tests/programs/aoc_2024/day_18.vi
@@ -73,7 +73,7 @@ pub fn main(&io: &IO) {
   while y < size {
     let x = 0;
     while x < size {
-      if (grid.get(y).unwrap(); _).get(x).unwrap() == N32::maximum {
+      if (*grid.at(y).unwrap()).get(x).unwrap() == N32::maximum {
         i += 1;
         remove_data(x, y);
       }
@@ -90,7 +90,7 @@ pub fn main(&io: &IO) {
     i -= 1;
   }
 
-  let (x, y) = data.get(i).unwrap();
+  let &(x, y) = data.at(i).unwrap();
 
   io.println("Part 2: {x},{y}");
 }
@@ -161,7 +161,7 @@ fn pathfind(grid: Array[Array[N32]], size: N32, iters: N32) -> N32 {
       if cell >= iters {
         cell = 0;
         let fn visit((x: N32, y: N32)) {
-          if x < size && y < size && (grid.get(y).unwrap(); _).get(x).unwrap() >= iters {
+          if x < size && y < size && (*grid.at(y).unwrap()).get(x).unwrap() >= iters {
             next ++= [(x, y)];
           }
         }

--- a/tests/programs/aoc_2024/day_18.vi
+++ b/tests/programs/aoc_2024/day_18.vi
@@ -15,7 +15,7 @@ pub fn main(&io: &IO) {
     let (x, y) = line.split_once(",");
     let x = N32::parse(x).unwrap();
     let y = N32::parse(y.unwrap()).unwrap();
-    *(*grid.get(y)).get(x) = i;
+    *(*grid.at(y).unwrap()).at(x).unwrap() = i;
     data ++= [(x, y)];
     i += 1;
   }
@@ -57,7 +57,7 @@ pub fn main(&io: &IO) {
     let fn connect(dx: N32, dy: N32) {
       let X = x + dx;
       let Y = y + dy;
-      if X < size && Y < size && !*(*blocked.get(Y)).get(X) {
+      if X < size && Y < size && !*(*blocked.at(Y).unwrap()).at(X).unwrap() {
         set.union(coord(x, y), coord(X, Y));
       }
     }
@@ -65,7 +65,7 @@ pub fn main(&io: &IO) {
     connect(-(1), 0);
     connect(0, 1);
     connect(0, -(1));
-    *(*blocked.get(y)).get(x) = false;
+    *(*blocked.at(y).unwrap()).at(x).unwrap() = false;
   }
 
   let i = 0;
@@ -73,7 +73,7 @@ pub fn main(&io: &IO) {
   while y < size {
     let x = 0;
     while x < size {
-      if *(*grid.get(y)).get(x) == N32::maximum {
+      if (grid.get(y).unwrap(); _).get(x).unwrap() == N32::maximum {
         i += 1;
         remove_data(x, y);
       }
@@ -90,7 +90,7 @@ pub fn main(&io: &IO) {
     i -= 1;
   }
 
-  let (x, y) = *data.get(i);
+  let (x, y) = data.get(i).unwrap();
 
   io.println("Part 2: {x},{y}");
 }
@@ -109,7 +109,7 @@ mod DisjointSet {
 
   pub fn .find(&DisjointSet(array), i: N32) -> N32 {
     let ~root;
-    while array.get(i) is &Node::Child(parent) {
+    while array.at(i) is Some(&Node::Child(parent)) {
       i = parent;
       parent = ~root;
     }
@@ -124,8 +124,8 @@ mod DisjointSet {
       return a;
     }
     let &DisjointSet(array) = &self;
-    let &a_node = array.get(a);
-    let &b_node = array.get(b);
+    let &a_node = array.at(a).unwrap();
+    let &b_node = array.at(b).unwrap();
     match (&a_node, &b_node) {
       (&Node::Root(a_size), &Node::Root(b_size)) {
         if a_size < b_size {
@@ -157,11 +157,11 @@ fn pathfind(grid: Array[Array[N32]], size: N32, iters: N32) -> N32 {
         next = [];
         break;
       }
-      let &cell = (*grid.get(y)).get(x);
+      let &cell = (*grid.at(y).unwrap()).at(x).unwrap();
       if cell >= iters {
         cell = 0;
         let fn visit((x: N32, y: N32)) {
-          if x < size && y < size && *(*grid.get(y)).get(x) >= iters {
+          if x < size && y < size && (grid.get(y).unwrap(); _).get(x).unwrap() >= iters {
             next ++= [(x, y)];
           }
         }

--- a/tests/programs/aoc_2024/day_19.vi
+++ b/tests/programs/aoc_2024/day_19.vi
@@ -30,7 +30,7 @@ fn match_counts(design: String, patterns: List[String]) -> Array[N64] {
     let total = N64::zero;
     while patterns.pop_front() is Some(pat) {
       if design.strip_prefix(&pat) is Ok(remaining) {
-        total += *array.get(remaining.len());
+        total += array.get(remaining.len()).unwrap();
       }
     }
     array.push_back(total);

--- a/tests/programs/aoc_2024/day_20.vi
+++ b/tests/programs/aoc_2024/day_20.vi
@@ -46,7 +46,7 @@ pub fn main(&io: &IO) {
   while !eq(cur, end) {
     let next;
     let fn check(pos: (N32, N32)) {
-      if !eq(prev, pos) && (grid.get(pos.1).unwrap(); _).get(pos.0).unwrap() {
+      if !eq(prev, pos) && (*grid.at(pos.1).unwrap()).get(pos.0).unwrap() {
         next = pos;
       }
     }

--- a/tests/programs/aoc_2024/day_20.vi
+++ b/tests/programs/aoc_2024/day_20.vi
@@ -45,8 +45,8 @@ pub fn main(&io: &IO) {
 
   while !eq(cur, end) {
     let next;
-    let fn check(pos) {
-      if !eq(prev, pos) && *(*grid.get(pos.1)).get(pos.0) {
+    let fn check(pos: (N32, N32)) {
+      if !eq(prev, pos) && (grid.get(pos.1).unwrap(); _).get(pos.0).unwrap() {
         next = pos;
       }
     }

--- a/tests/programs/aoc_2024/day_21.vi
+++ b/tests/programs/aoc_2024/day_21.vi
@@ -46,7 +46,7 @@ pub fn main(&io: &IO) {
         }
       }
       let to = pos(char);
-      cost += *(*c.get(last)).get(to);
+      cost += (c.get(last).unwrap(); _).get(to).unwrap();
       last = to;
     }
     let (num, _) = orig.split_once("A");
@@ -156,7 +156,7 @@ fn cost_func(c: CostFunc, size: N32, dead_row: N32) -> CostFunc {
         let ty = to / 3;
         let last = 5;
         let fn press(button: N32) {
-          cost += *(*c.get(last)).get(button);
+          cost += (c.get(last).unwrap(); _).get(button).unwrap();
           last = button;
         }
         let fn do_horiz() {
@@ -191,7 +191,7 @@ fn cost_func(c: CostFunc, size: N32, dead_row: N32) -> CostFunc {
         cost
       }
       let cost = test(true).min(test(false));
-      *(*o.get(from)).get(to) = cost;
+      *(*o.at(from).unwrap()).at(to).unwrap() = cost;
       to += 1;
     }
     from += 1;

--- a/tests/programs/aoc_2024/day_21.vi
+++ b/tests/programs/aoc_2024/day_21.vi
@@ -46,7 +46,7 @@ pub fn main(&io: &IO) {
         }
       }
       let to = pos(char);
-      cost += (c.get(last).unwrap(); _).get(to).unwrap();
+      cost += (*c.at(last).unwrap()).get(to).unwrap();
       last = to;
     }
     let (num, _) = orig.split_once("A");
@@ -156,7 +156,7 @@ fn cost_func(c: CostFunc, size: N32, dead_row: N32) -> CostFunc {
         let ty = to / 3;
         let last = 5;
         let fn press(button: N32) {
-          cost += (c.get(last).unwrap(); _).get(button).unwrap();
+          cost += (*c.at(last).unwrap()).get(button).unwrap();
           last = button;
         }
         let fn do_horiz() {

--- a/tests/programs/aoc_2024/day_22.vi
+++ b/tests/programs/aoc_2024/day_22.vi
@@ -18,10 +18,7 @@ pub fn main(&io: &IO) {
       (a, b, c, d) = (b, c, d, price - last_price);
       last_price = price;
       if i >= 4 {
-        let &(bananas, last_changed) = map.get_or_insert(
-          ((a * 20 + b) * 20 + c) * 20 + d,
-          (0, -(1)),
-        );
+        let &(bananas, last_changed) = map.at_or_insert(((a * 20 + b) * 20 + c) * 20 + d, (0, -(1)));
         if last_changed != buyer {
           bananas += price;
           last_changed = buyer;

--- a/tests/programs/aoc_2024/day_23.vi
+++ b/tests/programs/aoc_2024/day_23.vi
@@ -24,7 +24,7 @@ pub fn main(&io: &IO) {
         let triangle_tips = [];
         let a_out = a_out;
         while a_out.remove_min() is Some(c, _) {
-          let bool = graph.get(&b) is Some(b) && b.get(&c) is Some(_);
+          let bool = graph.at(&b) is Some(&b) && b.at(&c) is Some(&_);
           if bool {
             triangle_tips ++= [c];
             triangles += 1;
@@ -54,7 +54,7 @@ pub fn main(&io: &IO) {
         let out = [];
         let tips = tips;
         while tips.pop_front() is Some(y) {
-          if graph.get(&x) is Some(m) && m.get(&y) is Some(_) {
+          if graph.at(&x) is Some(&m) && m.at(&y) is Some(&_) {
             out ++= [y];
           }
         }

--- a/tests/programs/aoc_2024/day_23.vi
+++ b/tests/programs/aoc_2024/day_23.vi
@@ -12,7 +12,7 @@ pub fn main(&io: &IO) {
     if a > b {
       (b, a) = (a, b)
     }
-    (*graph.get_or_insert(a, Map::empty)).insert(b, ());
+    (*graph.at_or_insert(a, Map::empty)).insert(b, ());
   }
 
   do {
@@ -24,7 +24,7 @@ pub fn main(&io: &IO) {
         let triangle_tips = [];
         let a_out = a_out;
         while a_out.remove_min() is Some(c, _) {
-          let bool = graph.get(&b) is Some(&b) && b.get(&c) is Some(&_);
+          let bool = graph.get(&b) is Some(b) && b.get(&c) is Some(_);
           if bool {
             triangle_tips ++= [c];
             triangles += 1;
@@ -48,13 +48,13 @@ pub fn main(&io: &IO) {
   ) {
     if tips.len() != 0 {
       if clique.len() >= best.len() {
-        best = clique ++ [*tips.get(0)];
+        best = clique ++ [tips.get(0).unwrap()];
       }
       while tips.pop_front() is Some(x) {
         let out = [];
         let tips = tips;
         while tips.pop_front() is Some(y) {
-          if graph.get(&x) is Some(&m) && m.get(&y) is Some(&_) {
+          if graph.get(&x) is Some(m) && m.get(&y) is Some(_) {
             out ++= [y];
           }
         }

--- a/tests/programs/aoc_2024/day_24.vi
+++ b/tests/programs/aoc_2024/day_24.vi
@@ -21,7 +21,7 @@ pub fn main(&io: &IO) {
     let wire_out = move *pieces.at(4).unwrap();
     let a = (*at_wire(wire_a)).get();
     let b = (*at_wire(wire_b)).get();
-    let op = (pieces.get(1).unwrap()!; _).get(0).unwrap();
+    let op = (*pieces.at(1).unwrap())!.get(0).unwrap();
     let out = if op == 'A' {
       a & b
     } else if op == 'O' {

--- a/tests/programs/aoc_2024/day_24.vi
+++ b/tests/programs/aoc_2024/day_24.vi
@@ -6,22 +6,22 @@ pub fn main(&io: &IO) {
 
   while io.read_line() is Some(line) && line.len() != 0 {
     let (name, value) = line.split_once(": ");
-    let value = *(value.unwrap(); _)!.get(0) == '1';
+    let value = (value.unwrap(); _)!.get(0).unwrap() == '1';
     map.insert(name, Wire::input(value));
   }
 
-  let fn get_wire(wire) {
-    map.get_or_insert(wire, Wire::new())
+  let fn at_wire(wire) {
+    map.at_or_insert(wire, Wire::new())
   }
 
   while io.read_line() is Some(line) {
     let pieces = line.split(" ");
-    let wire_a = move *pieces.get(0);
-    let wire_b = move *pieces.get(2);
-    let wire_out = move *pieces.get(4);
-    let a = (*get_wire(wire_a)).get();
-    let b = (*get_wire(wire_b)).get();
-    let op = pieces.get(1).*!.get(0).*;
+    let wire_a = move *pieces.at(0).unwrap();
+    let wire_b = move *pieces.at(2).unwrap();
+    let wire_out = move *pieces.at(4).unwrap();
+    let a = (*at_wire(wire_a)).get();
+    let b = (*at_wire(wire_b)).get();
+    let op = (pieces.get(1).unwrap()!; _).get(0).unwrap();
     let out = if op == 'A' {
       a & b
     } else if op == 'O' {
@@ -29,7 +29,7 @@ pub fn main(&io: &IO) {
     } else {
       a ^ b
     };
-    (*get_wire(wire_out)).set(out);
+    (*at_wire(wire_out)).set(out);
   }
 
   let part1 = N64::zero;
@@ -37,7 +37,7 @@ pub fn main(&io: &IO) {
   let i = 0;
   loop {
     let wire = ['z', '0' + i / 10, '0' + i % 10] as String;
-    if map.get(&wire) is Some(&wire) {
+    if map.at(&wire) is Some(&wire) {
       let bit = if wire.get() {
         N64::one
       } else {

--- a/tests/programs/aoc_2024/day_25.vi
+++ b/tests/programs/aoc_2024/day_25.vi
@@ -4,14 +4,14 @@ pub fn main(&io: &IO) {
   let keys = [];
 
   while io.read_line() is Some(line) {
-    let on = line!.get(0).*;
+    let on = line!.get(0).unwrap();
     let is_lock = on == '#';
     let heights = List::new(5, 1);
     while io.read_line() is Some(line) && line.len() != 0 {
       let i = 0;
       while line!.pop_front() is Some(char) {
         if char == on {
-          heights.get(i).* += 1;
+          *heights.at(i).unwrap() += 1;
         }
         i += 1;
       }

--- a/tests/programs/array_order.vi
+++ b/tests/programs/array_order.vi
@@ -11,7 +11,7 @@ pub fn main(&io: &IO) {
       n
     },
   );
-  io.println("{(*a.get(42))}");
+  io.println("{(a.get(42).unwrap())}");
   a.for_each(
     &io,
     fn(&io: &IO, n: N32) {

--- a/tests/programs/lambda.vi
+++ b/tests/programs/lambda.vi
@@ -86,7 +86,7 @@ mod Parser {
   pub fn .parse_term(&self: &Parser) -> Term {
     let term = self.parse_atom();
     self.skip_ws();
-    while self.chars.len() != 0 && self.chars.get(0).* != ')' {
+    while self.chars.len() != 0 && self.chars.get(0).unwrap() != ')' {
       term = Term::Apply(term, self.parse_atom());
       self.skip_ws();
     }
@@ -98,7 +98,7 @@ mod Parser {
     if self.chars.len() == 0 {
       self.error("expected term");
     }
-    let char = self.chars.get(0).*;
+    let char = self.chars.get(0).unwrap();
     self.io.println(String([char]));
     if char == '\\' {
       self.io.println("lambda");
@@ -107,9 +107,9 @@ mod Parser {
       let var = self.parse_var();
       self.io.println(var);
       self.expect_char('.');
-      self.scope.get_or_insert(var, []).*.push_front([]);
+      self.scope.at_or_insert(var, []).*.push_front([]);
       let body = self.parse_atom();
-      let uses = self.scope.get(&var).unwrap().*.pop_front().unwrap();
+      let uses = self.scope.at(&var).unwrap().*.pop_front().unwrap();
       Term::Lambda(uses, body)
     } else if char == '(' {
       self.chars.pop_front();
@@ -118,9 +118,9 @@ mod Parser {
       term
     } else {
       let var = self.parse_var();
-      if self.scope.get(&var) is Some(&binds) && binds.len() != 0 {
+      if self.scope.at(&var) is Some(&binds) && binds.len() != 0 {
         let term;
-        binds.get(0).*.push_back(move ~term);
+        binds.at(0).unwrap().*.push_back(move ~term);
         term
       } else {
         self.error("unbound variable `{var}`")
@@ -130,7 +130,7 @@ mod Parser {
 
   fn .parse_var(&self: &Parser) -> String {
     let chars = [];
-    while self.chars.len() != 0 && self.chars.get(0).* is char && char.is_alphanumeric() {
+    while self.chars.len() != 0 && self.chars.get(0) is Some(char) && char.is_alphanumeric() {
       self.chars.pop_front();
       chars.push_back(char);
     }
@@ -148,7 +148,7 @@ mod Parser {
   }
 
   fn .skip_ws(&self: &Parser) {
-    while self.chars.len() != 0 && self.chars.get(0).*.is_whitespace() {
+    while self.chars.len() != 0 && self.chars.get(0).unwrap().is_whitespace() {
       self.chars.pop_front();
     }
   }

--- a/tests/programs/map_test.vi
+++ b/tests/programs/map_test.vi
@@ -40,7 +40,7 @@ pub fn main(&io: &IO) {
   while n > 0 {
     n -= 1;
     let num = rng.gen_n32();
-    if map.get(&num) is Some(&n) => n != num * num {
+    if map.get(&num) is Some(n) => n != num * num {
       io.println("missing {num}");
     }
   }

--- a/tests/programs/repl/misc.vi
+++ b/tests/programs/repl/misc.vi
@@ -51,7 +51,7 @@ N64::parse("1.0")
 "1,2, 3,4, 5,6".split_once(", ")
 123.show(2)
 let x = [[1]];
-(x.get(0).unwrap(); _).get(0)
+(*x.at(0).unwrap()).get(0)
 x.at(0).unwrap().*.at(0).unwrap().* = 2
 ~x.at(0).unwrap().*.at(0).unwrap().*.~
 move x

--- a/tests/programs/repl/misc.vi
+++ b/tests/programs/repl/misc.vi
@@ -51,9 +51,9 @@ N64::parse("1.0")
 "1,2, 3,4, 5,6".split_once(", ")
 123.show(2)
 let x = [[1]];
-x.get(0).*.get(0).*
-x.get(0).*.get(0).* = 2
-~x.get(0).*.get(0).*.~
+(x.get(0).unwrap(); _).get(0)
+x.at(0).unwrap().*.at(0).unwrap().* = 2
+~x.at(0).unwrap().*.at(0).unwrap().*.~
 move x
 let _: { a: N32, b: N32 } = { a: 1 }
 do { let x; x = (x, x); }

--- a/tests/programs/segmented_sieve.vi
+++ b/tests/programs/segmented_sieve.vi
@@ -16,7 +16,7 @@ pub fn main(&io: &IO) {
       primes.push_back(n);
       let i = n * n;
       while i <= sqrt {
-        *array.get(i - offset) = false;
+        *array.at(i - offset).unwrap() = false;
         i += n;
       }
     }
@@ -28,7 +28,7 @@ pub fn main(&io: &IO) {
     while iter.next() is Some(prime) {
       let i = N32::max(prime * prime, ((offset - 1) / prime + 1) * prime);
       while i < top {
-        *array.get(i - offset) = false;
+        *array.at(i - offset).unwrap() = false;
         i += prime;
       }
     }

--- a/tests/programs/sieve.vi
+++ b/tests/programs/sieve.vi
@@ -13,7 +13,7 @@ pub fn main(&io: &IO) {
       io.println("{n}");
       let i = n * n;
       while i < max {
-        *array.get(i - offset) = false;
+        *array.at(i - offset).unwrap() = false;
         i += n;
       }
     }

--- a/tests/snaps/vine/aoc_2024/day_04/stats.txt
+++ b/tests/snaps/vine/aoc_2024/day_04/stats.txt
@@ -1,17 +1,17 @@
 
 Interactions
-  Total               91_027
-    Depth              1_767
-    Breadth               51
-  Annihilate          28_613
+  Total               90_405
+    Depth              1_715
+    Breadth               52
+  Annihilate          28_263
   Commute             13_142
-  Copy                22_975
-  Erase               15_777
-  Expand               4_203
-  Call                 3_984
-  Branch               2_333
+  Copy                22_907
+  Erase               15_703
+  Expand               4_157
+  Call                 3_922
+  Branch               2_311
 
 Memory
-  Heap               306_560 B
-  Allocated        1_824_352 B
-  Freed            1_824_352 B
+  Heap               187_856 B
+  Allocated        1_810_400 B
+  Freed            1_810_400 B

--- a/tests/snaps/vine/aoc_2024/day_04/stats.txt
+++ b/tests/snaps/vine/aoc_2024/day_04/stats.txt
@@ -1,17 +1,17 @@
 
 Interactions
-  Total               90_357
-    Depth              1_715
-    Breadth               52
-  Annihilate          28_241
+  Total               91_027
+    Depth              1_767
+    Breadth               51
+  Annihilate          28_613
   Commute             13_142
-  Copy                22_903
-  Erase               15_695
-  Expand               4_151
-  Call                 3_918
-  Branch               2_307
+  Copy                22_975
+  Erase               15_777
+  Expand               4_203
+  Call                 3_984
+  Branch               2_333
 
 Memory
-  Heap               177_072 B
-  Allocated        1_809_456 B
-  Freed            1_809_456 B
+  Heap               306_560 B
+  Allocated        1_824_352 B
+  Freed            1_824_352 B

--- a/tests/snaps/vine/aoc_2024/day_05/stats.txt
+++ b/tests/snaps/vine/aoc_2024/day_05/stats.txt
@@ -1,17 +1,17 @@
 
 Interactions
-  Total               67_897
-    Depth              6_139
-    Breadth               11
-  Annihilate          32_205
-  Commute                545
-  Copy                 7_667
-  Erase                7_095
-  Expand               5_326
-  Call                10_381
-  Branch               4_678
+  Total               69_234
+    Depth              7_892
+    Breadth                8
+  Annihilate          32_970
+  Commute                454
+  Copy                 7_815
+  Erase                7_286
+  Expand               5_512
+  Call                10_450
+  Branch               4_747
 
 Memory
-  Heap                26_976 B
-  Allocated        1_423_696 B
-  Freed            1_423_696 B
+  Heap                22_528 B
+  Allocated        1_450_864 B
+  Freed            1_450_864 B

--- a/tests/snaps/vine/aoc_2024/day_06/stats.txt
+++ b/tests/snaps/vine/aoc_2024/day_06/stats.txt
@@ -1,17 +1,17 @@
 
 Interactions
-  Total              735_436
-    Depth             64_232
+  Total              813_739
+    Depth             68_718
     Breadth               11
-  Annihilate         333_473
+  Annihilate         368_532
   Commute              9_330
-  Copy               104_800
-  Erase               86_779
-  Expand              46_512
-  Call               108_576
-  Branch              45_966
+  Copy               115_795
+  Erase               97_471
+  Expand              56_302
+  Call               115_040
+  Branch              51_269
 
 Memory
-  Heap               253_456 B
-  Allocated       15_294_416 B
-  Freed           15_294_416 B
+  Heap               258_816 B
+  Allocated       16_815_632 B
+  Freed           16_815_632 B

--- a/tests/snaps/vine/aoc_2024/day_06/stats.txt
+++ b/tests/snaps/vine/aoc_2024/day_06/stats.txt
@@ -1,17 +1,17 @@
 
 Interactions
-  Total              813_739
-    Depth             68_718
+  Total              802_041
+    Depth             68_702
     Breadth               11
-  Annihilate         368_532
+  Annihilate         364_575
   Commute              9_330
-  Copy               115_795
-  Erase               97_471
-  Expand              56_302
-  Call               115_040
-  Branch              51_269
+  Copy               113_644
+  Erase               95_665
+  Expand              55_399
+  Call               113_019
+  Branch              50_409
 
 Memory
-  Heap               258_816 B
-  Allocated       16_815_632 B
-  Freed           16_815_632 B
+  Heap               257_312 B
+  Allocated       16_608_496 B
+  Freed           16_608_496 B

--- a/tests/snaps/vine/aoc_2024/day_08/stats.txt
+++ b/tests/snaps/vine/aoc_2024/day_08/stats.txt
@@ -1,17 +1,17 @@
 
 Interactions
-  Total               56_955
-    Depth             20_958
+  Total               57_045
+    Depth             20_959
     Breadth                2
-  Annihilate          31_548
-  Commute                209
-  Copy                 7_212
-  Erase                6_779
-  Expand               3_682
-  Call                 5_035
-  Branch               2_490
+  Annihilate          31_568
+  Commute                223
+  Copy                 7_241
+  Erase                6_796
+  Expand               3_690
+  Call                 5_036
+  Branch               2_491
 
 Memory
-  Heap                19_520 B
-  Allocated        1_274_656 B
-  Freed            1_274_656 B
+  Heap                20_032 B
+  Allocated        1_276_256 B
+  Freed            1_276_256 B

--- a/tests/snaps/vine/aoc_2024/day_08/stats.txt
+++ b/tests/snaps/vine/aoc_2024/day_08/stats.txt
@@ -1,17 +1,17 @@
 
 Interactions
-  Total               57_045
+  Total               56_976
     Depth             20_959
     Breadth                2
-  Annihilate          31_568
-  Commute                223
-  Copy                 7_241
-  Erase                6_796
-  Expand               3_690
+  Annihilate          31_559
+  Commute                209
+  Copy                 7_214
+  Erase                6_781
+  Expand               3_686
   Call                 5_036
   Branch               2_491
 
 Memory
-  Heap                20_032 B
-  Allocated        1_276_256 B
-  Freed            1_276_256 B
+  Heap                20_016 B
+  Allocated        1_275_088 B
+  Freed            1_275_088 B

--- a/tests/snaps/vine/aoc_2024/day_09/stats.txt
+++ b/tests/snaps/vine/aoc_2024/day_09/stats.txt
@@ -1,17 +1,17 @@
 
 Interactions
-  Total                6_245
+  Total                6_413
     Depth              1_066
-    Breadth                5
-  Annihilate           2_959
+    Breadth                6
+  Annihilate           3_036
   Commute                 21
-  Copy                   904
-  Erase                  610
-  Expand                 417
-  Call                 1_030
-  Branch                 304
+  Copy                   918
+  Erase                  638
+  Expand                 438
+  Call                 1_044
+  Branch                 318
 
 Memory
-  Heap                13_424 B
-  Allocated          136_624 B
-  Freed              136_624 B
+  Heap                15_296 B
+  Allocated          139_632 B
+  Freed              139_632 B

--- a/tests/snaps/vine/aoc_2024/day_10/stats.txt
+++ b/tests/snaps/vine/aoc_2024/day_10/stats.txt
@@ -1,17 +1,17 @@
 
 Interactions
-  Total              117_349
-    Depth              6_114
+  Total              117_639
+    Depth              6_159
     Breadth               19
-  Annihilate          20_368
+  Annihilate          20_530
   Commute             26_076
-  Copy                42_423
-  Erase               22_467
-  Expand               2_009
-  Call                 2_850
-  Branch               1_156
+  Copy                42_454
+  Erase               22_500
+  Expand               2_037
+  Call                 2_876
+  Branch               1_166
 
 Memory
-  Heap               115_536 B
-  Allocated        2_257_680 B
-  Freed            2_257_680 B
+  Heap               197_536 B
+  Allocated        2_264_320 B
+  Freed            2_264_320 B

--- a/tests/snaps/vine/aoc_2024/day_10/stats.txt
+++ b/tests/snaps/vine/aoc_2024/day_10/stats.txt
@@ -1,17 +1,17 @@
 
 Interactions
-  Total              117_639
-    Depth              6_159
+  Total              117_370
+    Depth              6_115
     Breadth               19
-  Annihilate          20_530
+  Annihilate          20_379
   Commute             26_076
-  Copy                42_454
-  Erase               22_500
-  Expand               2_037
-  Call                 2_876
-  Branch               1_166
+  Copy                42_425
+  Erase               22_469
+  Expand               2_013
+  Call                 2_851
+  Branch               1_157
 
 Memory
-  Heap               197_536 B
-  Allocated        2_264_320 B
-  Freed            2_264_320 B
+  Heap               117_520 B
+  Allocated        2_258_176 B
+  Freed            2_258_176 B

--- a/tests/snaps/vine/aoc_2024/day_12/stats.txt
+++ b/tests/snaps/vine/aoc_2024/day_12/stats.txt
@@ -1,17 +1,17 @@
 
 Interactions
-  Total              237_516
+  Total              235_107
     Depth             54_008
     Breadth                4
-  Annihilate         105_092
-  Commute              1_705
-  Copy                34_274
-  Erase               29_737
-  Expand              16_478
+  Annihilate         104_462
+  Commute                954
+  Copy                33_865
+  Erase               29_328
+  Expand              16_268
   Call                35_940
   Branch              14_290
 
 Memory
   Heap                88_080 B
-  Allocated        4_832_224 B
-  Freed            4_832_224 B
+  Allocated        4_781_488 B
+  Freed            4_781_488 B

--- a/tests/snaps/vine/aoc_2024/day_12/stats.txt
+++ b/tests/snaps/vine/aoc_2024/day_12/stats.txt
@@ -1,17 +1,17 @@
 
 Interactions
-  Total              224_606
-    Depth             51_509
+  Total              237_516
+    Depth             54_008
     Breadth                4
-  Annihilate          98_570
+  Annihilate         105_092
   Commute              1_705
-  Copy                32_782
-  Erase               28_035
-  Expand              14_776
-  Call                35_194
-  Branch              13_544
+  Copy                34_274
+  Erase               29_737
+  Expand              16_478
+  Call                35_940
+  Branch              14_290
 
 Memory
-  Heap                89_504 B
-  Allocated        4_570_112 B
-  Freed            4_570_112 B
+  Heap                88_080 B
+  Allocated        4_832_224 B
+  Freed            4_832_224 B

--- a/tests/snaps/vine/aoc_2024/day_14/stats.txt
+++ b/tests/snaps/vine/aoc_2024/day_14/stats.txt
@@ -1,17 +1,17 @@
 
 Interactions
-  Total               21_290
-    Depth              2_749
+  Total               22_034
+    Depth              2_764
     Breadth                7
-  Annihilate          11_333
+  Annihilate          11_669
   Commute                 50
-  Copy                 2_431
-  Erase                2_523
-  Expand               1_545
-  Call                 2_347
-  Branch               1_061
+  Copy                 2_503
+  Erase                2_667
+  Expand               1_641
+  Call                 2_395
+  Branch               1_109
 
 Memory
-  Heap                14_560 B
-  Allocated          462_832 B
-  Freed              462_832 B
+  Heap                16_000 B
+  Allocated          476_272 B
+  Freed              476_272 B

--- a/tests/snaps/vine/aoc_2024/day_15/stats.txt
+++ b/tests/snaps/vine/aoc_2024/day_15/stats.txt
@@ -1,17 +1,17 @@
 
 Interactions
-  Total            1_024_923
-    Depth            234_216
+  Total            1_127_200
+    Depth            255_897
     Breadth                4
-  Annihilate         460_050
+  Annihilate         507_741
   Commute              6_927
-  Copy               128_674
-  Erase              125_379
-  Expand              71_898
-  Call               163_279
-  Branch              68_716
+  Copy               142_269
+  Erase              139_102
+  Expand              85_487
+  Call               170_147
+  Branch              75_527
 
 Memory
-  Heap             1_463_552 B
-  Allocated       20_772_496 B
-  Freed           20_772_496 B
+  Heap             1_659_280 B
+  Allocated       22_787_808 B
+  Freed           22_787_808 B

--- a/tests/snaps/vine/aoc_2024/day_15/stats.txt
+++ b/tests/snaps/vine/aoc_2024/day_15/stats.txt
@@ -1,17 +1,17 @@
 
 Interactions
-  Total            1_127_200
+  Total            1_126_245
     Depth            255_897
     Breadth                4
-  Annihilate         507_741
+  Annihilate         507_350
   Commute              6_927
-  Copy               142_269
-  Erase              139_102
-  Expand              85_487
-  Call               170_147
-  Branch              75_527
+  Copy               142_118
+  Erase              138_921
+  Expand              85_392
+  Call               170_050
+  Branch              75_487
 
 Memory
-  Heap             1_659_280 B
-  Allocated       22_787_808 B
-  Freed           22_787_808 B
+  Heap             1_659_232 B
+  Allocated       22_770_688 B
+  Freed           22_770_688 B

--- a/tests/snaps/vine/aoc_2024/day_16/stats.txt
+++ b/tests/snaps/vine/aoc_2024/day_16/stats.txt
@@ -1,17 +1,17 @@
 
 Interactions
-  Total            1_028_505
-    Depth            229_086
+  Total            1_109_610
+    Depth            250_374
     Breadth                4
-  Annihilate         478_243
+  Annihilate         516_092
   Commute             12_292
-  Copy               139_661
-  Erase              130_952
-  Expand              68_722
-  Call               137_304
-  Branch              61_331
+  Copy               150_475
+  Erase              141_766
+  Expand              79_536
+  Call               142_711
+  Branch              66_738
 
 Memory
   Heap               393_040 B
-  Allocated       21_345_632 B
-  Freed           21_345_632 B
+  Allocated       22_966_848 B
+  Freed           22_966_848 B

--- a/tests/snaps/vine/aoc_2024/day_17/stats.txt
+++ b/tests/snaps/vine/aoc_2024/day_17/stats.txt
@@ -1,17 +1,17 @@
 
 Interactions
-  Total               22_726
-    Depth              9_914
+  Total               22_526
+    Depth              9_944
     Breadth                2
   Annihilate          11_531
   Commute                222
-  Copy                 2_724
-  Erase                2_609
-  Expand               1_697
+  Copy                 2_684
+  Erase                2_509
+  Expand               1_637
   Call                 2_687
   Branch               1_256
 
 Memory
   Heap                 7_936 B
-  Allocated          488_160 B
-  Freed              488_160 B
+  Allocated          487_520 B
+  Freed              487_520 B

--- a/tests/snaps/vine/aoc_2024/day_17/stats.txt
+++ b/tests/snaps/vine/aoc_2024/day_17/stats.txt
@@ -1,17 +1,17 @@
 
 Interactions
-  Total               21_526
-    Depth              9_704
+  Total               22_726
+    Depth              9_914
     Breadth                2
-  Annihilate          10_931
+  Annihilate          11_531
   Commute                222
-  Copy                 2_604
-  Erase                2_429
-  Expand               1_517
-  Call                 2_627
-  Branch               1_196
+  Copy                 2_724
+  Erase                2_609
+  Expand               1_697
+  Call                 2_687
+  Branch               1_256
 
 Memory
   Heap                 7_936 B
-  Allocated          464_160 B
-  Freed              464_160 B
+  Allocated          488_160 B
+  Freed              488_160 B

--- a/tests/snaps/vine/aoc_2024/day_18/stats.txt
+++ b/tests/snaps/vine/aoc_2024/day_18/stats.txt
@@ -1,17 +1,17 @@
 
 Interactions
-  Total              136_005
-    Depth             16_511
-    Breadth                8
-  Annihilate          60_877
-  Commute              1_280
-  Copy                18_564
-  Erase               16_382
-  Expand               9_279
-  Call                20_989
-  Branch               8_634
+  Total              180_363
+    Depth             17_897
+    Breadth               10
+  Annihilate          77_811
+  Commute              1_279
+  Copy                25_970
+  Erase               23_159
+  Expand              13_519
+  Call                26_921
+  Branch              11_704
 
 Memory
-  Heap                41_936 B
-  Allocated        2_779_728 B
-  Freed            2_779_728 B
+  Heap                42_064 B
+  Allocated        3_590_688 B
+  Freed            3_590_688 B

--- a/tests/snaps/vine/aoc_2024/day_18/stats.txt
+++ b/tests/snaps/vine/aoc_2024/day_18/stats.txt
@@ -1,17 +1,17 @@
 
 Interactions
-  Total              180_363
-    Depth             17_897
-    Breadth               10
-  Annihilate          77_811
+  Total              149_975
+    Depth             17_529
+    Breadth                8
+  Annihilate          67_464
   Commute              1_279
-  Copy                25_970
-  Erase               23_159
-  Expand              13_519
-  Call                26_921
-  Branch              11_704
+  Copy                20_405
+  Erase               18_388
+  Expand              11_128
+  Call                21_833
+  Branch               9_478
 
 Memory
-  Heap                42_064 B
-  Allocated        3_590_688 B
-  Freed            3_590_688 B
+  Heap                41_952 B
+  Allocated        3_053_520 B
+  Freed            3_053_520 B

--- a/tests/snaps/vine/aoc_2024/day_19/stats.txt
+++ b/tests/snaps/vine/aoc_2024/day_19/stats.txt
@@ -1,17 +1,17 @@
 
 Interactions
-  Total               63_448
-    Depth              2_538
-    Breadth               24
-  Annihilate          27_705
+  Total               64_308
+    Depth              2_545
+    Breadth               25
+  Annihilate          28_135
   Commute              3_914
-  Copy                11_557
-  Erase                9_672
-  Expand               3_828
-  Call                 4_382
-  Branch               2_390
+  Copy                11_643
+  Erase                9_801
+  Expand               3_957
+  Call                 4_425
+  Branch               2_433
 
 Memory
   Heap               165_760 B
-  Allocated        1_318_944 B
-  Freed            1_318_944 B
+  Allocated        1_336_144 B
+  Freed            1_336_144 B

--- a/tests/snaps/vine/aoc_2024/day_20/stats.txt
+++ b/tests/snaps/vine/aoc_2024/day_20/stats.txt
@@ -1,17 +1,17 @@
 
 Interactions
-  Total              504_741
-    Depth             23_990
-    Breadth               21
-  Annihilate         199_941
+  Total              401_770
+    Depth             23_318
+    Breadth               17
+  Annihilate         165_280
   Commute             12_860
-  Copy                87_427
-  Erase               62_261
-  Expand              35_456
-  Call                76_241
-  Branch              30_555
+  Copy                68_452
+  Erase               46_575
+  Expand              27_613
+  Call                58_025
+  Branch              22_965
 
 Memory
   Heap               238_768 B
-  Allocated       10_196_384 B
-  Freed           10_196_384 B
+  Allocated        8_370_736 B
+  Freed            8_370_736 B

--- a/tests/snaps/vine/aoc_2024/day_20/stats.txt
+++ b/tests/snaps/vine/aoc_2024/day_20/stats.txt
@@ -1,17 +1,17 @@
 
 Interactions
-  Total              392_915
-    Depth             22_327
-    Breadth               17
-  Annihilate         160_979
+  Total              504_741
+    Depth             23_990
+    Breadth               21
+  Annihilate         199_941
   Commute             12_860
-  Copy                67_440
-  Erase               45_310
-  Expand              26_348
-  Call                57_519
-  Branch              22_459
+  Copy                87_427
+  Erase               62_261
+  Expand              35_456
+  Call                76_241
+  Branch              30_555
 
 Memory
   Heap               238_768 B
-  Allocated        8_198_080 B
-  Freed            8_198_080 B
+  Allocated       10_196_384 B
+  Freed           10_196_384 B

--- a/tests/snaps/vine/aoc_2024/day_21/stats.txt
+++ b/tests/snaps/vine/aoc_2024/day_21/stats.txt
@@ -1,17 +1,17 @@
 
 Interactions
-  Total            1_393_062
-    Depth              3_352
-    Breadth              415
-  Annihilate         574_706
-  Commute              9_091
-  Copy               202_056
-  Erase              175_505
-  Expand              94_535
-  Call               242_933
-  Branch              94_236
+  Total            2_552_422
+    Depth              4_173
+    Breadth              611
+  Annihilate         959_154
+  Commute             39_523
+  Copy               432_208
+  Erase              368_937
+  Expand             189_383
+  Call               395_317
+  Branch             167_900
 
 Memory
-  Heap             2_399_328 B
-  Allocated       27_783_728 B
-  Freed           27_783_728 B
+  Heap             2_901_664 B
+  Allocated       48_363_392 B
+  Freed           48_363_392 B

--- a/tests/snaps/vine/aoc_2024/day_21/stats.txt
+++ b/tests/snaps/vine/aoc_2024/day_21/stats.txt
@@ -1,17 +1,17 @@
 
 Interactions
-  Total            2_552_422
-    Depth              4_173
-    Breadth              611
-  Annihilate         959_154
-  Commute             39_523
-  Copy               432_208
-  Erase              368_937
-  Expand             189_383
-  Call               395_317
-  Branch             167_900
+  Total            1_570_718
+    Depth              3_382
+    Breadth              464
+  Annihilate         665_530
+  Commute              9_091
+  Copy               214_024
+  Erase              202_201
+  Expand             121_231
+  Call               253_669
+  Branch             104_972
 
 Memory
-  Heap             2_901_664 B
-  Allocated       48_363_392 B
-  Freed           48_363_392 B
+  Heap             2_630_976 B
+  Allocated       31_229_248 B
+  Freed           31_229_248 B

--- a/tests/snaps/vine/aoc_2024/day_23/stats.txt
+++ b/tests/snaps/vine/aoc_2024/day_23/stats.txt
@@ -1,17 +1,17 @@
 
 Interactions
-  Total               48_130
-    Depth              9_780
-    Breadth                4
-  Annihilate          24_084
-  Commute                799
-  Copy                 6_460
-  Erase                6_632
-  Expand               3_493
-  Call                 4_308
-  Branch               2_354
+  Total               53_233
+    Depth              9_965
+    Breadth                5
+  Annihilate          26_008
+  Commute                807
+  Copy                 7_512
+  Erase                7_820
+  Expand               3_894
+  Call                 4_573
+  Branch               2_619
 
 Memory
-  Heap                25_664 B
-  Allocated        1_020_864 B
-  Freed            1_020_864 B
+  Heap                26_176 B
+  Allocated        1_107_968 B
+  Freed            1_107_968 B

--- a/tests/snaps/vine/aoc_2024/day_23/stats.txt
+++ b/tests/snaps/vine/aoc_2024/day_23/stats.txt
@@ -1,17 +1,17 @@
 
 Interactions
-  Total               53_233
-    Depth              9_965
-    Breadth                5
-  Annihilate          26_008
-  Commute                807
-  Copy                 7_512
-  Erase                7_820
-  Expand               3_894
-  Call                 4_573
-  Branch               2_619
+  Total               48_217
+    Depth              9_783
+    Breadth                4
+  Annihilate          24_126
+  Commute                799
+  Copy                 6_466
+  Erase                6_647
+  Expand               3_505
+  Call                 4_314
+  Branch               2_360
 
 Memory
-  Heap                26_176 B
-  Allocated        1_107_968 B
-  Freed            1_107_968 B
+  Heap                25_792 B
+  Allocated        1_022_496 B
+  Freed            1_022_496 B

--- a/tests/snaps/vine/aoc_2024/day_24/stats.txt
+++ b/tests/snaps/vine/aoc_2024/day_24/stats.txt
@@ -1,17 +1,17 @@
 
 Interactions
-  Total              230_135
+  Total              229_375
     Depth             59_594
     Breadth                3
-  Annihilate         131_685
-  Commute                595
-  Copy                24_052
-  Erase               27_350
-  Expand              16_883
+  Annihilate         131_541
+  Commute                432
+  Copy                23_834
+  Erase               27_151
+  Expand              16_847
   Call                19_405
   Branch              10_165
 
 Memory
-  Heap                63_264 B
-  Allocated        5_150_416 B
-  Freed            5_150_416 B
+  Heap                63_392 B
+  Allocated        5_137_104 B
+  Freed            5_137_104 B

--- a/tests/snaps/vine/aoc_2024/day_24/stats.txt
+++ b/tests/snaps/vine/aoc_2024/day_24/stats.txt
@@ -1,17 +1,17 @@
 
 Interactions
-  Total              221_423
+  Total              230_135
     Depth             59_594
     Breadth                3
-  Annihilate         128_089
-  Commute                432
-  Copy                22_894
-  Erase               25_975
-  Expand              15_979
-  Call                18_521
-  Branch               9_533
+  Annihilate         131_685
+  Commute                595
+  Copy                24_052
+  Erase               27_350
+  Expand              16_883
+  Call                19_405
+  Branch              10_165
 
 Memory
-  Heap                57_504 B
-  Allocated        4_987_344 B
-  Freed            4_987_344 B
+  Heap                63_264 B
+  Allocated        5_150_416 B
+  Freed            5_150_416 B

--- a/tests/snaps/vine/aoc_2024/day_25/stats.txt
+++ b/tests/snaps/vine/aoc_2024/day_25/stats.txt
@@ -1,17 +1,17 @@
 
 Interactions
-  Total               16_461
+  Total               17_676
     Depth              3_167
     Breadth                5
-  Annihilate           7_763
+  Annihilate           8_330
   Commute                 96
-  Copy                 2_114
-  Erase                2_097
-  Expand               1_262
-  Call                 2_162
-  Branch                 967
+  Copy                 2_271
+  Erase                2_264
+  Expand               1_424
+  Call                 2_243
+  Branch               1_048
 
 Memory
-  Heap                 7_168 B
-  Allocated          338_336 B
-  Freed              338_336 B
+  Heap                 7_184 B
+  Allocated          361_584 B
+  Freed              361_584 B

--- a/tests/snaps/vine/array_order/stats.txt
+++ b/tests/snaps/vine/array_order/stats.txt
@@ -1,17 +1,17 @@
 
 Interactions
-  Total               18_946
+  Total               18_983
     Depth                720
     Breadth               26
-  Annihilate           6_680
+  Annihilate           6_701
   Commute              2_178
-  Copy                 2_777
-  Erase                1_711
-  Expand               1_175
-  Call                 3_277
-  Branch               1_148
+  Copy                 2_779
+  Erase                1_714
+  Expand               1_184
+  Call                 3_278
+  Branch               1_149
 
 Memory
-  Heap                72_944 B
-  Allocated          406_736 B
-  Freed              406_736 B
+  Heap                72_688 B
+  Allocated          407_472 B
+  Freed              407_472 B

--- a/tests/snaps/vine/lambda/stats.txt
+++ b/tests/snaps/vine/lambda/stats.txt
@@ -1,17 +1,17 @@
 
 Interactions
-  Total               32_580
-    Depth              9_897
+  Total               37_823
+    Depth             12_232
     Breadth                3
-  Annihilate          12_100
+  Annihilate          14_623
   Commute              3_314
-  Copy                 6_713
-  Erase                5_052
-  Expand               1_715
-  Call                 2_580
-  Branch               1_106
+  Copy                 7_094
+  Erase                5_962
+  Expand               2_424
+  Call                 2_940
+  Branch               1_466
 
 Memory
   Heap                16_352 B
-  Allocated          668_736 B
-  Freed              668_736 B
+  Allocated          767_088 B
+  Freed              767_088 B

--- a/tests/snaps/vine/map_test/stats.txt
+++ b/tests/snaps/vine/map_test/stats.txt
@@ -1,15 +1,15 @@
 
 Interactions
-  Total           26_401_948
-  Annihilate      13_839_310
+  Total           26_434_148
+  Annihilate      13_853_110
   Commute             27_678
-  Copy             2_806_755
-  Erase            3_304_285
-  Expand           1_890_160
+  Copy             2_811_355
+  Erase            3_313_485
+  Expand           1_894_760
   Call             2_812_622
   Branch           1_721_138
 
 Memory
   Heap             1_032_736 B
-  Allocated      569_314_480 B
-  Freed          569_314_480 B
+  Allocated      569_829_680 B
+  Freed          569_829_680 B

--- a/tests/snaps/vine/repl/misc.repl.vi
+++ b/tests/snaps/vine/repl/misc.repl.vi
@@ -217,7 +217,7 @@ io = #io
 
 io = #io
 x = [[1]]
-> (x.get(0).unwrap(); _).get(0)
+> (*x.at(0).unwrap()).get(0)
 Some(1)
 
 io = #io
@@ -240,7 +240,7 @@ error input:1:29 - expected type `{ a: N32, b: N32 }`; found `{ a: N32 }`
 
 io = #io
 > do { let x; x = (x, x); }
-error input:1:17 - expected type `?786`; found `(?786, ?786)`
+error input:1:17 - expected type `?787`; found `(?787, ?787)`
 
 io = #io
 > let (a: N32, b: N32);

--- a/tests/snaps/vine/repl/misc.repl.vi
+++ b/tests/snaps/vine/repl/misc.repl.vi
@@ -217,16 +217,16 @@ io = #io
 
 io = #io
 x = [[1]]
-> x.get(0).*.get(0).*
-1
+> (x.get(0).unwrap(); _).get(0)
+Some(1)
 
 io = #io
 x = [[1]]
-> x.get(0).*.get(0).* = 2
+> x.at(0).unwrap().*.at(0).unwrap().* = 2
 
 io = #io
 x = [[2]]
-> ~x.get(0).*.get(0).*.~
+> ~x.at(0).unwrap().*.at(0).unwrap().*.~
 2
 
 io = #io
@@ -240,7 +240,7 @@ error input:1:29 - expected type `{ a: N32, b: N32 }`; found `{ a: N32 }`
 
 io = #io
 > do { let x; x = (x, x); }
-error input:1:17 - expected type `?760`; found `(?760, ?760)`
+error input:1:17 - expected type `?786`; found `(?786, ?786)`
 
 io = #io
 > let (a: N32, b: N32);

--- a/tests/snaps/vine/segmented_sieve/stats.txt
+++ b/tests/snaps/vine/segmented_sieve/stats.txt
@@ -1,15 +1,15 @@
 
 Interactions
-  Total           907_945_296
-  Annihilate      414_822_981
+  Total           939_775_986
+  Annihilate      429_677_303
   Commute             169_830
-  Copy            103_273_152
-  Erase            97_763_998
-  Expand           63_391_678
-  Call            166_301_816
-  Branch           62_221_841
+  Copy            107_517_244
+  Erase           102_008_090
+  Expand           67_635_770
+  Call            168_423_862
+  Branch           64_343_887
 
 Memory
-  Heap             48_710_640 B
-  Allocated    18_698_468_208 B
-  Freed        18_698_468_208 B
+  Heap             48_653_552 B
+  Allocated    19_343_547_616 B
+  Freed        19_343_547_616 B

--- a/tests/snaps/vine/sieve/stats.txt
+++ b/tests/snaps/vine/sieve/stats.txt
@@ -1,15 +1,15 @@
 
 Interactions
-  Total          131_495_414
-  Annihilate      61_127_669
+  Total          134_391_554
+  Annihilate      62_479_201
   Commute                  0
-  Copy            14_000_727
-  Erase           13_668_042
-  Expand           9_129_134
-  Call            24_540_713
-  Branch           9_029_129
+  Copy            14_386_879
+  Erase           14_054_194
+  Expand           9_515_286
+  Call            24_733_789
+  Branch           9_222_205
 
 Memory
-  Heap             4_800_512 B
-  Allocated    2_723_392_944 B
-  Freed        2_723_392_944 B
+  Heap             4_800_544 B
+  Allocated    2_778_998_832 B
+  Freed        2_778_998_832 B

--- a/tests/snaps/vine/the_greatest_show/stats.txt
+++ b/tests/snaps/vine/the_greatest_show/stats.txt
@@ -1,17 +1,17 @@
 
 Interactions
-  Total               42_769
+  Total               42_793
     Depth              8_205
     Breadth                5
-  Annihilate          20_252
+  Annihilate          20_265
   Commute                958
-  Copy                 4_922
-  Erase                5_675
-  Expand               2_856
-  Call                 5_947
-  Branch               2_159
+  Copy                 4_924
+  Erase                5_677
+  Expand               2_861
+  Call                 5_948
+  Branch               2_160
 
 Memory
-  Heap                76_096 B
-  Allocated          911_856 B
-  Freed              911_856 B
+  Heap                76_112 B
+  Allocated          912_336 B
+  Freed              912_336 B

--- a/vine/std/data/Array.vi
+++ b/vine/std/data/Array.vi
@@ -92,13 +92,20 @@ pub mod Array {
     self.0
   }
 
-  pub fn .get[T](&Array[T](len, *node), i: N32) -> &T {
+  pub fn .at[T](&Array[T](len, *node), i: N32) -> Option[&T] {
+    if i >= len {
+      return None
+    }
     let size = len;
     while size > 1 {
       (node, size) = Node::half(node, size, i % 2);
       i /= 2;
     }
-    node as &T
+    Some(node as &T)
+  }
+
+  pub fn .get[T+](&self: &Array[T], i: N32) -> Option[T] {
+    self.at(i).as_forked()
   }
 
   pub fn .push_back[T](&Array[T](len, *node), value: T) {

--- a/vine/std/data/List.vi
+++ b/vine/std/data/List.vi
@@ -22,14 +22,21 @@ pub mod List {
     list
   }
 
-  pub fn .get[T](&List[T](len, *buf, _), i: N32) -> &T {
+  pub fn .at[T](&List[T](len, *buf, _), i: N32) -> Option[&T] {
+    if i >= len {
+      return None
+    }
     while i != 0 {
       let &Buf(_, *tail) = buf;
       buf = tail;
       i -= 1;
     }
     let &Buf(*head, _) = buf;
-    head
+    Some(head)
+  }
+
+  pub fn .get[T+](&self: &List[T], i: N32) -> Option[T] {
+    self.at(i).as_forked()
   }
 
   pub fn .slice[T, B1, B2; Bound[B1, N32], Bound[B2, N32]](self: List[T], Range[B1, B2](start, end)) -> List[

--- a/vine/std/data/Map.vi
+++ b/vine/std/data/Map.vi
@@ -60,20 +60,24 @@ pub mod Map {
     }
   }
 
-  pub fn .get[K, V; Ord[K]](&Map[K, V](len, data), &key: &K) -> Option[&V] {
+  pub fn .at[K, V; Ord[K]](&Map[K, V](len, data), &key: &K) -> Option[&V] {
     if len == 0 {
       None
     } else {
       let &(left, (cur_key, cur_value), right) = &data;
       match key.cmp(&cur_key) {
-        Ord::Lt { left.get(&key) }
+        Ord::Lt { left.at(&key) }
         Ord::Eq { Some(&cur_value) }
-        Ord::Gt { right.get(&key) }
+        Ord::Gt { right.at(&key) }
       }
     }
   }
 
-  pub fn .get_or_insert[K, V; Ord[K]](&self: &Map[K, V], key: K, value: V) -> &V {
+  pub fn .get[K, V+; Ord[K]](&self: &Map[K, V], key: &K) -> Option[V] {
+    self.at(key).as_forked()
+  }
+
+  pub fn .at_or_insert[K, V; Ord[K]](&self: &Map[K, V], key: K, value: V) -> &V {
     let ~insert;
     let old = self.insert(key, ~insert);
     let value = old.unwrap_or(value);
@@ -82,16 +86,24 @@ pub mod Map {
     ref
   }
 
-  pub fn .get_le[K, V; Ord[K]](&Map[K, V](len, data), &key: &K) -> Option[&(K, V)] {
+  pub fn .get_or_insert[K, V; Ord[K]](&self: &Map[K, V], key: K, value: V) -> V {
+    let ~insert;
+    let old = self.insert(key, ~insert);
+    let value = old.unwrap_or(value);
+    ~insert = value;
+    value
+  }
+
+  pub fn .at_le[K, V; Ord[K]](&Map[K, V](len, data), &key: &K) -> Option[&(K, V)] {
     if len == 0 {
       None
     } else {
       let &(left, (cur_key, cur_value), right) = &data;
       match key.cmp(&cur_key) {
-        Ord::Lt { left.get_ge(&key) }
+        Ord::Lt { left.at_le(&key) }
         Ord::Eq { Some(&(cur_key, cur_value)) }
         Ord::Gt {
-          if right.get_ge(&key) is Some(entry) {
+          if right.at_le(&key) is Some(entry) {
             Some(entry)
           } else {
             Some(&(cur_key, cur_value))
@@ -101,23 +113,31 @@ pub mod Map {
     }
   }
 
-  pub fn .get_ge[K, V; Ord[K]](&Map[K, V](len, data), &key: &K) -> Option[&(K, V)] {
+  pub fn .get_le[K+, V+; Ord[K]](&self: &Map[K, V], &key: &K) -> Option[(K, V)] {
+    self.at_le(&key).as_forked()
+  }
+
+  pub fn .at_ge[K, V; Ord[K]](&Map[K, V](len, data), &key: &K) -> Option[&(K, V)] {
     if len == 0 {
       None
     } else {
       let &(left, (cur_key, cur_value), right) = &data;
       match key.cmp(&cur_key) {
         Ord::Lt {
-          if left.get_ge(&key) is Some(entry) {
+          if left.at_ge(&key) is Some(entry) {
             Some(entry)
           } else {
             Some(&(cur_key, cur_value))
           }
         }
         Ord::Eq { Some(&(cur_key, cur_value)) }
-        Ord::Gt { right.get_ge(&key) }
+        Ord::Gt { right.at_ge(&key) }
       }
     }
+  }
+
+  pub fn .get_ge[K+, V+; Ord[K]](&self: &Map[K, V], &key: &K) -> Option[(K, V)] {
+    self.at_ge(&key).as_forked()
   }
 
   pub fn .remove[K, V; Ord[K]](&Map[K, V](len, data), &key: &K) -> Option[V] {

--- a/vine/std/data/Map.vi
+++ b/vine/std/data/Map.vi
@@ -86,12 +86,8 @@ pub mod Map {
     ref
   }
 
-  pub fn .get_or_insert[K, V; Ord[K]](&self: &Map[K, V], key: K, value: V) -> V {
-    let ~insert;
-    let old = self.insert(key, ~insert);
-    let value = old.unwrap_or(value);
-    ~insert = value;
-    value
+  pub fn .get_or_insert[K, V+; Ord[K]](&self: &Map[K, V], key: K, value: V) -> V {
+    self.at_or_insert(key, value).*.fork()
   }
 
   pub fn .at_le[K, V; Ord[K]](&Map[K, V](len, data), &key: &K) -> Option[&(K, V)] {

--- a/vine/std/logical/Option.vi
+++ b/vine/std/logical/Option.vi
@@ -21,6 +21,13 @@ pub mod Option {
     }
   }
 
+  pub fn .as_forked[T+](self: Option[&T]) -> Option[T] {
+    match self {
+      Some(&val) { Some(val.fork()) }
+      None { None }
+    }
+  }
+
   pub fn .flatten[T](self: Option[Option[T]]) -> Option[T] {
     match self {
       Some(Some(val)) { Some(val) }

--- a/vine/std/numeric/F32.vi
+++ b/vine/std/numeric/F32.vi
@@ -161,7 +161,7 @@ pub mod F32 {
         let int = f as N32;
         f -= int as F32;
         let dec = ((f + 1.0) * 1.0e+5) as N32 as String;
-        dec!.get(0).* = '.';
+        dec!.at(0).unwrap().* = '.';
         "{sign}{int}{dec}{exp}"
       }
     }


### PR DESCRIPTION
Standardizes access methods to containers with `.at` and `.get`, closes #217.