### PR TITLE
vine: require exhaustive pattern matching 

### DIFF
--- a/cli/src/vine_cli.rs
+++ b/cli/src/vine_cli.rs
@@ -78,8 +78,8 @@ impl CompileArgs {
 
     match compiler.compile(()) {
       Ok(nets) => nets,
-      Err(err) => {
-        eprintln!("{}", err);
+      Err(diags) => {
+        eprintln!("{}", core.print_diags(&diags));
         exit(1);
       }
     }
@@ -175,8 +175,8 @@ impl VineReplCommand {
     let core = &Core::new(&arenas);
     let mut repl = match Repl::new(host, &mut ivm, core, self.libs) {
       Ok(repl) => repl,
-      Err(err) => {
-        eprintln!("{err}");
+      Err(diags) => {
+        eprintln!("{}", core.print_diags(&diags));
         exit(1);
       }
     };
@@ -192,7 +192,7 @@ impl VineReplCommand {
           match repl.exec(&line) {
             Ok(Some(result)) => println!("{result}"),
             Ok(None) => {}
-            Err(err) => println!("{err}"),
+            Err(diags) => println!("{}", core.print_diags(&diags)),
           }
         }
         Err(_) => break,

--- a/tests/programs/aoc_2024/day_12.vi
+++ b/tests/programs/aoc_2024/day_12.vi
@@ -131,6 +131,7 @@ mod Regions {
     let &Regions(array) = &self;
     match array.at(i).unwrap() {
       &Region::Root(a, _) { a }
+      _ { unsafe::unreachable() }
     }
   }
 
@@ -140,6 +141,7 @@ mod Regions {
         &Region::Root(_, p) {
           p += 1;
         }
+        _ { unsafe::unreachable() }
       }
       i
     } else {
@@ -159,6 +161,7 @@ mod Regions {
             i
           }
         }
+        _ { unsafe::unreachable() }
       }
     }
   }

--- a/tests/programs/aoc_2024/day_18.vi
+++ b/tests/programs/aoc_2024/day_18.vi
@@ -138,6 +138,7 @@ mod DisjointSet {
           a
         }
       }
+      _ { unsafe::unreachable() }
     }
   }
 }

--- a/tests/programs/lambda.vi
+++ b/tests/programs/lambda.vi
@@ -27,6 +27,7 @@ pub mod Term {
             body.whnf()
           }
           Term::Spine(var, args) { Term::Spine(var, args ++ [arg]) }
+          Term::Apply(_) { unsafe::unreachable() }
         }
       }
       term { term }
@@ -52,6 +53,7 @@ pub mod Term {
           out ++ ")"
         }
       }
+      Term::Apply(_) { unsafe::unreachable() }
     }
   }
 

--- a/tests/programs/repl/misc.vi
+++ b/tests/programs/repl/misc.vi
@@ -85,3 +85,4 @@ x.drop(); let x;
 F32::inf.abs()
 F32::neg_inf.abs()
 F32::nan.abs()
+do { match Some(1) { Some(_) {} } }

--- a/tests/snaps/vine/fail/atypical.txt
+++ b/tests/snaps/vine/fail/atypical.txt
@@ -23,16 +23,16 @@ error tests/programs/fail/atypical.vi:19:12 - no type associated with `::atypica
 error tests/programs/fail/atypical.vi:20:14 - expected type `T`; found `N32`
 error tests/programs/fail/atypical.vi:21:14 - expected type `U`; found `T`
 error tests/programs/fail/atypical.vi:22:7 - expected a complete pattern
-error tests/programs/fail/atypical.vi:22:17 - expected type `Ay`; found `N32`
-error tests/programs/fail/atypical.vi:23:4 - cannot find impl of trait `Add[String, N32, ?77]`
-error tests/programs/fail/atypical.vi:24:7 - expected type `N32`; found `&?81`
+error tests/programs/fail/atypical.vi:23:4 - cannot find impl of trait `Add[String, N32, ?76]`
+error tests/programs/fail/atypical.vi:24:7 - expected type `N32`; found `&?80`
 error tests/programs/fail/atypical.vi:25:3 - no loop to continue
 error tests/programs/fail/atypical.vi:26:3 - no loop to break from
 error tests/programs/fail/atypical.vi:27:10 - expected type `()`; found `F32`
-error tests/programs/fail/atypical.vi:28:14 - cannot find impl of trait `Add[~N32, ~N32, ?87]`
+error tests/programs/fail/atypical.vi:28:14 - cannot find impl of trait `Add[~N32, ~N32, ?86]`
 error tests/programs/fail/atypical.vi:29:3 - cannot find impl of trait `Add[N32, F32, N32]`
 error tests/programs/fail/atypical.vi:30:3 - type `N32` has no method `parse`
 error tests/programs/fail/atypical.vi:31:3 - cannot find label `stuff`
 error tests/programs/fail/atypical.vi:32:14 - cannot continue label `stuff`
 error tests/programs/fail/atypical.vi:33:3 - expected type `()`; found `N32`
 error - main cannot be generic
+error tests/programs/fail/atypical.vi:6:1 - unconditional infinite loops are invalid

--- a/tests/snaps/vine/fail/is_not.txt
+++ b/tests/snaps/vine/fail/is_not.txt
@@ -6,3 +6,4 @@ error tests/programs/fail/is_not.vi:5:26 - cannot find `y` in `::is_not::main`
 error tests/programs/fail/is_not.vi:5:29 - cannot find `z` in `::is_not::main`
 error tests/programs/fail/is_not.vi:5:25 - expected type `()`; found `(??, ??)`
 error tests/programs/fail/is_not.vi:7:3 - cannot find `y` in `::is_not::main`
+error tests/programs/fail/is_not.vi:2:1 - unconditional infinite loops are invalid

--- a/tests/snaps/vine/repl/misc.repl.vi
+++ b/tests/snaps/vine/repl/misc.repl.vi
@@ -364,3 +364,7 @@ io = #io
 ::std::numeric::F32::nan
 
 io = #io
+> do { match Some(1) { Some(_) {} } }
+error input:1:6 - match arms do not cover all possible cases
+
+io = #io

--- a/vine/src/compiler.rs
+++ b/vine/src/compiler.rs
@@ -83,7 +83,7 @@ impl<'core> Compiler<'core> {
       let tir = &self.resolutions.consts[const_id];
       let vir = distiller.distill_tir(tir);
       let mut vir = normalize(&vir);
-      analyze(&mut vir);
+      analyze(self.core, chart.concrete_consts[const_id].span, &mut vir);
       assert_eq!(self.const_vir.next_index(), const_id);
       self.const_vir.push(vir);
     }
@@ -91,7 +91,7 @@ impl<'core> Compiler<'core> {
       let tir = &self.resolutions.fns[fn_id];
       let vir = distiller.distill_tir(tir);
       let mut vir = normalize(&vir);
-      analyze(&mut vir);
+      analyze(self.core, chart.concrete_fns[fn_id].span, &mut vir);
       assert_eq!(self.fn_vir.next_index(), fn_id);
       self.fn_vir.push(vir);
     }

--- a/vine/src/compiler.rs
+++ b/vine/src/compiler.rs
@@ -15,6 +15,7 @@ use crate::{
   structures::{
     chart::{checkpoint::ChartCheckpoint, Chart, ConcreteConstId, ConcreteFnId},
     core::Core,
+    diag::Diag,
     signatures::Signatures,
     vir::Vir,
   },
@@ -45,7 +46,7 @@ impl<'core> Compiler<'core> {
     }
   }
 
-  pub fn compile(&mut self, hooks: impl Hooks<'core>) -> Result<Nets, String> {
+  pub fn compile(&mut self, hooks: impl Hooks<'core>) -> Result<Nets, Vec<Diag<'core>>> {
     let checkpoint = self.checkpoint();
     self._compile(hooks, &checkpoint).inspect_err(|_| {
       self.revert(&checkpoint);
@@ -56,7 +57,7 @@ impl<'core> Compiler<'core> {
     &mut self,
     mut hooks: impl Hooks<'core>,
     checkpoint: &CompilerCheckpoint,
-  ) -> Result<Nets, String> {
+  ) -> Result<Nets, Vec<Diag<'core>>> {
     let core = self.core;
     let root = self.loader.finish();
     core.bail()?;
@@ -71,14 +72,12 @@ impl<'core> Compiler<'core> {
     resolver.resolve_since(&checkpoint.chart);
     hooks.resolve(&mut resolver);
 
-    core.bail()?;
-
     let mut specializer =
       Specializer { chart, resolutions: &self.resolutions, specs: &mut self.specs };
     specializer.specialize_since(&checkpoint.chart);
     hooks.specialize(&mut specializer);
 
-    let mut distiller = Distiller::new(chart);
+    let mut distiller = Distiller::new(core, chart);
     let mut emitter = Emitter::new(chart, &self.specs);
     for const_id in chart.concrete_consts.keys_from(checkpoint.chart.concrete_consts) {
       let tir = &self.resolutions.consts[const_id];
@@ -106,6 +105,8 @@ impl<'core> Compiler<'core> {
     }
 
     hooks.emit(&mut distiller, &mut emitter);
+
+    core.bail()?;
 
     Ok(emitter.nets)
   }

--- a/vine/src/components/distiller.rs
+++ b/vine/src/components/distiller.rs
@@ -23,7 +23,6 @@ mod pattern_matching;
 
 #[derive(Debug)]
 pub struct Distiller<'core, 'r> {
-  #[allow(unused)]
   core: &'core Core<'core>,
   chart: &'r Chart<'core>,
 
@@ -110,7 +109,7 @@ impl<'core, 'r> Distiller<'core, 'r> {
       TirExprKind::Return(value) => self.distill_return(stage, value),
       TirExprKind::Break(label, value) => self.distill_break(stage, *label, value),
       TirExprKind::Continue(label) => self.distill_continue(stage, *label),
-      TirExprKind::Match(value, arms) => self.distill_match(stage, value, arms),
+      TirExprKind::Match(value, arms) => self.distill_match(expr.span, stage, value, arms),
       TirExprKind::Try(result) => self.distill_try(stage, result),
 
       TirExprKind::Unwrap(inner) | TirExprKind::Struct(_, inner) => {

--- a/vine/src/components/distiller/control_flow.rs
+++ b/vine/src/components/distiller/control_flow.rs
@@ -78,6 +78,7 @@ impl<'core, 'r> Distiller<'core, 'r> {
     let mut then_stage = self.new_unconditional_stage(&mut layer);
     let mut else_stage = self.new_unconditional_stage(&mut layer);
     self.distill_pattern_match(
+      Span::NONE,
       &mut layer,
       &mut init_stage,
       value,
@@ -96,6 +97,7 @@ impl<'core, 'r> Distiller<'core, 'r> {
 
   pub(super) fn distill_match(
     &mut self,
+    span: Span,
     stage: &mut Stage,
     value: &TirExpr,
     arms: &[(TirPat, TirExpr)],
@@ -114,7 +116,7 @@ impl<'core, 'r> Distiller<'core, 'r> {
         Row::new(Some(pat), interface)
       })
       .collect();
-    self.distill_pattern_match(&mut layer, &mut init_stage, value, rows);
+    self.distill_pattern_match(span, &mut layer, &mut init_stage, value, rows);
     self.finish_stage(init_stage);
     self.finish_layer(layer);
     stage.take_local(local)
@@ -329,6 +331,7 @@ impl<'core, 'r> Distiller<'core, 'r> {
         let true_stage = self.new_unconditional_stage(layer);
         let false_stage = self.new_unconditional_stage(layer);
         self.distill_pattern_match(
+          Span::NONE,
           layer,
           stage,
           value,
@@ -384,6 +387,7 @@ impl<'core, 'r> Distiller<'core, 'r> {
     };
 
     self.distill_pattern_match(
+      Span::NONE,
       &mut layer,
       &mut init_stage,
       result,

--- a/vine/src/components/emitter.rs
+++ b/vine/src/components/emitter.rs
@@ -354,6 +354,7 @@ impl<'core, 'a> VirEmitter<'core, 'a> {
     port: &Port,
   ) -> Tree {
     match port {
+      Port::Error(_) => Tree::Erase,
       Port::Erase => Tree::Erase,
       Port::N32(n) => Tree::N32(*n),
       Port::F32(f) => Tree::F32(*f),

--- a/vine/src/components/resolver.rs
+++ b/vine/src/components/resolver.rs
@@ -336,18 +336,14 @@ impl<'core, 'a> Resolver<'core, 'a> {
   fn resolve_stmts_type(&mut self, span: Span, stmts: &[Stmt<'core>], ty: Type) -> TirExpr {
     let [stmt, rest @ ..] = stmts else {
       let nil = self.types.nil();
-      return if self.types.unify(ty, nil).is_failure() {
-        TirExpr {
-          span,
-          ty,
-          form: Form::Value,
-          kind: Box::new(TirExprKind::Error(
-            self.core.report(Diag::MissingBlockExpr { span, ty: self.types.show(self.chart, ty) }),
-          )),
-        }
+      let kind = if self.types.unify(ty, nil).is_failure() {
+        TirExprKind::Error(
+          self.core.report(Diag::MissingBlockExpr { span, ty: self.types.show(self.chart, ty) }),
+        )
       } else {
-        TirExpr { span, ty, form: Form::Value, kind: Box::new(TirExprKind::Composite(Vec::new())) }
+        TirExprKind::Composite(Vec::new())
       };
+      return TirExpr { span, ty, form: Form::Value, kind: Box::new(kind) };
     };
     let kind = match &stmt.kind {
       StmtKind::Let(l) => {

--- a/vine/src/components/resolver.rs
+++ b/vine/src/components/resolver.rs
@@ -334,26 +334,22 @@ impl<'core, 'a> Resolver<'core, 'a> {
   }
 
   fn resolve_stmts_type(&mut self, span: Span, stmts: &[Stmt<'core>], ty: Type) -> TirExpr {
-    TirExpr {
-      span,
-      ty,
-      form: Form::Value,
-      kind: Box::new(self._resolve_stmts_type(span, stmts, ty)),
-    }
-  }
-
-  fn _resolve_stmts_type(&mut self, span: Span, stmts: &[Stmt<'core>], ty: Type) -> TirExprKind {
     let [stmt, rest @ ..] = stmts else {
       let nil = self.types.nil();
       return if self.types.unify(ty, nil).is_failure() {
-        TirExprKind::Error(
-          self.core.report(Diag::MissingBlockExpr { span, ty: self.types.show(self.chart, ty) }),
-        )
+        TirExpr {
+          span,
+          ty,
+          form: Form::Value,
+          kind: Box::new(TirExprKind::Error(
+            self.core.report(Diag::MissingBlockExpr { span, ty: self.types.show(self.chart, ty) }),
+          )),
+        }
       } else {
-        TirExprKind::Composite(Vec::new())
+        TirExpr { span, ty, form: Form::Value, kind: Box::new(TirExprKind::Composite(Vec::new())) }
       };
     };
-    match &stmt.kind {
+    let kind = match &stmt.kind {
       StmtKind::Let(l) => {
         let init = l.init.as_ref().map(|init| self.resolve_expr_form(init, Form::Value));
         let else_block = l.else_block.as_ref().map(|block| {
@@ -378,18 +374,19 @@ impl<'core, 'a> Resolver<'core, 'a> {
       StmtKind::LetFn(l) => {
         let (fn_ty, id) = self.resolve_closure(&l.params, &l.ret, &l.body, true);
         self.bind(l.name, Binding::Closure(id, fn_ty));
-        self._resolve_stmts_type(span, rest, ty)
+        return self.resolve_stmts_type(span, rest, ty);
       }
       StmtKind::Expr(expr, semi) => {
         if !semi && rest.is_empty() {
-          *self.resolve_expr_form_type(expr, Form::Value, ty).kind
+          return self.resolve_expr_form_type(expr, Form::Value, ty);
         } else {
           let expr = self.resolve_expr_form(expr, Form::Value);
           TirExprKind::Seq(expr, self.resolve_stmts_type(span, rest, ty))
         }
       }
-      StmtKind::Item(_) | StmtKind::Empty => self._resolve_stmts_type(span, rest, ty),
-    }
+      StmtKind::Item(_) | StmtKind::Empty => return self.resolve_stmts_type(span, rest, ty),
+    };
+    TirExpr { span, ty, form: Form::Value, kind: Box::new(kind) }
   }
 
   fn resolve_closure(

--- a/vine/src/components/resolver/resolve_expr.rs
+++ b/vine/src/components/resolver/resolve_expr.rs
@@ -335,7 +335,7 @@ impl<'core> Resolver<'core, '_> {
             });
           }
         } else {
-          self.core.report(Diag::NoReturn { span });
+          Err(Diag::NoReturn { span })?
         }
         (Form::Value, ok, TirExprKind::Try(result))
       }
@@ -545,7 +545,7 @@ impl<'core> Resolver<'core, '_> {
         let data_ty = self.get_struct_data(span, ty, struct_id, type_params);
         self.tuple_field(span, data_ty.invert_if(inv), index)
       }
-      (_, TypeKind::Error(_)) => Some((ty, 0)),
+      (_, TypeKind::Error(_)) => Some((ty, index + 1)),
       _ => None,
     }
   }
@@ -568,7 +568,7 @@ impl<'core> Resolver<'core, '_> {
         let data_ty = self.get_struct_data(span, ty, struct_id, type_params);
         self.object_field(span, data_ty.invert_if(inv), key)
       }
-      (_, TypeKind::Error(_)) => Some((ty, 0, 0)),
+      (_, TypeKind::Error(_)) => Some((ty, 0, 1)),
       _ => None,
     }
   }

--- a/vine/src/components/resolver/resolve_pat.rs
+++ b/vine/src/components/resolver/resolve_pat.rs
@@ -100,7 +100,7 @@ impl<'core> Resolver<'core, '_> {
               }
             };
             if !refutable {
-              self.core.report(Diag::ExpectedCompletePat { span });
+              Err(Diag::ExpectedCompletePat { span })?
             }
             let ty = self.types.new(TypeKind::Enum(enum_id, type_params));
             (ty, TirPatKind::Enum(enum_id, variant, data))

--- a/vine/src/structures/diag.rs
+++ b/vine/src/structures/diag.rs
@@ -216,6 +216,8 @@ diags! {
     ["expected a value of type `{ty}` to evaluate to"]
   GenericMain
     ["main cannot be generic"]
+  InfiniteLoop
+    ["unconditional infinite loops are invalid"]
 }
 
 fn plural<'a>(n: usize, plural: &'a str, singular: &'a str) -> &'a str {

--- a/vine/src/structures/diag.rs
+++ b/vine/src/structures/diag.rs
@@ -240,28 +240,31 @@ impl<'core> Core<'core> {
     !self.diags.borrow().is_empty()
   }
 
-  pub fn take_diags(&self) -> Vec<Diag> {
+  pub fn take_diags(&self) -> Vec<Diag<'core>> {
     take(&mut *self.diags.borrow_mut())
   }
 
-  pub fn bail(&self) -> Result<(), String> {
-    let mut diags = self.diags.borrow_mut();
+  pub fn bail(&self) -> Result<(), Vec<Diag<'core>>> {
+    let diags = self.take_diags();
     if diags.is_empty() {
       Ok(())
     } else {
-      let mut err = String::new();
-      for diag in diags.iter() {
-        if let Some(span) = diag.span() {
-          match self.show_span(span) {
-            Some(span) => writeln!(err, "error {span} - {}", diag).unwrap(),
-            None => writeln!(err, "error - {}", diag).unwrap(),
-          }
+      Err(diags)
+    }
+  }
+
+  pub fn print_diags(&self, diags: &[Diag<'core>]) -> String {
+    let mut err = String::new();
+    for diag in diags.iter() {
+      if let Some(span) = diag.span() {
+        match self.show_span(span) {
+          Some(span) => writeln!(err, "error {span} - {}", diag).unwrap(),
+          None => writeln!(err, "error - {}", diag).unwrap(),
         }
       }
-      err.pop();
-      diags.clear();
-      Err(err)
     }
+    err.pop();
+    err
   }
 
   pub fn show_span(&self, span: Span) -> Option<String> {

--- a/vine/src/structures/diag.rs
+++ b/vine/src/structures/diag.rs
@@ -218,6 +218,8 @@ diags! {
     ["main cannot be generic"]
   InfiniteLoop
     ["unconditional infinite loops are invalid"]
+  NonExhaustiveMatch
+    ["match arms do not cover all possible cases"]
 }
 
 fn plural<'a>(n: usize, plural: &'a str, singular: &'a str) -> &'a str {

--- a/vine/src/structures/tir.rs
+++ b/vine/src/structures/tir.rs
@@ -151,7 +151,7 @@ pub enum TirExprKind {
   LetElse(TirPat, TirExpr, TirExpr, TirExpr),
   #[class(value)]
   Seq(TirExpr, TirExpr),
-  #[class(error)]
+  #[class(value, place, space)]
   Error(ErrorGuaranteed),
 }
 
@@ -181,7 +181,7 @@ pub enum TirPatKind {
   Inverse(TirPat),
   #[class(value, place, space)]
   Composite(Vec<TirPat>),
-  #[class(error)]
+  #[class(value, place, space)]
   Error(ErrorGuaranteed),
 }
 

--- a/vine/src/structures/vir.rs
+++ b/vine/src/structures/vir.rs
@@ -11,6 +11,7 @@ use crate::{
   components::analyzer::{usage::Usage, UsageVar},
   structures::{
     chart::{EnumId, VariantId},
+    diag::ErrorGuaranteed,
     tir::{ConstRelId, FnRelId, Local},
   },
 };
@@ -195,6 +196,7 @@ pub enum Port {
   N32(u32),
   F32(f32),
   Wire(WireId),
+  Error(ErrorGuaranteed),
 }
 
 #[derive(Debug, Clone)]

--- a/vine/src/tools/repl.rs
+++ b/vine/src/tools/repl.rs
@@ -64,7 +64,7 @@ impl<'core, 'ctx, 'ivm, 'ext> Repl<'core, 'ctx, 'ivm, 'ext> {
     ivm: &'ctx mut IVM<'ivm, 'ext>,
     core: &'core Core<'core>,
     libs: Vec<PathBuf>,
-  ) -> Result<Self, String> {
+  ) -> Result<Self, Vec<Diag<'core>>> {
     let mut compiler = Compiler::new(core);
     for lib in libs {
       compiler.loader.load_mod(lib);
@@ -107,7 +107,7 @@ impl<'core, 'ctx, 'ivm, 'ext> Repl<'core, 'ctx, 'ivm, 'ext> {
     })
   }
 
-  pub fn exec(&mut self, line: &str) -> Result<Option<String>, String> {
+  pub fn exec(&mut self, line: &str) -> Result<Option<String>, Vec<Diag<'core>>> {
     let stmts = match self.parse_line(line) {
       Ok(stmts) => stmts,
       Err(diag) => {

--- a/vine/src/tools/repl.rs
+++ b/vine/src/tools/repl.rs
@@ -124,6 +124,7 @@ impl<'core, 'ctx, 'ivm, 'ext> Repl<'core, 'ctx, 'ivm, 'ext> {
     let mut name = String::new();
 
     let nets = self.compiler.compile(ExecHooks {
+      core: self.core,
       repl_mod: self.repl_mod,
       vars: &mut self.vars,
       ivm: self.ivm,
@@ -140,6 +141,7 @@ impl<'core, 'ctx, 'ivm, 'ext> Repl<'core, 'ctx, 'ivm, 'ext> {
     let tir = tir.unwrap();
 
     struct ExecHooks<'core, 'ivm, 'ext, 'a> {
+      core: &'core Core<'core>,
       repl_mod: DefId,
       vars: &'a mut HashMap<Ident<'core>, Var<'ivm>>,
       ivm: &'a mut IVM<'ivm, 'ext>,
@@ -201,7 +203,7 @@ impl<'core, 'ctx, 'ivm, 'ext> Repl<'core, 'ctx, 'ivm, 'ext> {
         vir.stages[StageId(0)].declarations.retain(|l| !self.locals.contains_key(l));
         vir.globals.extend(self.vars.values().map(|v| (v.local, Usage::Mut)));
         let mut vir = normalize(&vir);
-        analyze(&mut vir);
+        analyze(self.core, Span::NONE, &mut vir);
         for var in self.vars.values() {
           vir.interfaces[InterfaceId(0)].wires.insert(var.local, (Usage::Mut, Usage::Mut));
         }

--- a/vine/std/logical/Option.vi
+++ b/vine/std/logical/Option.vi
@@ -56,7 +56,7 @@ pub mod Option {
   pub fn .unwrap[T](self: Option[T]) -> T {
     match self {
       Some(val) { val }
-      None { unsafe::eraser }
+      None { unsafe::unreachable() }
     }
   }
 

--- a/vine/std/logical/Option.vi
+++ b/vine/std/logical/Option.vi
@@ -56,6 +56,7 @@ pub mod Option {
   pub fn .unwrap[T](self: Option[T]) -> T {
     match self {
       Some(val) { val }
+      None { unsafe::eraser }
     }
   }
 

--- a/vine/std/logical/Result.vi
+++ b/vine/std/logical/Result.vi
@@ -51,6 +51,7 @@ pub mod Result {
   pub fn .unwrap[T, E](self: Result[T, E], default: T) -> T {
     match self {
       Ok(val) { val }
+      Err(_) { unsafe::unreachable() }
     }
   }
 

--- a/vine/std/unsafe.vi
+++ b/vine/std/unsafe.vi
@@ -11,3 +11,7 @@ pub const eraser[T]: T = inline_ivy! () -> T { _ };
 pub fn erase[T](value: T) {
   ~eraser = value;
 }
+
+pub fn unreachable[T]() -> T {
+  eraser
+}


### PR DESCRIPTION
Resolves #134 

The error message is not very helpful at the moment, but this can be improved in the future. Better than just silently evaluating to an eraser node, at any rate.