### PR TITLE
tooling: stop using workspace lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,3 @@
 [workspace]
 resolver = "2"
 members = ["cli", "ivm", "ivy", "lsp", "tests", "util", "vine"]
-
-[workspace.lints.clippy]
-absolute_paths = "warn"
-needless_lifetimes = "allow"
-large_enum_variant = "allow"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -15,8 +15,8 @@ vine = { path = "../vine", optional = true }
 vine-lsp = { path = "../lsp", optional = true }
 vine-util = { path = "../util" }
 
-[lints]
-workspace = true
+[lints.clippy]
+absolute_paths = "warn"
 
 [features]
 vine = ["dep:vine", "dep:vine-lsp"]

--- a/ivm/Cargo.toml
+++ b/ivm/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 
 [dependencies]
 
-[lints]
-workspace = true
+[lints.clippy]
+absolute_paths = "warn"

--- a/ivy/Cargo.toml
+++ b/ivy/Cargo.toml
@@ -10,5 +10,5 @@ logos = "0.14.0"
 ivm = { path = "../ivm" }
 vine-util = { path = "../util" }
 
-[lints]
-workspace = true
+[lints.clippy]
+absolute_paths = "warn"

--- a/lsp/Cargo.toml
+++ b/lsp/Cargo.toml
@@ -10,5 +10,5 @@ tokio = { version = "1.41.1", features = ["full"] }
 tower-lsp = "0.20.0"
 vine = { version = "0.1.0", path = "../vine" }
 
-[lints]
-workspace = true
+[lints.clippy]
+absolute_paths = "warn"

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -8,5 +8,5 @@ hashbrown = "0.14.5"
 logos = "0.14.0"
 nohash-hasher = "0.2.0"
 
-[lints]
-workspace = true
+[lints.clippy]
+absolute_paths = "warn"

--- a/vine/Cargo.toml
+++ b/vine/Cargo.toml
@@ -14,5 +14,6 @@ ivm = { path = "../ivm" }
 ivy = { path = "../ivy" }
 vine-util = { path = "../util" }
 
-[lints]
-workspace = true
+[lints.clippy]
+absolute_paths = "warn"
+large_enum_variant = "allow"


### PR DESCRIPTION
This commit doesn't remove any lints from any packages.

This is a slightly cheeky PR. Because I don't really have time to work out how to fix https://github.com/NixOS/nixpkgs/issues/406228 , removing the workspace lints would mean I don't have to maintain a fork for dependent packages. Hopefully this issue will be fixed upstream soon, either by me or someone else.

We are currently running into this issue for in a dependent package.