### PR TITLE
ivm: lower max heap size

### DIFF
--- a/ivm/src/heap.rs
+++ b/ivm/src/heap.rs
@@ -15,7 +15,7 @@ pub(crate) struct Node(pub AtomicWord, pub AtomicWord);
 pub const HEAP_SIZE_BYTES: usize = if cfg!(miri) {
   1 << 16
 } else if cfg!(target_pointer_width = "64") {
-  1 << 40
+  1 << 32
 } else {
   1 << 30
 };


### PR DESCRIPTION
Fixes an issue I encounter not infrequently:
- the IVM requests a terabyte of virtual memory, which the OS happily provides
- a buggy Ivy program causes an infinite allocation loop
- IVM fills its virtual memory at the speed of light
- unable to keep up, the kernel panics

Four gigabytes ought to be enough for anyone ;)