### PR TITLE
vine: tuple/object impl derivation

### DIFF
--- a/tests/programs/the_greatest_show.vi
+++ b/tests/programs/the_greatest_show.vi
@@ -38,17 +38,3 @@ pub fn main(&io: &IO) {
   };
   io.println("{the_greatest.show()}");
 }
-
-impl show_obj[A, B, C; Show[A], Show[B], Show[C]]: Show[{ a: A, b: B, c: C }] {
-  fn show(&{ a:: A, b:: B, c:: C }) -> Show {
-    Show::Object([
-      (Show::Literal("a"), a.show()),
-      (Show::Literal("b"), b.show()),
-      (Show::Literal("c"), c.show()),
-    ])
-  }
-}
-
-impl drop_obj[A?, B?, C?]: Drop[{ a: A, b: B, c: C }] {
-  fn drop({ a: _: A, b: _: B, c: _: C }) {}
-}

--- a/tests/snaps/vine/fail/atypical.txt
+++ b/tests/snaps/vine/fail/atypical.txt
@@ -35,24 +35,38 @@ error tests/programs/fail/atypical.vi:31:3 - invalid break target
 error tests/programs/fail/atypical.vi:32:14 - invalid continue target
 error tests/programs/fail/atypical.vi:33:3 - expected type `()`; found `N32`
 error - main cannot be generic
-error tests/programs/fail/atypical.vi:4:8 - search limit reached when finding flex of type `?0`
-error tests/programs/fail/atypical.vi:4:11 - search limit reached when finding flex of type `(?1, ??, ??)`
+error tests/programs/fail/atypical.vi:4:8 - found several impls of trait `Fork[?1]`
+error tests/programs/fail/atypical.vi:4:8 - found several impls of trait `Drop[?1]`
+error tests/programs/fail/atypical.vi:4:8 - found several impls of trait `Fork[~?1]`
+error tests/programs/fail/atypical.vi:4:8 - found several impls of trait `Drop[~?1]`
 error tests/programs/fail/atypical.vi:4:8 - cannot drop `?0`
 error tests/programs/fail/atypical.vi:4:11 - cannot drop `(?1, ??, ??)`
-error tests/programs/fail/atypical.vi:12:3 - search limit reached when finding impl of trait `Drop[?29]`
-error tests/programs/fail/atypical.vi:13:14 - search limit reached when finding impl of trait `Drop[?33]`
+error tests/programs/fail/atypical.vi:12:3 - found several impls of trait `Drop[?29]`
+error tests/programs/fail/atypical.vi:13:14 - found several impls of trait `Drop[?33]`
 error tests/programs/fail/atypical.vi:14:3 - cannot find impl of trait `Drop[??]`
 error tests/programs/fail/atypical.vi:16:3 - cannot find impl of trait `Drop[??]`
 error tests/programs/fail/atypical.vi:17:3 - cannot find impl of trait `Drop[??]`
 error tests/programs/fail/atypical.vi:22:7 - expected a complete pattern
-error tests/programs/fail/atypical.vi:23:4 - search limit reached when finding impl of trait `Drop[?72]`
-error tests/programs/fail/atypical.vi:28:14 - search limit reached when finding impl of trait `Drop[?82]`
+error tests/programs/fail/atypical.vi:23:4 - found several impls of trait `Drop[?72]`
+error tests/programs/fail/atypical.vi:28:14 - found several impls of trait `Drop[?82]`
 error tests/programs/fail/atypical.vi:30:3 - cannot find impl of trait `Drop[??]`
 error tests/programs/fail/atypical.vi:32:3 - cannot find impl of trait `Drop[??]`
-error tests/programs/fail/atypical.vi:10:8 - search limit reached when finding flex of type `?19`
-error tests/programs/fail/atypical.vi:10:11 - search limit reached when finding flex of type `?20`
-error tests/programs/fail/atypical.vi:18:14 - search limit reached when finding flex of type `?53`
-error tests/programs/fail/atypical.vi:24:8 - search limit reached when finding flex of type `?76`
+error tests/programs/fail/atypical.vi:10:8 - found several impls of trait `Fork[?2]`
+error tests/programs/fail/atypical.vi:10:8 - found several impls of trait `Drop[?2]`
+error tests/programs/fail/atypical.vi:10:8 - found several impls of trait `Fork[~?2]`
+error tests/programs/fail/atypical.vi:10:8 - found several impls of trait `Drop[~?2]`
+error tests/programs/fail/atypical.vi:10:11 - found several impls of trait `Fork[?2]`
+error tests/programs/fail/atypical.vi:10:11 - found several impls of trait `Drop[?2]`
+error tests/programs/fail/atypical.vi:10:11 - found several impls of trait `Fork[~?2]`
+error tests/programs/fail/atypical.vi:10:11 - found several impls of trait `Drop[~?2]`
+error tests/programs/fail/atypical.vi:18:14 - found several impls of trait `Fork[?2]`
+error tests/programs/fail/atypical.vi:18:14 - found several impls of trait `Drop[?2]`
+error tests/programs/fail/atypical.vi:18:14 - found several impls of trait `Fork[~?2]`
+error tests/programs/fail/atypical.vi:18:14 - found several impls of trait `Drop[~?2]`
+error tests/programs/fail/atypical.vi:24:8 - found several impls of trait `Fork[?2]`
+error tests/programs/fail/atypical.vi:24:8 - found several impls of trait `Drop[?2]`
+error tests/programs/fail/atypical.vi:24:8 - found several impls of trait `Fork[~?2]`
+error tests/programs/fail/atypical.vi:24:8 - found several impls of trait `Drop[~?2]`
 error tests/programs/fail/atypical.vi:6:1 - unconditional infinite loops are invalid
 error tests/programs/fail/atypical.vi:6:19 - cannot drop `IO`
 error tests/programs/fail/atypical.vi:10:8 - cannot drop `?19`

--- a/tests/snaps/vine/fail/informal.txt
+++ b/tests/snaps/vine/fail/informal.txt
@@ -3,15 +3,15 @@ error tests/programs/fail/informal.vi:7:3 - cannot find impl of trait `Add[?13, 
 error tests/programs/fail/informal.vi:9:15 - expected type `IO`; found `&?0`
 error tests/programs/fail/informal.vi:4:13 - `*` is only valid in a place pattern
 error tests/programs/fail/informal.vi:5:3 - expected a space expression; found a value expression
-error tests/programs/fail/informal.vi:6:8 - search limit reached when finding impl of trait `Drop[~?11]`
+error tests/programs/fail/informal.vi:6:8 - found several impls of trait `Drop[~?11]`
 error tests/programs/fail/informal.vi:6:8 - expected a value expression; found a space expression
-error tests/programs/fail/informal.vi:6:4 - search limit reached when finding impl of trait `Drop[?11]`
+error tests/programs/fail/informal.vi:6:4 - found several impls of trait `Drop[?11]`
 error tests/programs/fail/informal.vi:6:4 - expected a value expression; found a space expression
 error tests/programs/fail/informal.vi:7:9 - expected a space expression; found a value expression
-error tests/programs/fail/informal.vi:7:3 - search limit reached when finding impl of trait `Drop[?13]`
-error tests/programs/fail/informal.vi:7:3 - search limit reached when finding impl of trait `Drop[~?13]`
-error tests/programs/fail/informal.vi:8:15 - search limit reached when finding impl of trait `Drop[?17]`
-error tests/programs/fail/informal.vi:8:15 - search limit reached when finding impl of trait `Drop[~?17]`
+error tests/programs/fail/informal.vi:7:3 - found several impls of trait `Drop[?13]`
+error tests/programs/fail/informal.vi:7:3 - found several impls of trait `Drop[~?13]`
+error tests/programs/fail/informal.vi:8:15 - found several impls of trait `Drop[?17]`
+error tests/programs/fail/informal.vi:8:15 - found several impls of trait `Drop[~?17]`
 error tests/programs/fail/informal.vi:8:14 - expected a space expression; found a value expression
 error tests/programs/fail/informal.vi:8:8 - `&` is invalid in a space pattern
 error tests/programs/fail/informal.vi:9:7 - expected a complete pattern

--- a/tests/snaps/vine/fail/is_not.txt
+++ b/tests/snaps/vine/fail/is_not.txt
@@ -8,15 +8,42 @@ error tests/programs/fail/is_not.vi:5:3 - missing else block
 error tests/programs/fail/is_not.vi:7:3 - cannot find `y` in `::is_not::main`
 error tests/programs/fail/is_not.vi:4:3 - cannot find impl of trait `Drop[??]`
 error tests/programs/fail/is_not.vi:5:3 - cannot find impl of trait `Drop[(??, ??)]`
-error tests/programs/fail/is_not.vi:2:13 - search limit reached when finding flex of type `?0`
-error tests/programs/fail/is_not.vi:3:11 - search limit reached when finding flex of type `?0`
-error tests/programs/fail/is_not.vi:4:13 - search limit reached when finding flex of type `?0`
-error tests/programs/fail/is_not.vi:5:11 - search limit reached when finding flex of type `?0`
-error tests/programs/fail/is_not.vi:6:14 - search limit reached when finding flex of type `?0`
-error tests/programs/fail/is_not.vi:3:3 - search limit reached when finding flex of type `?0`
-error tests/programs/fail/is_not.vi:4:3 - search limit reached when finding flex of type `?0`
-error tests/programs/fail/is_not.vi:5:3 - search limit reached when finding flex of type `?0`
-error tests/programs/fail/is_not.vi:6:3 - search limit reached when finding flex of type `?0`
+error tests/programs/fail/is_not.vi:2:13 - found several impls of trait `Fork[?2]`
+error tests/programs/fail/is_not.vi:2:13 - found several impls of trait `Drop[?2]`
+error tests/programs/fail/is_not.vi:2:13 - found several impls of trait `Fork[~?2]`
+error tests/programs/fail/is_not.vi:2:13 - found several impls of trait `Drop[~?2]`
+error tests/programs/fail/is_not.vi:3:11 - found several impls of trait `Fork[?2]`
+error tests/programs/fail/is_not.vi:3:11 - found several impls of trait `Drop[?2]`
+error tests/programs/fail/is_not.vi:3:11 - found several impls of trait `Fork[~?2]`
+error tests/programs/fail/is_not.vi:3:11 - found several impls of trait `Drop[~?2]`
+error tests/programs/fail/is_not.vi:4:13 - found several impls of trait `Fork[?2]`
+error tests/programs/fail/is_not.vi:4:13 - found several impls of trait `Drop[?2]`
+error tests/programs/fail/is_not.vi:4:13 - found several impls of trait `Fork[~?2]`
+error tests/programs/fail/is_not.vi:4:13 - found several impls of trait `Drop[~?2]`
+error tests/programs/fail/is_not.vi:5:11 - found several impls of trait `Fork[?2]`
+error tests/programs/fail/is_not.vi:5:11 - found several impls of trait `Drop[?2]`
+error tests/programs/fail/is_not.vi:5:11 - found several impls of trait `Fork[~?2]`
+error tests/programs/fail/is_not.vi:5:11 - found several impls of trait `Drop[~?2]`
+error tests/programs/fail/is_not.vi:6:14 - found several impls of trait `Fork[?2]`
+error tests/programs/fail/is_not.vi:6:14 - found several impls of trait `Drop[?2]`
+error tests/programs/fail/is_not.vi:6:14 - found several impls of trait `Fork[~?2]`
+error tests/programs/fail/is_not.vi:6:14 - found several impls of trait `Drop[~?2]`
+error tests/programs/fail/is_not.vi:3:3 - found several impls of trait `Fork[?2]`
+error tests/programs/fail/is_not.vi:3:3 - found several impls of trait `Drop[?2]`
+error tests/programs/fail/is_not.vi:3:3 - found several impls of trait `Fork[~?2]`
+error tests/programs/fail/is_not.vi:3:3 - found several impls of trait `Drop[~?2]`
+error tests/programs/fail/is_not.vi:4:3 - found several impls of trait `Fork[?2]`
+error tests/programs/fail/is_not.vi:4:3 - found several impls of trait `Drop[?2]`
+error tests/programs/fail/is_not.vi:4:3 - found several impls of trait `Fork[~?2]`
+error tests/programs/fail/is_not.vi:4:3 - found several impls of trait `Drop[~?2]`
+error tests/programs/fail/is_not.vi:5:3 - found several impls of trait `Fork[?2]`
+error tests/programs/fail/is_not.vi:5:3 - found several impls of trait `Drop[?2]`
+error tests/programs/fail/is_not.vi:5:3 - found several impls of trait `Fork[~?2]`
+error tests/programs/fail/is_not.vi:5:3 - found several impls of trait `Drop[~?2]`
+error tests/programs/fail/is_not.vi:6:3 - found several impls of trait `Fork[?2]`
+error tests/programs/fail/is_not.vi:6:3 - found several impls of trait `Drop[?2]`
+error tests/programs/fail/is_not.vi:6:3 - found several impls of trait `Fork[~?2]`
+error tests/programs/fail/is_not.vi:6:3 - found several impls of trait `Drop[~?2]`
 error tests/programs/fail/is_not.vi:2:1 - unconditional infinite loops are invalid
 error tests/programs/fail/is_not.vi:2:13 - cannot fork `?0`
 error tests/programs/fail/is_not.vi:3:11 - cannot drop `?0`

--- a/tests/snaps/vine/repl/misc.repl.vi
+++ b/tests/snaps/vine/repl/misc.repl.vi
@@ -32,7 +32,7 @@ let io: IO = #io;
 let io: IO = #io;
 > "abc" ++ 123
 error input:1:1 - cannot find impl of trait `Concat[String, N32, ?86]`
-error input:1:1 - search limit reached when finding impl of trait `Drop[?83]`
+error input:1:1 - found several impls of trait `Drop[?83]`
 
 let io: IO = #io;
 > ([true, false]; _).show().as[String]
@@ -278,12 +278,14 @@ let x: List[List[N32]] = [[2]];
 let io: IO = #io;
 > let _: { a: N32, b: N32 } = { a: 1 }
 error input:1:29 - expected type `{ a: N32, b: N32 }`; found `{ a: N32 }`
-error input:1:5 - cannot find impl of trait `Drop[{ a: N32, b: N32 }]`
 
 let io: IO = #io;
 > do { let x; x = (x, x); }
 error input:1:17 - expected type `?1514`; found `(?1514, ?1514)`
-error input:1:10 - search limit reached when finding flex of type `?1514`
+error input:1:10 - found several impls of trait `Fork[?1]`
+error input:1:10 - found several impls of trait `Drop[?1]`
+error input:1:10 - found several impls of trait `Fork[~?1]`
+error input:1:10 - found several impls of trait `Drop[~?1]`
 error input:1:10 - cannot drop `?1514`
 error input:1:10 - variable of type `?1514` read whilst uninitialized
 error input:1:10 - cannot fork `?1514`
@@ -326,12 +328,21 @@ let y: { a: ~N32, b: ~N32 };
 let io: IO = #io;
 > let x; x.a; x.a
 error input:1:5 - cannot infer type
-error input:1:8 - search limit reached when finding flex of type `?1604`
-error input:1:8 - search limit reached when finding impl of trait `Drop[?1604]`
-error input:1:13 - search limit reached when finding flex of type `?1604`
-error - search limit reached when finding impl of trait `Drop[?1604]`
-error input:1:5 - search limit reached when finding flex of type `?1604`
-error input:1:5 - variable of type `?1604` read whilst uninitialized
+error input:1:8 - found several impls of trait `Fork[?1]`
+error input:1:8 - found several impls of trait `Drop[?1]`
+error input:1:8 - found several impls of trait `Fork[~?1]`
+error input:1:8 - found several impls of trait `Drop[~?1]`
+error input:1:8 - found several impls of trait `Drop[?1628]`
+error input:1:13 - found several impls of trait `Fork[?1]`
+error input:1:13 - found several impls of trait `Drop[?1]`
+error input:1:13 - found several impls of trait `Fork[~?1]`
+error input:1:13 - found several impls of trait `Drop[~?1]`
+error - found several impls of trait `Drop[?1628]`
+error input:1:5 - found several impls of trait `Fork[?1]`
+error input:1:5 - found several impls of trait `Drop[?1]`
+error input:1:5 - found several impls of trait `Fork[~?1]`
+error input:1:5 - found several impls of trait `Drop[~?1]`
+error input:1:5 - variable of type `?1628` read whilst uninitialized
 
 let io: IO = #io;
 > Ok(true)?
@@ -340,9 +351,16 @@ error input:1:1 - no function to return from
 let io: IO = #io;
 > fn foo() -> N32 { Ok(123)? }
 error input:1:19 - cannot try `Result[N32, ?2]` in a function returning `N32`
-error input:1:19 - search limit reached when finding flex of type `?2`
-error input:1:19 - search limit reached when finding flex of type `Result[N32, ?2]`
-error input:1:19 - search limit reached when finding flex of type `?2`
+error input:1:19 - found several impls of trait `Fork[?0]`
+error input:1:19 - found several impls of trait `Drop[?0]`
+error input:1:19 - found several impls of trait `Fork[~?0]`
+error input:1:19 - found several impls of trait `Drop[~?0]`
+error input:1:19 - found several impls of trait `Fork[Result[N32, ?2]]`
+error input:1:19 - found several impls of trait `Drop[Result[N32, ?2]]`
+error input:1:19 - found several impls of trait `Fork[?0]`
+error input:1:19 - found several impls of trait `Drop[?0]`
+error input:1:19 - found several impls of trait `Fork[~?0]`
+error input:1:19 - found several impls of trait `Drop[~?0]`
 
 let io: IO = #io;
 > fn foo() -> Result[N32, String] { Ok(123)? }

--- a/tests/snaps/vine/repl/objects.repl.vi
+++ b/tests/snaps/vine/repl/objects.repl.vi
@@ -17,101 +17,101 @@ let x: { a: N32, b: N32, c: N32 } = { a: 1, b: 2, c: 3 };
 > let y = { x }
 
 let io: IO = #io;
-let x: { a: N32, b: N32, c: N32 };
+let x: { a: N32, b: N32, c: N32 } = { a: 1, b: 2, c: 3 };
 let y: { x: { a: N32, b: N32, c: N32 } } = { x: { a: 1, b: 2, c: 3 } };
 > let z = { y }
 
 let io: IO = #io;
-let x: { a: N32, b: N32, c: N32 };
-let y: { x: { a: N32, b: N32, c: N32 } };
+let x: { a: N32, b: N32, c: N32 } = { a: 1, b: 2, c: 3 };
+let y: { x: { a: N32, b: N32, c: N32 } } = { x: { a: 1, b: 2, c: 3 } };
 let z: { y: { x: { a: N32, b: N32, c: N32 } } } = { y: { x: { a: 1, b: 2, c: 3 } } };
 > z.y.x.a
 1
 
 let io: IO = #io;
-let x: { a: N32, b: N32, c: N32 };
-let y: { x: { a: N32, b: N32, c: N32 } };
+let x: { a: N32, b: N32, c: N32 } = { a: 1, b: 2, c: 3 };
+let y: { x: { a: N32, b: N32, c: N32 } } = { x: { a: 1, b: 2, c: 3 } };
 let z: { y: { x: { a: N32, b: N32, c: N32 } } } = { y: { x: { a: 1, b: 2, c: 3 } } };
 > z.y.x.a += y.x.b
-error input:1:5 - variable of type `{ x: { a: N32, b: N32, c: N32 } }` read whilst uninitialized
 
 let io: IO = #io;
-let x: { a: N32, b: N32, c: N32 };
-let y: { x: { a: N32, b: N32, c: N32 } };
-let z: { y: { x: { a: N32, b: N32, c: N32 } } } = { y: { x: { a: 1, b: 2, c: 3 } } };
+let x: { a: N32, b: N32, c: N32 } = { a: 1, b: 2, c: 3 };
+let y: { x: { a: N32, b: N32, c: N32 } } = { x: { a: 1, b: 2, c: 3 } };
+let z: { y: { x: { a: N32, b: N32, c: N32 } } } = { y: { x: { a: 3, b: 2, c: 3 } } };
 > let { y: { x: o } } = z
 
 let io: IO = #io;
-let x: { a: N32, b: N32, c: N32 };
-let y: { x: { a: N32, b: N32, c: N32 } };
-let z: { y: { x: { a: N32, b: N32, c: N32 } } };
-let o: { a: N32, b: N32, c: N32 } = { a: 1, b: 2, c: 3 };
+let x: { a: N32, b: N32, c: N32 } = { a: 1, b: 2, c: 3 };
+let y: { x: { a: N32, b: N32, c: N32 } } = { x: { a: 1, b: 2, c: 3 } };
+let z: { y: { x: { a: N32, b: N32, c: N32 } } } = { y: { x: { a: 3, b: 2, c: 3 } } };
+let o: { a: N32, b: N32, c: N32 } = { a: 3, b: 2, c: 3 };
 > let { c, b, a } = o
 
 let io: IO = #io;
-let x: { a: N32, b: N32, c: N32 };
-let y: { x: { a: N32, b: N32, c: N32 } };
-let z: { y: { x: { a: N32, b: N32, c: N32 } } };
-let o: { a: N32, b: N32, c: N32 };
+let x: { a: N32, b: N32, c: N32 } = { a: 1, b: 2, c: 3 };
+let y: { x: { a: N32, b: N32, c: N32 } } = { x: { a: 1, b: 2, c: 3 } };
+let z: { y: { x: { a: N32, b: N32, c: N32 } } } = { y: { x: { a: 3, b: 2, c: 3 } } };
+let o: { a: N32, b: N32, c: N32 } = { a: 3, b: 2, c: 3 };
 let c: N32 = 3;
 let b: N32 = 2;
-let a: N32 = 1;
+let a: N32 = 3;
 > a + b + c
-6
+8
 
 let io: IO = #io;
-let x: { a: N32, b: N32, c: N32 };
-let y: { x: { a: N32, b: N32, c: N32 } };
-let z: { y: { x: { a: N32, b: N32, c: N32 } } };
-let o: { a: N32, b: N32, c: N32 };
+let x: { a: N32, b: N32, c: N32 } = { a: 1, b: 2, c: 3 };
+let y: { x: { a: N32, b: N32, c: N32 } } = { x: { a: 1, b: 2, c: 3 } };
+let z: { y: { x: { a: N32, b: N32, c: N32 } } } = { y: { x: { a: 3, b: 2, c: 3 } } };
+let o: { a: N32, b: N32, c: N32 } = { a: 3, b: 2, c: 3 };
 let c: N32 = 3;
 let b: N32 = 2;
-let a: N32 = 1;
+let a: N32 = 3;
 > x.p
 error input:1:3 - type `{ a: N32, b: N32, c: N32 }` has no field `p`
 
 let io: IO = #io;
-let x: { a: N32, b: N32, c: N32 };
-let y: { x: { a: N32, b: N32, c: N32 } };
-let z: { y: { x: { a: N32, b: N32, c: N32 } } };
-let o: { a: N32, b: N32, c: N32 };
+let x: { a: N32, b: N32, c: N32 } = { a: 1, b: 2, c: 3 };
+let y: { x: { a: N32, b: N32, c: N32 } } = { x: { a: 1, b: 2, c: 3 } };
+let z: { y: { x: { a: N32, b: N32, c: N32 } } } = { y: { x: { a: 3, b: 2, c: 3 } } };
+let o: { a: N32, b: N32, c: N32 } = { a: 3, b: 2, c: 3 };
 let c: N32 = 3;
 let b: N32 = 2;
-let a: N32 = 1;
+let a: N32 = 3;
 > do { let { p } = x }
-error input:1:18 - expected type `{ p: ?66 }`; found `{ a: N32, b: N32, c: N32 }`
-error input:1:12 - search limit reached when finding flex of type `?66`
-error input:1:5 - variable of type `{ a: N32, b: N32, c: N32 }` read whilst uninitialized
-error input:1:12 - cannot drop `?66`
+error input:1:18 - expected type `{ p: ?320 }`; found `{ a: N32, b: N32, c: N32 }`
+error input:1:12 - found several impls of trait `Fork[?1]`
+error input:1:12 - found several impls of trait `Drop[?1]`
+error input:1:12 - found several impls of trait `Fork[~?1]`
+error input:1:12 - found several impls of trait `Drop[~?1]`
+error input:1:12 - cannot drop `?320`
 
 let io: IO = #io;
-let x: { a: N32, b: N32, c: N32 };
-let y: { x: { a: N32, b: N32, c: N32 } };
-let z: { y: { x: { a: N32, b: N32, c: N32 } } };
-let o: { a: N32, b: N32, c: N32 };
+let x: { a: N32, b: N32, c: N32 } = { a: 1, b: 2, c: 3 };
+let y: { x: { a: N32, b: N32, c: N32 } } = { x: { a: 1, b: 2, c: 3 } };
+let z: { y: { x: { a: N32, b: N32, c: N32 } } } = { y: { x: { a: 3, b: 2, c: 3 } } };
+let o: { a: N32, b: N32, c: N32 } = { a: 3, b: 2, c: 3 };
 let c: N32 = 3;
 let b: N32 = 2;
-let a: N32 = 1;
+let a: N32 = 3;
 > z = { Y: y }
 error input:1:5 - expected type `{ y: { x: { a: N32, b: N32, c: N32 } } }`; found `{ Y: { x: { a: N32, b: N32, c: N32 } } }`
-error input:1:5 - variable of type `{ x: { a: N32, b: N32, c: N32 } }` read whilst uninitialized
 
 let io: IO = #io;
-let x: { a: N32, b: N32, c: N32 };
-let y: { x: { a: N32, b: N32, c: N32 } };
-let z: { y: { x: { a: N32, b: N32, c: N32 } } };
-let o: { a: N32, b: N32, c: N32 };
+let x: { a: N32, b: N32, c: N32 } = { a: 1, b: 2, c: 3 };
+let y: { x: { a: N32, b: N32, c: N32 } } = { x: { a: 1, b: 2, c: 3 } };
+let z: { y: { x: { a: N32, b: N32, c: N32 } } } = { y: { x: { a: 3, b: 2, c: 3 } } };
+let o: { a: N32, b: N32, c: N32 } = { a: 3, b: 2, c: 3 };
 let c: N32 = 3;
 let b: N32 = 2;
-let a: N32 = 1;
+let a: N32 = 3;
 > z = { y: 1 }
 error input:1:5 - expected type `{ y: { x: { a: N32, b: N32, c: N32 } } }`; found `{ y: N32 }`
 
 let io: IO = #io;
-let x: { a: N32, b: N32, c: N32 };
-let y: { x: { a: N32, b: N32, c: N32 } };
-let z: { y: { x: { a: N32, b: N32, c: N32 } } };
-let o: { a: N32, b: N32, c: N32 };
+let x: { a: N32, b: N32, c: N32 } = { a: 1, b: 2, c: 3 };
+let y: { x: { a: N32, b: N32, c: N32 } } = { x: { a: 1, b: 2, c: 3 } };
+let z: { y: { x: { a: N32, b: N32, c: N32 } } } = { y: { x: { a: 3, b: 2, c: 3 } } };
+let o: { a: N32, b: N32, c: N32 } = { a: 3, b: 2, c: 3 };
 let c: N32 = 3;
 let b: N32 = 2;
-let a: N32 = 1;
+let a: N32 = 3;

--- a/tests/snaps/vine/the_greatest_show/stats.txt
+++ b/tests/snaps/vine/the_greatest_show/stats.txt
@@ -1,17 +1,17 @@
 
 Interactions
-  Total               49_942
-    Depth              9_644
+  Total               50_193
+    Depth              9_648
     Breadth                5
-  Annihilate          23_892
+  Annihilate          24_045
   Commute                177
-  Copy                 5_442
-  Erase                7_038
-  Expand               3_669
-  Call                 6_946
-  Branch               2_778
+  Copy                 5_444
+  Erase                7_074
+  Expand               3_727
+  Call                 6_953
+  Branch               2_773
 
 Memory
-  Heap                79_072 B
-  Allocated        1_040_176 B
-  Freed            1_040_176 B
+  Heap                80_496 B
+  Allocated        1_045_392 B
+  Freed            1_045_392 B

--- a/vine/src/compiler.rs
+++ b/vine/src/compiler.rs
@@ -85,18 +85,20 @@ impl<'core> Compiler<'core> {
       self.templates.push_to(fragment_id, template);
     }
 
+    let mut nets = Nets::default();
+
     let mut specializer = Specializer {
+      core,
       chart,
       resolutions: &self.resolutions,
       fragments: &self.fragments,
       specs: &mut self.specs,
       vir: &self.vir,
+      nets: &mut nets,
     };
     specializer.specialize_since(checkpoint);
 
     core.bail()?;
-
-    let mut nets = Nets::default();
 
     if let Some(main) = self.resolutions.main {
       let path = self.fragments[main].path;
@@ -109,7 +111,9 @@ impl<'core> Compiler<'core> {
 
     for spec_id in self.specs.specs.keys_from(checkpoint.specs) {
       let spec = self.specs.specs[spec_id].as_ref().unwrap();
-      self.templates[spec.fragment].instantiate(&mut nets, &self.specs, spec);
+      if let Some(fragment_id) = spec.fragment {
+        self.templates[fragment_id].instantiate(&mut nets, &self.specs, spec);
+      }
     }
 
     Ok(nets)

--- a/vine/src/components/distiller.rs
+++ b/vine/src/components/distiller.rs
@@ -37,7 +37,7 @@ pub struct Distiller<'core, 'r> {
   pub(crate) def: DefId,
   pub(crate) generics: GenericsId,
   pub(crate) types: Types<'core>,
-  pub(crate) rels: Rels,
+  pub(crate) rels: Rels<'core>,
   pub(crate) locals: IdxVec<Local, TirLocal>,
 }
 

--- a/vine/src/components/emitter.rs
+++ b/vine/src/components/emitter.rs
@@ -6,6 +6,7 @@ use vine_util::idx::{Counter, IdxVec};
 use crate::{
   features::local::LocalEmissionState,
   structures::{
+    ast::Ident,
     chart::Chart,
     core::Core,
     resolutions::{ConstRelId, FnRelId},
@@ -251,5 +252,64 @@ impl<'core, 'a> Emitter<'core, 'a> {
   pub(crate) fn new_wire(&mut self) -> (Tree, Tree) {
     let label = format!("w{}", self.wires.next());
     (Tree::Var(label.clone()), Tree::Var(label))
+  }
+
+  pub(crate) fn composite_deconstruct(len: usize) -> Net {
+    Net {
+      root: if len == 1 {
+        Tree::n_ary(
+          "fn",
+          [
+            Tree::Erase,
+            Tree::Var("x".into()),
+            Tree::Comb("tup".into(), Box::new(Tree::Var("x".into())), Box::new(Tree::Erase)),
+          ],
+        )
+      } else {
+        Tree::n_ary("fn", [Tree::Erase, Tree::Var("x".into()), Tree::Var("x".into())])
+      },
+      pairs: vec![],
+    }
+  }
+
+  pub(crate) fn composite_reconstruct(len: usize) -> Net {
+    Net {
+      root: if len == 1 {
+        Tree::n_ary("fn", [Tree::Erase, Tree::Var("x".into()), Tree::Erase, Tree::Var("x".into())])
+      } else {
+        Tree::n_ary(
+          "fn",
+          [
+            Tree::Erase,
+            Tree::Var("x".into()),
+            Tree::Var("y".into()),
+            Tree::Comb(
+              "tup".into(),
+              Box::new(Tree::Var("x".into())),
+              Box::new(Tree::Var("y".into())),
+            ),
+          ],
+        )
+      },
+      pairs: vec![],
+    }
+  }
+
+  pub(crate) fn object_key(key: Ident<'core>) -> Net {
+    let str = key.0 .0;
+    Net {
+      root: Tree::n_ary(
+        "tup",
+        [
+          Tree::N32(str.chars().count() as u32),
+          Tree::n_ary(
+            "tup",
+            str.chars().map(|c| Tree::N32(c as u32)).chain([Tree::Var("x".into())]),
+          ),
+          Tree::Var("x".into()),
+        ],
+      ),
+      pairs: vec![],
+    }
   }
 }

--- a/vine/src/components/normalizer.rs
+++ b/vine/src/components/normalizer.rs
@@ -67,7 +67,7 @@ struct Normalizer<'core, 'a> {
   generics: GenericsId,
 
   types: Types<'core>,
-  rels: Rels,
+  rels: Rels<'core>,
   locals: IdxVec<Local, VirLocal>,
   interfaces: IdxVec<InterfaceId, Interface>,
   stages: IdxVec<StageId, Option<Stage>>,

--- a/vine/src/components/resolver.rs
+++ b/vine/src/components/resolver.rs
@@ -44,7 +44,7 @@ pub struct Resolver<'core, 'a> {
   pub(crate) targets: HashMap<Target<'core>, Vec<TargetInfo>>,
   pub(crate) target_id: Counter<TargetId>,
 
-  pub(crate) rels: Rels,
+  pub(crate) rels: Rels<'core>,
   pub(crate) closures: IdxVec<ClosureId, TirClosure>,
 }
 
@@ -309,7 +309,7 @@ impl<'core, 'a> Resolver<'core, 'a> {
     }
   }
 
-  pub(crate) fn resolve_impl_type(&mut self, impl_: &Impl<'core>, ty: &ImplType) -> TirImpl {
+  pub(crate) fn resolve_impl_type(&mut self, impl_: &Impl<'core>, ty: &ImplType) -> TirImpl<'core> {
     let span = impl_.span;
     match &*impl_.kind {
       ImplKind::Hole => self.find_impl(span, ty),
@@ -327,7 +327,7 @@ impl<'core, 'a> Resolver<'core, 'a> {
     }
   }
 
-  fn resolve_impl(&mut self, impl_: &Impl<'core>) -> (ImplType, TirImpl) {
+  fn resolve_impl(&mut self, impl_: &Impl<'core>) -> (ImplType, TirImpl<'core>) {
     let span = impl_.span;
     match &*impl_.kind {
       ImplKind::Path(path) => self.resolve_impl_path(path),
@@ -344,7 +344,7 @@ impl<'core, 'a> Resolver<'core, 'a> {
     Finder::new(self.core, self.chart, self.sigs, self.cur_def, self.cur_generics, span)
   }
 
-  pub(crate) fn find_impl(&mut self, span: Span, ty: &ImplType) -> TirImpl {
+  pub(crate) fn find_impl(&mut self, span: Span, ty: &ImplType) -> TirImpl<'core> {
     Finder::new(self.core, self.chart, self.sigs, self.cur_def, self.cur_generics, span)
       .find_impl(&mut self.types, ty)
   }

--- a/vine/src/features/builtin.rs
+++ b/vine/src/features/builtin.rs
@@ -40,6 +40,8 @@ pub enum Builtin {
   BoundInclusive,
   BoundExclusive,
   Advance,
+  Tuple,
+  Object,
 }
 
 impl<'core> VineParser<'core, '_> {
@@ -90,6 +92,8 @@ impl<'core> VineParser<'core, '_> {
       "BoundInclusive" => Builtin::BoundInclusive,
       "BoundExclusive" => Builtin::BoundExclusive,
       "advance" => Builtin::Advance,
+      "Tuple" => Builtin::Tuple,
+      "Object" => Builtin::Object,
       _ => Err(Diag::BadBuiltin { span })?,
     })
   }
@@ -129,6 +133,9 @@ pub struct Builtins {
   pub bound_unbounded: Option<StructId>,
 
   pub advance: Option<FnId>,
+
+  pub tuple: Option<TraitId>,
+  pub object: Option<TraitId>,
 }
 
 impl<'core> Charter<'core, '_> {
@@ -197,6 +204,8 @@ impl<'core> Charter<'core, '_> {
       Builtin::BoundExclusive => set(&mut builtins.bound_exclusive, struct_id),
       Builtin::BoundInclusive => set(&mut builtins.bound_inclusive, struct_id),
       Builtin::Advance => set(&mut builtins.advance, fn_id),
+      Builtin::Tuple => set(&mut builtins.tuple, trait_id),
+      Builtin::Object => set(&mut builtins.object, trait_id),
     }
   }
 }

--- a/vine/src/features/fn_.rs
+++ b/vine/src/features/fn_.rs
@@ -297,7 +297,7 @@ impl<'core> Resolver<'core, '_> {
     )
   }
 
-  pub(crate) fn resolve_impl_fn(&mut self, path: &Path<'core>) -> (ImplType, TirImpl) {
+  pub(crate) fn resolve_impl_fn(&mut self, path: &Path<'core>) -> (ImplType, TirImpl<'core>) {
     match self.resolve_path(self.cur_def, path, "fn", |d| d.fn_id()) {
       Ok(fn_id) => {
         let (type_params, impl_params) =

--- a/vine/src/features/generics.rs
+++ b/vine/src/features/generics.rs
@@ -218,7 +218,7 @@ impl<'core> Resolver<'core, '_> {
     path: &Path<'core>,
     params_id: GenericsId,
     inference: bool,
-  ) -> (Vec<Type>, Vec<TirImpl>) {
+  ) -> (Vec<Type>, Vec<TirImpl<'core>>) {
     self._resolve_generics(path.span, path.generics.as_ref(), params_id, inference, None)
   }
 
@@ -229,7 +229,7 @@ impl<'core> Resolver<'core, '_> {
     params_id: GenericsId,
     inference: bool,
     inferred_type_params: Option<Vec<Type>>,
-  ) -> (Vec<Type>, Vec<TirImpl>) {
+  ) -> (Vec<Type>, Vec<TirImpl<'core>>) {
     let _args = GenericArgs { span, types: Vec::new(), impls: Vec::new() };
     let args = args.unwrap_or(&_args);
     let params = &self.chart.generics[params_id];

--- a/vine/src/features/impl_.rs
+++ b/vine/src/features/impl_.rs
@@ -231,7 +231,7 @@ impl<'core> Resolver<'core, '_> {
     &mut self,
     path: &Path<'core>,
     id: ImplId,
-  ) -> (ImplType, TirImpl) {
+  ) -> (ImplType, TirImpl<'core>) {
     let (type_params, impl_params) =
       self.resolve_generics(path, self.chart.impls[id].generics, true);
     let ty = self.types.import(&self.sigs.impls[id], Some(&type_params)).ty;

--- a/vine/src/features/path.rs
+++ b/vine/src/features/path.rs
@@ -289,7 +289,7 @@ impl<'core> Resolver<'core, '_> {
     }
   }
 
-  pub(crate) fn resolve_impl_path(&mut self, path: &Path<'core>) -> (ImplType, TirImpl) {
+  pub(crate) fn resolve_impl_path(&mut self, path: &Path<'core>) -> (ImplType, TirImpl<'core>) {
     if let Some(ident) = path.as_ident() {
       if let Some(&i) = self.impl_param_lookup.get(&ident) {
         let ty = self.types.import_with(&self.sigs.generics[self.cur_generics], None, |t, sig| {

--- a/vine/src/structures/checkpoint.rs
+++ b/vine/src/structures/checkpoint.rs
@@ -210,6 +210,8 @@ impl Builtins {
       bound_inclusive,
       bound_unbounded,
       advance,
+      tuple,
+      object,
     } = self;
     revert_idx(prelude, checkpoint.defs);
     revert_idx(bool, checkpoint.opaque_types);
@@ -237,6 +239,8 @@ impl Builtins {
     revert_idx(bound_inclusive, checkpoint.structs);
     revert_idx(bound_unbounded, checkpoint.structs);
     revert_fn(advance, checkpoint);
+    revert_idx(tuple, checkpoint.traits);
+    revert_idx(object, checkpoint.traits);
   }
 }
 
@@ -277,10 +281,14 @@ impl Resolutions {
 
 impl<'core> Specializations<'core> {
   fn revert(&mut self, checkpoint: &Checkpoint) {
-    let Specializations { lookup, specs } = self;
+    let Specializations { lookup, specs, composite_deconstruct, composite_reconstruct, object_key } =
+      self;
     specs.truncate(checkpoint.specs.0);
     lookup.truncate(checkpoint.fragments.0);
     lookup.values_mut().for_each(|map| map.retain(|_, s| *s < checkpoint.specs));
+    composite_deconstruct.retain(|_, s| *s < checkpoint.specs);
+    composite_reconstruct.retain(|_, s| *s < checkpoint.specs);
+    object_key.retain(|_, s| *s < checkpoint.specs);
   }
 }
 

--- a/vine/src/structures/resolutions.rs
+++ b/vine/src/structures/resolutions.rs
@@ -38,24 +38,24 @@ pub struct Fragment<'core> {
 new_idx!(pub ConstRelId);
 new_idx!(pub FnRelId);
 #[derive(Debug, Clone, Default)]
-pub struct Rels {
-  pub consts: IdxVec<ConstRelId, (ConstId, Vec<TirImpl>)>,
-  pub fns: IdxVec<FnRelId, FnRel>,
+pub struct Rels<'core> {
+  pub consts: IdxVec<ConstRelId, (ConstId, Vec<TirImpl<'core>>)>,
+  pub fns: IdxVec<FnRelId, FnRel<'core>>,
 }
 
 #[derive(Debug, Clone)]
-pub enum FnRel {
-  Item(FnId, Vec<TirImpl>),
-  Impl(TirImpl),
+pub enum FnRel<'core> {
+  Item(FnId, Vec<TirImpl<'core>>),
+  Impl(TirImpl<'core>),
 }
 
-impl Rels {
-  pub fn fork_rel<'core>(&mut self, chart: &Chart<'core>, impl_: TirImpl) -> FnRelId {
+impl<'core> Rels<'core> {
+  pub fn fork_rel(&mut self, chart: &Chart<'core>, impl_: TirImpl<'core>) -> FnRelId {
     let fork = chart.builtins.fork.unwrap();
     self.fns.push(FnRel::Item(FnId::Abstract(fork, TraitFnId(0)), vec![impl_]))
   }
 
-  pub fn drop_rel<'core>(&mut self, chart: &Chart<'core>, impl_: TirImpl) -> FnRelId {
+  pub fn drop_rel(&mut self, chart: &Chart<'core>, impl_: TirImpl<'core>) -> FnRelId {
     let drop = chart.builtins.drop.unwrap();
     self.fns.push(FnRel::Item(FnId::Abstract(drop, TraitFnId(0)), vec![impl_]))
   }

--- a/vine/src/structures/specializations.rs
+++ b/vine/src/structures/specializations.rs
@@ -1,8 +1,12 @@
 use std::collections::HashMap;
 
-use vine_util::{idx::IdxVec, new_idx};
+use vine_util::{
+  idx::{IdxVec, IntMap},
+  new_idx,
+};
 
 use crate::structures::{
+  ast::Ident,
   chart::{FnId, ImplId},
   diag::ErrorGuaranteed,
   resolutions::{ConstRelId, FnRelId, FragmentId},
@@ -12,8 +16,12 @@ use crate::structures::{
 
 #[derive(Debug, Default)]
 pub struct Specializations<'core> {
-  pub lookup: IdxVec<FragmentId, HashMap<Vec<ImplTree>, SpecId>>,
+  pub lookup: IdxVec<FragmentId, HashMap<Vec<ImplTree<'core>>, SpecId>>,
   pub specs: IdxVec<SpecId, Option<Spec<'core>>>,
+
+  pub composite_deconstruct: IntMap<usize, SpecId>,
+  pub composite_reconstruct: IntMap<usize, SpecId>,
+  pub object_key: HashMap<Ident<'core>, SpecId>,
 }
 
 impl<'core> Specializations<'core> {
@@ -25,25 +33,33 @@ impl<'core> Specializations<'core> {
 new_idx!(pub SpecId);
 #[derive(Debug)]
 pub struct Spec<'core> {
-  pub fragment: FragmentId,
+  pub fragment: Option<FragmentId>,
   pub path: &'core str,
   pub index: usize,
   pub singular: bool,
   pub rels: SpecRels,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct SpecRels {
   pub fns: IdxVec<FnRelId, Result<(SpecId, StageId), ErrorGuaranteed>>,
   pub consts: IdxVec<ConstRelId, Result<SpecId, ErrorGuaranteed>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum ImplTree {
+pub enum ImplTree<'core> {
   Error(ErrorGuaranteed),
-  Def(ImplId, Vec<ImplTree>),
-  Fn(FnId, Vec<ImplTree>),
-  Closure(FragmentId, Vec<ImplTree>, ClosureId),
-  ForkClosure(FragmentId, Vec<ImplTree>, ClosureId),
-  DropClosure(FragmentId, Vec<ImplTree>, ClosureId),
+  Def(ImplId, Vec<ImplTree<'core>>),
+  Fn(FnId, Vec<ImplTree<'core>>),
+  Closure(FragmentId, Vec<ImplTree<'core>>, ClosureId),
+  ForkClosure(FragmentId, Vec<ImplTree<'core>>, ClosureId),
+  DropClosure(FragmentId, Vec<ImplTree<'core>>, ClosureId),
+  Tuple(usize),
+  Object(Ident<'core>, usize),
+}
+
+impl<'core> Spec<'core> {
+  pub fn synthetic(path: &'core str) -> Self {
+    Spec { fragment: None, path, index: 0, singular: true, rels: Default::default() }
+  }
 }

--- a/vine/src/structures/tir.rs
+++ b/vine/src/structures/tir.rs
@@ -3,7 +3,7 @@ use ivy::ast::Net;
 use vine_util::{idx::IdxVec, new_idx};
 
 use crate::structures::{
-  ast::{Flex, LogicalOp, Span},
+  ast::{Flex, Ident, LogicalOp, Span},
   chart::{EnumId, FnId, ImplId, StructId, VariantId},
   diag::ErrorGuaranteed,
   resolutions::{ConstRelId, FnRelId, Rels},
@@ -19,7 +19,7 @@ pub struct Tir<'core> {
   pub span: Span,
   pub types: Types<'core>,
   pub locals: IdxVec<Local, TirLocal>,
-  pub rels: Rels,
+  pub rels: Rels<'core>,
   pub closures: IdxVec<ClosureId, TirClosure>,
   pub root: TirExpr,
 }
@@ -166,14 +166,16 @@ pub enum TirPatKind {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum TirImpl {
+pub enum TirImpl<'core> {
   Error(ErrorGuaranteed),
   Param(usize),
-  Def(ImplId, Vec<TirImpl>),
-  Fn(FnId, Vec<TirImpl>),
+  Def(ImplId, Vec<TirImpl<'core>>),
+  Fn(FnId, Vec<TirImpl<'core>>),
   Closure(ClosureId),
   ForkClosure(ClosureId),
   DropClosure(ClosureId),
+  Tuple(usize),
+  Object(Ident<'core>, usize),
 }
 
 impl TirExpr {

--- a/vine/src/structures/vir.rs
+++ b/vine/src/structures/vir.rs
@@ -33,7 +33,7 @@ impl LayerId {
 pub struct Vir<'core> {
   pub types: Types<'core>,
   pub locals: IdxVec<Local, VirLocal>,
-  pub rels: Rels,
+  pub rels: Rels<'core>,
   pub layers: IdxVec<LayerId, Layer>,
   pub interfaces: IdxVec<InterfaceId, Interface>,
   pub stages: IdxVec<StageId, Stage>,
@@ -347,7 +347,7 @@ impl VirLocal {
     def: DefId,
     generics: GenericsId,
     types: &mut Types<'core>,
-    rels: &mut Rels,
+    rels: &mut Rels<'core>,
     span: Span,
     ty: Type,
   ) -> VirLocal {

--- a/vine/std/debug/Show.vi
+++ b/vine/std/debug/Show.vi
@@ -1,6 +1,7 @@
 
 use ops::Cast;
 use data::List as List_;
+use derive::{Object as Object_, Tuple as Tuple_};
 
 pub trait Show[T] {
   fn .show(self: &T) -> Show;
@@ -132,34 +133,54 @@ pub mod Show {
       }
     }
   }
-}
 
-pub impl show_nil: Show[()] {
-  fn show(&()) -> Show {
-    Show::Tuple([])
+  pub trait ShowTuple[T] {
+    fn .show_tuple(&self: &T) -> List_[Show];
   }
-}
 
-pub impl show_singleton[A; Show[A]]: Show[(A,)] {
-  fn show(&(a: A,)) -> Show {
-    Show::Tuple([a.show()])
+  pub impl tuple[T; ShowTuple[T]]: Show[T] {
+    fn show(&self: &T) -> Show {
+      Show::Tuple(self.show_tuple())
+    }
   }
-}
 
-pub impl show_pair[A, B; Show[A], Show[B]]: Show[(A, B)] {
-  fn show(&(a: A, b: B)) -> Show {
-    Show::Tuple([a.show(), b.show()])
+  pub mod ShowTuple {
+    pub impl nil: ShowTuple[()] {
+      fn show_tuple(&()) -> List_[Show] {
+        []
+      }
+    }
+
+    pub impl tuple[T, I, R; Tuple_[T, I, R], Show[I], ShowTuple[R]]: ShowTuple[T] {
+      fn show_tuple(&tuple: &T) -> List_[Show] {
+        let &(init, rest) = &tuple as &(I, R);
+        [init.show()] ++ rest.show_tuple()
+      }
+    }
   }
-}
 
-pub impl show_triple[A, B, C; Show[A], Show[B], Show[C]]: Show[(A, B, C)] {
-  fn show(&(a: A, b: B, c: C)) -> Show {
-    Show::Tuple([a.show(), b.show(), c.show()])
+  pub trait ShowObject[T] {
+    fn .show_object(&self: &T) -> List_[(Show, Show)];
   }
-}
 
-pub impl show_quad[A, B, C, D; Show[A], Show[B], Show[C], Show[D]]: Show[(A, B, C, D)] {
-  fn show(&(a: A, b: B, c: C, d: D)) -> Show {
-    Show::Tuple([a.show(), b.show(), c.show(), d.show()])
+  pub impl object[T; ShowObject[T]]: Show[T] {
+    fn show(&self: &T) -> Show {
+      Show::Object(self.show_object())
+    }
+  }
+
+  pub mod ShowObject {
+    pub impl nil: ShowObject[{}] {
+      fn show_object(&{}) -> List_[(Show, Show)] {
+        []
+      }
+    }
+
+    pub impl object[O, I, R; Object_[O, I, R], Show[I], ShowObject[R]]: ShowObject[O] {
+      fn show_object(&object: &O) -> List_[(Show, Show)] {
+        let &(init, rest) = &object as &(I, R);
+        [(Show::Literal(Object_::key), init.show())] ++ rest.show_object()
+      }
+    }
   }
 }

--- a/vine/std/derive.vi
+++ b/vine/std/derive.vi
@@ -1,0 +1,62 @@
+
+use ops::Cast;
+
+#[builtin = "Tuple"]
+pub trait Tuple[Tuple, Init, Rest] {
+  fn deconstruct(tuple: Tuple) -> (Init, Rest);
+  fn reconstruct(init: Init, rest: Rest) -> Tuple;
+}
+
+pub mod Tuple {
+  pub use Composite::{cast_deconstruct, cast_reconstruct};
+}
+
+#[builtin = "Object"]
+pub trait Object[Object, Init, Rest] {
+  const key: String;
+  fn deconstruct(object: Object) -> (Init, Rest);
+  fn reconstruct(init: Init, rest: Rest) -> Object;
+}
+
+pub mod Object {
+  pub use Composite::{cast_deconstruct, cast_reconstruct};
+}
+
+pub trait Composite[Composite, Init, Rest] {
+  fn deconstruct(composite: Composite) -> (Init, Rest);
+  fn reconstruct(init: Init, rest: Rest) -> Composite;
+}
+
+pub mod Composite {
+  pub impl tuple[C, I, R; Tuple[C, I, R]]: Composite[C, I, R] {
+    fn deconstruct(composite: C) -> (I, R) {
+      Tuple::deconstruct(composite)
+    }
+
+    fn reconstruct(init: I, rest: R) -> C {
+      Tuple::reconstruct(init, rest)
+    }
+  }
+
+  pub impl object[C, I, R; Object[C, I, R]]: Composite[C, I, R] {
+    fn deconstruct(composite: C) -> (I, R) {
+      Object::deconstruct(composite)
+    }
+
+    fn reconstruct(init: I, rest: R) -> C {
+      Object::reconstruct(init, rest)
+    }
+  }
+
+  pub impl cast_deconstruct[C, I, R; Composite[C, I, R]]: Cast[C, (I, R)] {
+    fn cast(composite: C) -> (I, R) {
+      Composite::deconstruct(composite)
+    }
+  }
+
+  pub impl cast_reconstruct[C, I, R; Composite[C, I, R]]: Cast[(I, R), C] {
+    fn cast((init: I, rest: R)) -> C {
+      Composite::reconstruct(init, rest)
+    }
+  }
+}

--- a/vine/std/ops/comparison.vi
+++ b/vine/std/ops/comparison.vi
@@ -1,4 +1,6 @@
 
+use derive::Tuple;
+
 pub trait Eq[T] {
   #[builtin = "eq"]
   fn .eq(a: &T, b: &T) -> Bool;
@@ -8,13 +10,37 @@ pub trait Eq[T] {
 }
 
 pub mod Eq {
-  pub impl pair[A, B; Eq[A], Eq[B]]: Eq[(A, B)] {
-    fn eq(&(a0: A, b0: B), &(a1: A, b1: B)) -> Bool {
-      a0 == a1 && b0 == b1
+  pub impl unary[T; Eq[T]]: Eq[(T,)] {
+    fn eq(&(a: T,), &(b: T,)) -> Bool {
+      a == b
     }
 
-    fn ne(&(a0: A, b0: B), &(a1: A, b1: B)) -> Bool {
-      a0 != a1 || b0 != b1
+    fn ne(&(a: T,), &(b: T,)) -> Bool {
+      a != b
+    }
+  }
+
+  pub impl tuple[T, I, R; Tuple[T, I, R], Eq[I], Eq[R]]: Eq[T] {
+    fn eq(&a: &T, &b: &T) -> Bool {
+      let &(ai, ar) = &a as &(I, R);
+      let &(bi, br) = &b as &(I, R);
+      ai == bi && ar == br
+    }
+
+    fn ne(&a: &T, &b: &T) -> Bool {
+      let &(ai, ar) = &a as &(I, R);
+      let &(bi, br) = &b as &(I, R);
+      ai != bi || ar != br
+    }
+  }
+
+  pub impl ref[T; Eq[T]]: Eq[&T] {
+    fn eq(&&a: &&T, &&b: &&T) -> Bool {
+      a == b
+    }
+
+    fn ne(&&a: &&T, &&b: &&T) -> Bool {
+      a != b
     }
   }
 }
@@ -32,21 +58,51 @@ pub enum Ord {
 }
 
 pub mod Ord {
-  pub impl pair[A, B; Ord[A], Ord[B]]: Ord[(A, B)] {
-    fn cmp(&(a0: A, b0: B), &(a1: A, b1: B)) -> Ord {
-      match a0.cmp(&a1) {
+  pub impl unary[T; Ord[T]]: Ord[(T,)] {
+    fn cmp(&(a: T,), &(b: T,)) -> Ord {
+      Ord::cmp(&a, &b)
+    }
+
+    fn lt(&(a: T,), &(b: T,)) -> Bool {
+      a < b
+    }
+
+    fn le(&(a: T,), &(b: T,)) -> Bool {
+      a <= b
+    }
+  }
+
+  pub impl tuple[T, I, R; Tuple[T, I, R], Ord[I], Ord[R]]: Ord[T] {
+    fn cmp(&a: &T, &b: &T) -> Ord {
+      let &(ai, ar) = &a as &(I, R);
+      let &(bi, br) = &b as &(I, R);
+      match ai.cmp(&bi) {
         Ord::Lt { Ord::Lt }
         Ord::Gt { Ord::Gt }
-        Ord::Eq { b0.cmp(&b1) }
+        Ord::Eq { ar.cmp(&br) }
       }
     }
 
-    fn lt(x: &(A, B), y: &(A, B)) -> Bool {
-      Ord::lt_from_cmp(x, y)
+    fn lt(a: &T, b: &T) -> Bool {
+      Ord::lt_from_cmp(a, b)
     }
 
-    fn le(x: &(A, B), y: &(A, B)) -> Bool {
-      Ord::le_from_cmp(x, y)
+    fn le(a: &T, b: &T) -> Bool {
+      Ord::le_from_cmp(a, b)
+    }
+  }
+
+  pub impl ref[T; Ord[T]]: Ord[&T] {
+    fn cmp(&&a: &&T, &&b: &&T) -> Ord {
+      Ord::cmp(&a, &b)
+    }
+
+    fn lt(&&a: &&T, &&b: &&T) -> Bool {
+      a < b
+    }
+
+    fn le(&&a: &&T, &&b: &&T) -> Bool {
+      a <= b
     }
   }
 

--- a/vine/std/ops/flex.vi
+++ b/vine/std/ops/flex.vi
@@ -1,4 +1,6 @@
 
+use derive::Composite;
+
 #[builtin = "Fork"]
 pub trait Fork[T] {
   fn .fork(&self: &T) -> T;
@@ -17,35 +19,22 @@ pub mod Fork {
   }
 
   #[duplicate]
-  pub impl nil: Fork[()] {
+  pub impl tuple_nil: Fork[()] {
     fn fork(&()) -> () {}
   }
 
   #[duplicate]
-  pub impl unary[A+]: Fork[(A,)] {
-    fn fork(&(a: A,)) -> (A,) {
-      (a,)
+  pub impl object_nil: Fork[{}] {
+    fn fork(&{}) -> {} {
+      {}
     }
   }
 
   #[duplicate]
-  pub impl pair[A+, B+]: Fork[(A, B)] {
-    fn fork(&(a: A, b: B)) -> (A, B) {
-      (a, b)
-    }
-  }
-
-  #[duplicate]
-  pub impl triple[A+, B+, C+]: Fork[(A, B, C)] {
-    fn fork(&(a: A, b: B, c: C)) -> (A, B, C) {
-      (a, b, c)
-    }
-  }
-
-  #[duplicate]
-  pub impl quad[A+, B+, C+, D+]: Fork[(A, B, C, D)] {
-    fn fork(&(a: A, b: B, c: C, d: D)) -> (A, B, C, D) {
-      (a, b, c, d)
+  pub impl composite[C, I, R; Composite[C, I, R], Fork[I], Fork[R]]: Fork[C] {
+    fn fork(&composite: &C) -> C {
+      let &(init, rest) = &composite as &(I, R);
+      (init, rest) as C
     }
   }
 }
@@ -56,27 +45,19 @@ pub mod Drop {
   }
 
   #[erase]
-  pub impl nil: Drop[()] {
+  pub impl tuple_nil: Drop[()] {
     fn drop(()) {}
   }
 
   #[erase]
-  pub impl unary[A?]: Drop[(A,)] {
-    fn drop((_: A,)) {}
+  pub impl object_nil: Drop[{}] {
+    fn drop({}) {}
   }
 
   #[erase]
-  pub impl pair[A?, B?]: Drop[(A, B)] {
-    fn drop((_: A, _: B)) {}
-  }
-
-  #[erase]
-  pub impl triple[A?, B?, C?]: Drop[(A, B, C)] {
-    fn drop((_: A, _: B, _: C)) {}
-  }
-
-  #[erase]
-  pub impl quad[A?, B?, C?, D?]: Drop[(A, B, C, D)] {
-    fn drop((_: A, _: B, _: C, _: D)) {}
+  pub impl composite[C, I, R; Composite[C, I, R], Drop[I], Drop[R]]: Drop[C] {
+    fn drop(composite: C) {
+      (_, _) = composite as (I, R);
+    }
   }
 }

--- a/vine/std/std.vi
+++ b/vine/std/std.vi
@@ -1,6 +1,7 @@
 
 pub mod data = "./data/data.vi";
 pub mod debug = "./debug/debug.vi";
+pub mod derive = "./derive.vi";
 pub mod logical = "./logical/logical.vi";
 pub mod numeric = "./numeric/numeric.vi";
 pub mod rng = "./rng/rng.vi";


### PR DESCRIPTION
Implements the `Tuple` and `Object` traits from #169, allowing traits to be implemented for all tuple and object types, as well as a `Composite` trait that abstracts over `Tuple` and `Object` for things like `Fork` and `Drop` which do not need to differentiate between tuples and objects. These traits are now used for implementing `Fork`, `Drop`, `Show`, `Eq`, and `Ord`.