### PR TITLE
vine: remove use of `(expr; _)`

### DIFF
--- a/tests/programs/aoc_2024/day_12.vi
+++ b/tests/programs/aoc_2024/day_12.vi
@@ -113,7 +113,7 @@ mod Region {
 mod Regions {
   pub impl to_string: Cast[Regions, String] {
     fn cast(Regions(array)) -> String {
-      (array.as[List]; _).show() as String
+      array.as[List].show() as String
     }
   }
 

--- a/tests/programs/aoc_2024/day_19.vi
+++ b/tests/programs/aoc_2024/day_19.vi
@@ -9,7 +9,7 @@ pub fn main(&io: &IO) {
   let possible = 0;
   let ways = N64::zero;
   while io.read_line() is Some(design) {
-    let count = (match_counts(design, patterns); _).pop_back().unwrap();
+    let count = match_counts(design, patterns).pop_back().unwrap();
     if count != N64::zero {
       possible += 1;
       ways += count;

--- a/tests/programs/aoc_2024/day_24.vi
+++ b/tests/programs/aoc_2024/day_24.vi
@@ -6,7 +6,7 @@ pub fn main(&io: &IO) {
 
   while io.read_line() is Some(line) && line.len() != 0 {
     let (name, value) = line.split_once(": ");
-    let value = (value.unwrap(); _)!.get(0).unwrap() == '1';
+    let value = value.unwrap()!.get(0).unwrap() == '1';
     unsafe::erase(map.insert(name, Wire::input(value)));
   }
 

--- a/tests/programs/repl/misc.vi
+++ b/tests/programs/repl/misc.vi
@@ -7,7 +7,7 @@ fn _foo() {}
 ((1,2),(3,4)).0.0.as[String]
 ((1,2),(3,4)).1.1.as[String]
 "abc" ++ 123
-([true, false]; _).show().as[String]
+[true, false].show().as[String]
 [1,2,3,4].split_at(2)
 [1,2,3,4].split_at(0)
 [1,2,3,4].split_at(6)
@@ -18,9 +18,9 @@ List::empty[Bool].filter(fn* (&x) { x })
 let l = [+1,+2,-13,+4];
 l.find(fn* (&x: &I32) { x == +7 })
 *l.find(fn* (&x: &I32) { x < +0 }).unwrap() -= +5;
-l.contains(&(+1; _))
-l.contains(&(+4; _))
-l.contains(&(+7; _))
+l.contains(&+1)
+l.contains(&+4)
+l.contains(&+7)
 /clear l
 let a = Array::from_fn(5, do { let x = 0; (fn* () { let n = x; x += 1; n }) });
 a.for_each(fn* (v: N32) { io.println("{v}")})

--- a/tests/programs/repl/string_ops.vi
+++ b/tests/programs/repl/string_ops.vi
@@ -1,11 +1,11 @@
 let s = "hello world!";
 s.len()
-s.starts_with(&(""; _))
-s.starts_with(&("h"; _))
-s.starts_with(&("hello "; _))
-s.starts_with(&("world"; _))
-s.starts_with(&("held"; _))
-s.starts_with(&("hello world! hi"; _))
+s.starts_with(&"")
+s.starts_with(&"h")
+s.starts_with(&"hello ")
+s.starts_with(&"world")
+s.starts_with(&"held")
+s.starts_with(&"hello world! hi")
 "" == ""
 "" != ""
 "hello" == "hello"

--- a/tests/programs/specializations.vi
+++ b/tests/programs/specializations.vi
@@ -1,8 +1,8 @@
 
 pub fn main(&io: &IO) {
-  io.println("{([1, 2, 3, 4]; _).show()}");
-  io.println("{(["abc", "def", "ghi"]; _).show()}");
-  io.println("{(['x', 'y', 'z']; _).show()}");
-  io.println("{([true, false]; _).show()}");
-  io.println("{([(1, 'a'), (2, 'b')]; _).show()}");
+  io.println("{[1, 2, 3, 4].show()}");
+  io.println("{["abc", "def", "ghi"].show()}");
+  io.println("{['x', 'y', 'z'].show()}");
+  io.println("{[true, false].show()}");
+  io.println("{[(1, 'a'), (2, 'b')].show()}");
 }

--- a/tests/snaps/vine/repl/misc.repl.vi
+++ b/tests/snaps/vine/repl/misc.repl.vi
@@ -35,7 +35,7 @@ error input:1:1 - cannot find impl of trait `Concat[String, N32, ?86]`
 error input:1:1 - found several impls of trait `Drop[?83]`
 
 let io: IO = #io;
-> ([true, false]; _).show().as[String]
+> [true, false].show().as[String]
 "[true, false]"
 
 let io: IO = #io;
@@ -80,17 +80,17 @@ let l: List[I32] = [+1, +2, -13, +4];
 
 let io: IO = #io;
 let l: List[I32] = [+1, +2, -18, +4];
-> l.contains(&(+1; _))
+> l.contains(&+1)
 true
 
 let io: IO = #io;
 let l: List[I32] = [+1, +2, -18, +4];
-> l.contains(&(+4; _))
+> l.contains(&+4)
 true
 
 let io: IO = #io;
 let l: List[I32] = [+1, +2, -18, +4];
-> l.contains(&(+7; _))
+> l.contains(&+7)
 ::std::data::List::contains:0:s6
 
 let io: IO = #io;
@@ -281,14 +281,14 @@ error input:1:29 - expected type `{ a: N32, b: N32 }`; found `{ a: N32 }`
 
 let io: IO = #io;
 > do { let x; x = (x, x); }
-error input:1:17 - expected type `?1514`; found `(?1514, ?1514)`
+error input:1:17 - expected type `?1510`; found `(?1510, ?1510)`
 error input:1:10 - found several impls of trait `Fork[?1]`
 error input:1:10 - found several impls of trait `Drop[?1]`
 error input:1:10 - found several impls of trait `Fork[~?1]`
 error input:1:10 - found several impls of trait `Drop[~?1]`
-error input:1:10 - cannot drop `?1514`
-error input:1:10 - variable of type `?1514` read whilst uninitialized
-error input:1:10 - cannot fork `?1514`
+error input:1:10 - cannot drop `?1510`
+error input:1:10 - variable of type `?1510` read whilst uninitialized
+error input:1:10 - cannot fork `?1510`
 
 let io: IO = #io;
 > let (a: N32, b: N32);
@@ -332,17 +332,17 @@ error input:1:8 - found several impls of trait `Fork[?1]`
 error input:1:8 - found several impls of trait `Drop[?1]`
 error input:1:8 - found several impls of trait `Fork[~?1]`
 error input:1:8 - found several impls of trait `Drop[~?1]`
-error input:1:8 - found several impls of trait `Drop[?1628]`
+error input:1:8 - found several impls of trait `Drop[?1624]`
 error input:1:13 - found several impls of trait `Fork[?1]`
 error input:1:13 - found several impls of trait `Drop[?1]`
 error input:1:13 - found several impls of trait `Fork[~?1]`
 error input:1:13 - found several impls of trait `Drop[~?1]`
-error - found several impls of trait `Drop[?1628]`
+error - found several impls of trait `Drop[?1624]`
 error input:1:5 - found several impls of trait `Fork[?1]`
 error input:1:5 - found several impls of trait `Drop[?1]`
 error input:1:5 - found several impls of trait `Fork[~?1]`
 error input:1:5 - found several impls of trait `Drop[~?1]`
-error input:1:5 - variable of type `?1628` read whilst uninitialized
+error input:1:5 - variable of type `?1624` read whilst uninitialized
 
 let io: IO = #io;
 > Ok(true)?

--- a/tests/snaps/vine/repl/string_ops.repl.vi
+++ b/tests/snaps/vine/repl/string_ops.repl.vi
@@ -9,32 +9,32 @@ let s: String = "hello world!";
 
 let io: IO = #io;
 let s: String = "hello world!";
-> s.starts_with(&(""; _))
+> s.starts_with(&"")
 true
 
 let io: IO = #io;
 let s: String = "hello world!";
-> s.starts_with(&("h"; _))
+> s.starts_with(&"h")
 true
 
 let io: IO = #io;
 let s: String = "hello world!";
-> s.starts_with(&("hello "; _))
+> s.starts_with(&"hello ")
 true
 
 let io: IO = #io;
 let s: String = "hello world!";
-> s.starts_with(&("world"; _))
+> s.starts_with(&"world")
 false
 
 let io: IO = #io;
 let s: String = "hello world!";
-> s.starts_with(&("held"; _))
+> s.starts_with(&"held")
 false
 
 let io: IO = #io;
 let s: String = "hello world!";
-> s.starts_with(&("hello world! hi"; _))
+> s.starts_with(&"hello world! hi")
 false
 
 let io: IO = #io;


### PR DESCRIPTION
This was previously used to turn values into places, but as of #302 this now happens automatically.