### PR TITLE
vine: enum impl derivation

### DIFF
--- a/ivy/src/ast.rs
+++ b/ivy/src/ast.rs
@@ -28,6 +28,12 @@ pub struct Net {
   pub pairs: Vec<(Tree, Tree)>,
 }
 
+impl Net {
+  pub fn new(root: Tree) -> Self {
+    Net { root, pairs: Vec::new() }
+  }
+}
+
 #[derive(Debug, Default, Clone)]
 pub struct Nets(IndexMap<String, Net>);
 

--- a/lsp/tree-sitter-vine/grammar.js
+++ b/lsp/tree-sitter-vine/grammar.js
@@ -597,6 +597,7 @@ module.exports = grammar({
     _ty: $ =>
       choice(
         $.ty_hole,
+        $.ty_never,
         $.ty_paren,
         $.ty_fn,
         $.ty_tuple,
@@ -607,6 +608,7 @@ module.exports = grammar({
       ),
 
     ty_hole: $ => "_",
+    ty_never: $ => "!",
     ty_paren: $ => seq("(", $._ty, ")"),
     ty_fn: $ => seq("fn", $.path),
     ty_tuple: $ => tuple($._ty),

--- a/tests/programs/aoc_2024/day_12.vi
+++ b/tests/programs/aoc_2024/day_12.vi
@@ -87,17 +87,9 @@ enum Region {
 }
 
 mod Region {
-  pub impl show: Show[Region] {
-    fn show(&self: &Region) -> Show {
-      match self {
-        Region::Root(x) { Show::Constructor("Root", x.show()) }
-        Region::Child(x) { Show::Constructor("Child", x.show()) }
-      }
-    }
-  }
-
-  pub impl fork: Fork[Region] = unsafe::duplicate;
-  pub impl drop: Drop[Region] = unsafe::erase;
+  pub impl show: Show[Region];
+  pub impl fork: Fork[Region];
+  pub impl drop: Drop[Region];
 }
 
 mod Regions {

--- a/tests/programs/aoc_2024/day_18.vi
+++ b/tests/programs/aoc_2024/day_18.vi
@@ -103,23 +103,8 @@ enum Node {
 }
 
 mod Node {
-  pub impl fork: Fork[Node] {
-    fn fork(&self: &Node) -> Node {
-      match &self {
-        &Root(x) { Root(x) }
-        &Child(x) { Child(x) }
-      }
-    }
-  }
-
-  pub impl drop: Drop[Node] {
-    fn drop(self: Node) {
-      match self {
-        Root(_) {}
-        Child(_) {}
-      }
-    }
-  }
+  pub impl fork: Fork[Node];
+  pub impl drop: Drop[Node];
 }
 
 mod DisjointSet {

--- a/tests/programs/brainfuck.vi
+++ b/tests/programs/brainfuck.vi
@@ -93,11 +93,4 @@ pub fn main(&io: &IO) {
   io.flush();
 }
 
-impl drop: Drop[Instruction] {
-  fn drop(self: Instruction) {
-    match self {
-      Loop(_) {}
-      _ {}
-    }
-  }
-}
+impl drop: Drop[Instruction];

--- a/tests/programs/centimanes.vi
+++ b/tests/programs/centimanes.vi
@@ -35,23 +35,6 @@ pub fn main(&io: &IO) {
 }
 
 mod Centimanes {
-  pub impl fork: Fork[Centimanes] {
-    fn fork(&self: &Centimanes) -> Centimanes {
-      match &self {
-        &Gyges { Gyges }
-        &Cottus { Cottus }
-        &Briareus { Briareus }
-      }
-    }
-  }
-
-  pub impl drop: Drop[Centimanes] {
-    fn drop(self: Centimanes) {
-      match self {
-        Gyges {}
-        Cottus {}
-        Briareus {}
-      }
-    }
-  }
+  pub impl fork: Fork[Centimanes];
+  pub impl drop: Drop[Centimanes];
 }

--- a/tests/snaps/vine/aoc_2024/day_18/stats.txt
+++ b/tests/snaps/vine/aoc_2024/day_18/stats.txt
@@ -1,17 +1,17 @@
 
 Interactions
-  Total              148_573
+  Total              147_625
     Depth             17_612
     Breadth                8
-  Annihilate          66_868
-  Commute                396
-  Copy                20_143
-  Erase               18_314
-  Expand              11_166
-  Call                22_105
-  Branch               9_581
+  Annihilate          66_517
+  Commute                540
+  Copy                20_042
+  Erase               18_114
+  Expand              11_066
+  Call                21_863
+  Branch               9_483
 
 Memory
-  Heap                35_616 B
-  Allocated        3_008_240 B
-  Freed            3_008_240 B
+  Heap                37_152 B
+  Allocated        2_994_560 B
+  Freed            2_994_560 B

--- a/tests/snaps/vine/brainfuck/stats.txt
+++ b/tests/snaps/vine/brainfuck/stats.txt
@@ -1,17 +1,17 @@
 
 Interactions
-  Total                8_475
-    Depth              2_983
+  Total                8_250
+    Depth              2_965
     Breadth                2
-  Annihilate           5_351
+  Annihilate           5_173
   Commute                  0
-  Copy                   480
-  Erase                1_200
-  Expand                 586
-  Call                   561
-  Branch                 297
+  Copy                   538
+  Erase                1_164
+  Expand                 550
+  Call                   540
+  Branch                 285
 
 Memory
-  Heap                 4_288 B
-  Allocated          192_960 B
-  Freed              192_960 B
+  Heap                 3_904 B
+  Allocated          187_664 B
+  Freed              187_664 B

--- a/tests/snaps/vine/centimanes/stats.txt
+++ b/tests/snaps/vine/centimanes/stats.txt
@@ -1,17 +1,17 @@
 
 Interactions
-  Total               22_218
-    Depth              7_441
-    Breadth                2
-  Annihilate          11_757
-  Commute                  0
-  Copy                 1_677
-  Erase                3_403
-  Expand               2_173
-  Call                 2_355
-  Branch                 853
+  Total               17_899
+    Depth              4_838
+    Breadth                3
+  Annihilate           8_846
+  Commute                900
+  Copy                 2_079
+  Erase                2_199
+  Expand               1_269
+  Call                 1_954
+  Branch                 652
 
 Memory
-  Heap                31_552 B
-  Allocated          454_672 B
-  Freed              454_672 B
+  Heap                50_272 B
+  Allocated          387_120 B
+  Freed              387_120 B

--- a/tests/snaps/vine/fail/atypical.txt
+++ b/tests/snaps/vine/fail/atypical.txt
@@ -35,38 +35,24 @@ error tests/programs/fail/atypical.vi:31:3 - invalid break target
 error tests/programs/fail/atypical.vi:32:14 - invalid continue target
 error tests/programs/fail/atypical.vi:33:3 - expected type `()`; found `N32`
 error - main cannot be generic
-error tests/programs/fail/atypical.vi:4:8 - found several impls of trait `Fork[?1]`
-error tests/programs/fail/atypical.vi:4:8 - found several impls of trait `Drop[?1]`
-error tests/programs/fail/atypical.vi:4:8 - found several impls of trait `Fork[~?1]`
-error tests/programs/fail/atypical.vi:4:8 - found several impls of trait `Drop[~?1]`
+error tests/programs/fail/atypical.vi:4:8 - search limit reached when finding flex of type `?0`
+error tests/programs/fail/atypical.vi:4:11 - search limit reached when finding flex of type `(?1, ??, ??)`
 error tests/programs/fail/atypical.vi:4:8 - cannot drop `?0`
 error tests/programs/fail/atypical.vi:4:11 - cannot drop `(?1, ??, ??)`
-error tests/programs/fail/atypical.vi:12:3 - found several impls of trait `Drop[?29]`
-error tests/programs/fail/atypical.vi:13:14 - found several impls of trait `Drop[?33]`
+error tests/programs/fail/atypical.vi:12:3 - search limit reached when finding impl of trait `Drop[?29]`
+error tests/programs/fail/atypical.vi:13:14 - search limit reached when finding impl of trait `Drop[?33]`
 error tests/programs/fail/atypical.vi:14:3 - cannot find impl of trait `Drop[??]`
 error tests/programs/fail/atypical.vi:16:3 - cannot find impl of trait `Drop[??]`
 error tests/programs/fail/atypical.vi:17:3 - cannot find impl of trait `Drop[??]`
 error tests/programs/fail/atypical.vi:22:7 - expected a complete pattern
-error tests/programs/fail/atypical.vi:23:4 - found several impls of trait `Drop[?72]`
-error tests/programs/fail/atypical.vi:28:14 - found several impls of trait `Drop[?82]`
+error tests/programs/fail/atypical.vi:23:4 - search limit reached when finding impl of trait `Drop[?72]`
+error tests/programs/fail/atypical.vi:28:14 - search limit reached when finding impl of trait `Drop[?82]`
 error tests/programs/fail/atypical.vi:30:3 - cannot find impl of trait `Drop[??]`
 error tests/programs/fail/atypical.vi:32:3 - cannot find impl of trait `Drop[??]`
-error tests/programs/fail/atypical.vi:10:8 - found several impls of trait `Fork[?2]`
-error tests/programs/fail/atypical.vi:10:8 - found several impls of trait `Drop[?2]`
-error tests/programs/fail/atypical.vi:10:8 - found several impls of trait `Fork[~?2]`
-error tests/programs/fail/atypical.vi:10:8 - found several impls of trait `Drop[~?2]`
-error tests/programs/fail/atypical.vi:10:11 - found several impls of trait `Fork[?2]`
-error tests/programs/fail/atypical.vi:10:11 - found several impls of trait `Drop[?2]`
-error tests/programs/fail/atypical.vi:10:11 - found several impls of trait `Fork[~?2]`
-error tests/programs/fail/atypical.vi:10:11 - found several impls of trait `Drop[~?2]`
-error tests/programs/fail/atypical.vi:18:14 - found several impls of trait `Fork[?2]`
-error tests/programs/fail/atypical.vi:18:14 - found several impls of trait `Drop[?2]`
-error tests/programs/fail/atypical.vi:18:14 - found several impls of trait `Fork[~?2]`
-error tests/programs/fail/atypical.vi:18:14 - found several impls of trait `Drop[~?2]`
-error tests/programs/fail/atypical.vi:24:8 - found several impls of trait `Fork[?2]`
-error tests/programs/fail/atypical.vi:24:8 - found several impls of trait `Drop[?2]`
-error tests/programs/fail/atypical.vi:24:8 - found several impls of trait `Fork[~?2]`
-error tests/programs/fail/atypical.vi:24:8 - found several impls of trait `Drop[~?2]`
+error tests/programs/fail/atypical.vi:10:8 - search limit reached when finding flex of type `?19`
+error tests/programs/fail/atypical.vi:10:11 - search limit reached when finding flex of type `?20`
+error tests/programs/fail/atypical.vi:18:14 - search limit reached when finding flex of type `?53`
+error tests/programs/fail/atypical.vi:24:8 - search limit reached when finding flex of type `?76`
 error tests/programs/fail/atypical.vi:6:1 - unconditional infinite loops are invalid
 error tests/programs/fail/atypical.vi:6:19 - cannot drop `IO`
 error tests/programs/fail/atypical.vi:10:8 - cannot drop `?19`

--- a/tests/snaps/vine/fail/informal.txt
+++ b/tests/snaps/vine/fail/informal.txt
@@ -3,15 +3,15 @@ error tests/programs/fail/informal.vi:7:3 - cannot find impl of trait `Add[?13, 
 error tests/programs/fail/informal.vi:9:15 - expected type `IO`; found `&?0`
 error tests/programs/fail/informal.vi:4:13 - `*` is only valid in a place pattern
 error tests/programs/fail/informal.vi:5:3 - expected a space expression; found a value expression
-error tests/programs/fail/informal.vi:6:8 - found several impls of trait `Drop[~?11]`
+error tests/programs/fail/informal.vi:6:8 - search limit reached when finding impl of trait `Drop[~?11]`
 error tests/programs/fail/informal.vi:6:8 - expected a value expression; found a space expression
-error tests/programs/fail/informal.vi:6:4 - found several impls of trait `Drop[?11]`
+error tests/programs/fail/informal.vi:6:4 - search limit reached when finding impl of trait `Drop[?11]`
 error tests/programs/fail/informal.vi:6:4 - expected a value expression; found a space expression
 error tests/programs/fail/informal.vi:7:9 - expected a space expression; found a value expression
-error tests/programs/fail/informal.vi:7:3 - found several impls of trait `Drop[?13]`
-error tests/programs/fail/informal.vi:7:3 - found several impls of trait `Drop[~?13]`
-error tests/programs/fail/informal.vi:8:15 - found several impls of trait `Drop[?17]`
-error tests/programs/fail/informal.vi:8:15 - found several impls of trait `Drop[~?17]`
+error tests/programs/fail/informal.vi:7:3 - search limit reached when finding impl of trait `Drop[?13]`
+error tests/programs/fail/informal.vi:7:3 - search limit reached when finding impl of trait `Drop[~?13]`
+error tests/programs/fail/informal.vi:8:15 - search limit reached when finding impl of trait `Drop[?17]`
+error tests/programs/fail/informal.vi:8:15 - search limit reached when finding impl of trait `Drop[~?17]`
 error tests/programs/fail/informal.vi:8:14 - expected a space expression; found a value expression
 error tests/programs/fail/informal.vi:8:8 - `&` is invalid in a space pattern
 error tests/programs/fail/informal.vi:9:7 - expected a complete pattern

--- a/tests/snaps/vine/fail/is_not.txt
+++ b/tests/snaps/vine/fail/is_not.txt
@@ -8,42 +8,15 @@ error tests/programs/fail/is_not.vi:5:3 - missing else block
 error tests/programs/fail/is_not.vi:7:3 - cannot find `y` in `::is_not::main`
 error tests/programs/fail/is_not.vi:4:3 - cannot find impl of trait `Drop[??]`
 error tests/programs/fail/is_not.vi:5:3 - cannot find impl of trait `Drop[(??, ??)]`
-error tests/programs/fail/is_not.vi:2:13 - found several impls of trait `Fork[?2]`
-error tests/programs/fail/is_not.vi:2:13 - found several impls of trait `Drop[?2]`
-error tests/programs/fail/is_not.vi:2:13 - found several impls of trait `Fork[~?2]`
-error tests/programs/fail/is_not.vi:2:13 - found several impls of trait `Drop[~?2]`
-error tests/programs/fail/is_not.vi:3:11 - found several impls of trait `Fork[?2]`
-error tests/programs/fail/is_not.vi:3:11 - found several impls of trait `Drop[?2]`
-error tests/programs/fail/is_not.vi:3:11 - found several impls of trait `Fork[~?2]`
-error tests/programs/fail/is_not.vi:3:11 - found several impls of trait `Drop[~?2]`
-error tests/programs/fail/is_not.vi:4:13 - found several impls of trait `Fork[?2]`
-error tests/programs/fail/is_not.vi:4:13 - found several impls of trait `Drop[?2]`
-error tests/programs/fail/is_not.vi:4:13 - found several impls of trait `Fork[~?2]`
-error tests/programs/fail/is_not.vi:4:13 - found several impls of trait `Drop[~?2]`
-error tests/programs/fail/is_not.vi:5:11 - found several impls of trait `Fork[?2]`
-error tests/programs/fail/is_not.vi:5:11 - found several impls of trait `Drop[?2]`
-error tests/programs/fail/is_not.vi:5:11 - found several impls of trait `Fork[~?2]`
-error tests/programs/fail/is_not.vi:5:11 - found several impls of trait `Drop[~?2]`
-error tests/programs/fail/is_not.vi:6:14 - found several impls of trait `Fork[?2]`
-error tests/programs/fail/is_not.vi:6:14 - found several impls of trait `Drop[?2]`
-error tests/programs/fail/is_not.vi:6:14 - found several impls of trait `Fork[~?2]`
-error tests/programs/fail/is_not.vi:6:14 - found several impls of trait `Drop[~?2]`
-error tests/programs/fail/is_not.vi:3:3 - found several impls of trait `Fork[?2]`
-error tests/programs/fail/is_not.vi:3:3 - found several impls of trait `Drop[?2]`
-error tests/programs/fail/is_not.vi:3:3 - found several impls of trait `Fork[~?2]`
-error tests/programs/fail/is_not.vi:3:3 - found several impls of trait `Drop[~?2]`
-error tests/programs/fail/is_not.vi:4:3 - found several impls of trait `Fork[?2]`
-error tests/programs/fail/is_not.vi:4:3 - found several impls of trait `Drop[?2]`
-error tests/programs/fail/is_not.vi:4:3 - found several impls of trait `Fork[~?2]`
-error tests/programs/fail/is_not.vi:4:3 - found several impls of trait `Drop[~?2]`
-error tests/programs/fail/is_not.vi:5:3 - found several impls of trait `Fork[?2]`
-error tests/programs/fail/is_not.vi:5:3 - found several impls of trait `Drop[?2]`
-error tests/programs/fail/is_not.vi:5:3 - found several impls of trait `Fork[~?2]`
-error tests/programs/fail/is_not.vi:5:3 - found several impls of trait `Drop[~?2]`
-error tests/programs/fail/is_not.vi:6:3 - found several impls of trait `Fork[?2]`
-error tests/programs/fail/is_not.vi:6:3 - found several impls of trait `Drop[?2]`
-error tests/programs/fail/is_not.vi:6:3 - found several impls of trait `Fork[~?2]`
-error tests/programs/fail/is_not.vi:6:3 - found several impls of trait `Drop[~?2]`
+error tests/programs/fail/is_not.vi:2:13 - search limit reached when finding flex of type `?0`
+error tests/programs/fail/is_not.vi:3:11 - search limit reached when finding flex of type `?0`
+error tests/programs/fail/is_not.vi:4:13 - search limit reached when finding flex of type `?0`
+error tests/programs/fail/is_not.vi:5:11 - search limit reached when finding flex of type `?0`
+error tests/programs/fail/is_not.vi:6:14 - search limit reached when finding flex of type `?0`
+error tests/programs/fail/is_not.vi:3:3 - search limit reached when finding flex of type `?0`
+error tests/programs/fail/is_not.vi:4:3 - search limit reached when finding flex of type `?0`
+error tests/programs/fail/is_not.vi:5:3 - search limit reached when finding flex of type `?0`
+error tests/programs/fail/is_not.vi:6:3 - search limit reached when finding flex of type `?0`
 error tests/programs/fail/is_not.vi:2:1 - unconditional infinite loops are invalid
 error tests/programs/fail/is_not.vi:2:13 - cannot fork `?0`
 error tests/programs/fail/is_not.vi:3:11 - cannot drop `?0`

--- a/tests/snaps/vine/primenesses/stats.txt
+++ b/tests/snaps/vine/primenesses/stats.txt
@@ -1,17 +1,17 @@
 
 Interactions
-  Total                7_914
+  Total                8_065
     Depth              2_249
     Breadth                3
-  Annihilate           3_690
+  Annihilate           3_767
   Commute                 51
-  Copy                   868
-  Erase                1_104
-  Expand                 619
-  Call                 1_117
-  Branch                 465
+  Copy                   872
+  Erase                1_132
+  Expand                 641
+  Call                 1_130
+  Branch                 472
 
 Memory
   Heap                11_376 B
-  Allocated          163_568 B
-  Freed              163_568 B
+  Allocated          166_416 B
+  Freed              166_416 B

--- a/tests/snaps/vine/repl/misc.repl.vi
+++ b/tests/snaps/vine/repl/misc.repl.vi
@@ -32,7 +32,7 @@ let io: IO = #io;
 let io: IO = #io;
 > "abc" ++ 123
 error input:1:1 - cannot find impl of trait `Concat[String, N32, ?86]`
-error input:1:1 - found several impls of trait `Drop[?83]`
+error input:1:1 - search limit reached when finding impl of trait `Drop[?83]`
 
 let io: IO = #io;
 > [true, false].show().as[String]
@@ -282,10 +282,7 @@ error input:1:29 - expected type `{ a: N32, b: N32 }`; found `{ a: N32 }`
 let io: IO = #io;
 > do { let x; x = (x, x); }
 error input:1:17 - expected type `?1510`; found `(?1510, ?1510)`
-error input:1:10 - found several impls of trait `Fork[?1]`
-error input:1:10 - found several impls of trait `Drop[?1]`
-error input:1:10 - found several impls of trait `Fork[~?1]`
-error input:1:10 - found several impls of trait `Drop[~?1]`
+error input:1:10 - search limit reached when finding flex of type `?1510`
 error input:1:10 - cannot drop `?1510`
 error input:1:10 - variable of type `?1510` read whilst uninitialized
 error input:1:10 - cannot fork `?1510`
@@ -328,20 +325,11 @@ let y: { a: ~N32, b: ~N32 };
 let io: IO = #io;
 > let x; x.a; x.a
 error input:1:5 - cannot infer type
-error input:1:8 - found several impls of trait `Fork[?1]`
-error input:1:8 - found several impls of trait `Drop[?1]`
-error input:1:8 - found several impls of trait `Fork[~?1]`
-error input:1:8 - found several impls of trait `Drop[~?1]`
-error input:1:8 - found several impls of trait `Drop[?1624]`
-error input:1:13 - found several impls of trait `Fork[?1]`
-error input:1:13 - found several impls of trait `Drop[?1]`
-error input:1:13 - found several impls of trait `Fork[~?1]`
-error input:1:13 - found several impls of trait `Drop[~?1]`
-error - found several impls of trait `Drop[?1624]`
-error input:1:5 - found several impls of trait `Fork[?1]`
-error input:1:5 - found several impls of trait `Drop[?1]`
-error input:1:5 - found several impls of trait `Fork[~?1]`
-error input:1:5 - found several impls of trait `Drop[~?1]`
+error input:1:8 - search limit reached when finding flex of type `?1624`
+error input:1:8 - search limit reached when finding impl of trait `Drop[?1624]`
+error input:1:13 - search limit reached when finding flex of type `?1624`
+error - search limit reached when finding impl of trait `Drop[?1624]`
+error input:1:5 - search limit reached when finding flex of type `?1624`
 error input:1:5 - variable of type `?1624` read whilst uninitialized
 
 let io: IO = #io;
@@ -351,16 +339,9 @@ error input:1:1 - no function to return from
 let io: IO = #io;
 > fn foo() -> N32 { Ok(123)? }
 error input:1:19 - cannot try `Result[N32, ?2]` in a function returning `N32`
-error input:1:19 - found several impls of trait `Fork[?0]`
-error input:1:19 - found several impls of trait `Drop[?0]`
-error input:1:19 - found several impls of trait `Fork[~?0]`
-error input:1:19 - found several impls of trait `Drop[~?0]`
-error input:1:19 - found several impls of trait `Fork[Result[N32, ?2]]`
-error input:1:19 - found several impls of trait `Drop[Result[N32, ?2]]`
-error input:1:19 - found several impls of trait `Fork[?0]`
-error input:1:19 - found several impls of trait `Drop[?0]`
-error input:1:19 - found several impls of trait `Fork[~?0]`
-error input:1:19 - found several impls of trait `Drop[~?0]`
+error input:1:19 - search limit reached when finding flex of type `?2`
+error input:1:19 - search limit reached when finding flex of type `Result[N32, ?2]`
+error input:1:19 - search limit reached when finding flex of type `?2`
 
 let io: IO = #io;
 > fn foo() -> Result[N32, String] { Ok(123)? }

--- a/tests/snaps/vine/repl/objects.repl.vi
+++ b/tests/snaps/vine/repl/objects.repl.vi
@@ -79,10 +79,7 @@ let b: N32 = 2;
 let a: N32 = 3;
 > do { let { p } = x }
 error input:1:18 - expected type `{ p: ?320 }`; found `{ a: N32, b: N32, c: N32 }`
-error input:1:12 - found several impls of trait `Fork[?1]`
-error input:1:12 - found several impls of trait `Drop[?1]`
-error input:1:12 - found several impls of trait `Fork[~?1]`
-error input:1:12 - found several impls of trait `Drop[~?1]`
+error input:1:12 - search limit reached when finding flex of type `?320`
 error input:1:12 - cannot drop `?320`
 
 let io: IO = #io;

--- a/tests/snaps/vine/the_greatest_show/stats.txt
+++ b/tests/snaps/vine/the_greatest_show/stats.txt
@@ -1,17 +1,17 @@
 
 Interactions
-  Total               50_386
+  Total               50_525
     Depth              9_680
     Breadth                5
-  Annihilate          24_132
+  Annihilate          24_195
   Commute                177
-  Copy                 5_457
-  Erase                7_121
-  Expand               3_751
-  Call                 6_969
-  Branch               2_779
+  Copy                 5_464
+  Erase                7_158
+  Expand               3_772
+  Call                 6_976
+  Branch               2_783
 
 Memory
   Heap                80_640 B
-  Allocated        1_048_832 B
-  Freed            1_048_832 B
+  Allocated        1_051_136 B
+  Freed            1_051_136 B

--- a/util/src/idx.rs
+++ b/util/src/idx.rs
@@ -162,8 +162,8 @@ impl<I: Idx, T> IdxVec<I, T> {
   }
 
   #[inline(always)]
-  pub fn keys(&self) -> impl Iterator<Item = I> + Clone {
-    (0..self.vec.len()).map(I::from)
+  pub fn keys(&self) -> RangeIter<I> {
+    (I::from(0)..I::from(self.vec.len())).iter()
   }
 
   #[inline(always)]
@@ -172,17 +172,17 @@ impl<I: Idx, T> IdxVec<I, T> {
   }
 
   #[inline(always)]
-  pub fn into_values(self) -> impl Iterator<Item = T> {
+  pub fn into_values(self) -> vec::IntoIter<T> {
     self.vec.into_iter()
   }
 
   #[inline(always)]
-  pub fn values(&self) -> impl Iterator<Item = &T> {
+  pub fn values(&self) -> slice::Iter<'_, T> {
     self.vec.iter()
   }
 
   #[inline(always)]
-  pub fn values_mut(&mut self) -> impl Iterator<Item = &mut T> {
+  pub fn values_mut(&mut self) -> slice::IterMut<'_, T> {
     self.vec.iter_mut()
   }
 

--- a/vine/src/compiler.rs
+++ b/vine/src/compiler.rs
@@ -117,7 +117,7 @@ impl<'core> Compiler<'core> {
           self.templates[*fragment_id].instantiate(&mut nets, &self.specs, spec);
         }
         SpecKind::Synthetic(item) => {
-          synthesize(&mut nets, &self.chart, spec, *item);
+          synthesize(&mut nets, &self.chart, &self.specs, spec, *item);
         }
       }
     }

--- a/vine/src/compiler.rs
+++ b/vine/src/compiler.rs
@@ -4,7 +4,7 @@ use vine_util::idx::IdxVec;
 use crate::{
   components::{
     analyzer::analyze, charter::Charter, distiller::Distiller, emitter::emit, loader::Loader,
-    normalizer::normalize, resolver::Resolver, specializer::Specializer,
+    normalizer::normalize, resolver::Resolver, specializer::Specializer, synthesizer::synthesize,
   },
   structures::{
     chart::Chart,
@@ -13,7 +13,7 @@ use crate::{
     diag::Diag,
     resolutions::{Fragment, FragmentId, Resolutions},
     signatures::Signatures,
-    specializations::Specializations,
+    specializations::{SpecKind, Specializations},
     template::Template,
     tir::ClosureId,
     vir::{InterfaceKind, Vir},
@@ -112,8 +112,13 @@ impl<'core> Compiler<'core> {
 
     for spec_id in self.specs.specs.keys_from(checkpoint.specs) {
       let spec = self.specs.specs[spec_id].as_ref().unwrap();
-      if let Some(fragment_id) = spec.fragment {
-        self.templates[fragment_id].instantiate(&mut nets, &self.specs, spec);
+      match &spec.kind {
+        SpecKind::Fragment(fragment_id) => {
+          self.templates[*fragment_id].instantiate(&mut nets, &self.specs, spec);
+        }
+        SpecKind::Synthetic(item) => {
+          synthesize(&mut nets, &self.chart, spec, *item);
+        }
       }
     }
 

--- a/vine/src/components.rs
+++ b/vine/src/components.rs
@@ -10,3 +10,4 @@ pub mod normalizer;
 pub mod parser;
 pub mod resolver;
 pub mod specializer;
+pub mod synthesizer;

--- a/vine/src/components/emitter.rs
+++ b/vine/src/components/emitter.rs
@@ -6,7 +6,6 @@ use vine_util::idx::{Counter, IdxVec};
 use crate::{
   features::local::LocalEmissionState,
   structures::{
-    ast::Ident,
     chart::Chart,
     core::Core,
     resolutions::{ConstRelId, FnRelId},
@@ -252,71 +251,5 @@ impl<'core, 'a> Emitter<'core, 'a> {
   pub(crate) fn new_wire(&mut self) -> (Tree, Tree) {
     let label = format!("w{}", self.wires.next());
     (Tree::Var(label.clone()), Tree::Var(label))
-  }
-
-  pub(crate) fn composite_deconstruct(len: usize) -> Net {
-    Net {
-      root: if len == 1 {
-        Tree::n_ary(
-          "fn",
-          [
-            Tree::Erase,
-            Tree::Var("x".into()),
-            Tree::Comb("tup".into(), Box::new(Tree::Var("x".into())), Box::new(Tree::Erase)),
-          ],
-        )
-      } else {
-        Tree::n_ary("fn", [Tree::Erase, Tree::Var("x".into()), Tree::Var("x".into())])
-      },
-      pairs: vec![],
-    }
-  }
-
-  pub(crate) fn composite_reconstruct(len: usize) -> Net {
-    Net {
-      root: if len == 1 {
-        Tree::n_ary("fn", [Tree::Erase, Tree::Var("x".into()), Tree::Erase, Tree::Var("x".into())])
-      } else {
-        Tree::n_ary(
-          "fn",
-          [
-            Tree::Erase,
-            Tree::Var("x".into()),
-            Tree::Var("y".into()),
-            Tree::Comb(
-              "tup".into(),
-              Box::new(Tree::Var("x".into())),
-              Box::new(Tree::Var("y".into())),
-            ),
-          ],
-        )
-      },
-      pairs: vec![],
-    }
-  }
-
-  pub(crate) fn ident_const(key: Ident<'core>) -> Net {
-    let str = key.0 .0;
-    Net {
-      root: Tree::n_ary(
-        "tup",
-        [
-          Tree::N32(str.chars().count() as u32),
-          Tree::n_ary(
-            "tup",
-            str.chars().map(|c| Tree::N32(c as u32)).chain([Tree::Var("x".into())]),
-          ),
-          Tree::Var("x".into()),
-        ],
-      ),
-      pairs: vec![],
-    }
-  }
-
-  pub(crate) fn identity() -> Net {
-    Net {
-      root: Tree::n_ary("fn", [Tree::Erase, Tree::Var("x".into()), Tree::Var("x".into())]),
-      pairs: vec![],
-    }
   }
 }

--- a/vine/src/components/finder.rs
+++ b/vine/src/components/finder.rs
@@ -2,17 +2,20 @@ use std::collections::{BTreeSet, HashSet};
 
 use vine_util::idx::IntSet;
 
-use crate::structures::{
-  ast::{Ident, Span},
-  chart::{
-    Chart, Def, DefId, DefImplKind, DefTraitKind, DefValueKind, FnId, GenericsId, ImplId,
-    MemberKind, WithVis,
+use crate::{
+  components::synthesizer::SyntheticImpl,
+  structures::{
+    ast::{Ident, Span},
+    chart::{
+      Chart, Def, DefId, DefImplKind, DefTraitKind, DefValueKind, FnId, GenericsId, ImplId,
+      MemberKind, WithVis,
+    },
+    core::Core,
+    diag::{Diag, ErrorGuaranteed},
+    signatures::{ImportState, Signatures},
+    tir::TirImpl,
+    types::{ImplType, Inverted, Type, TypeCtx, TypeKind, Types},
   },
-  core::Core,
-  diag::{Diag, ErrorGuaranteed},
-  signatures::{ImportState, Signatures},
-  tir::TirImpl,
-  types::{ImplType, Inverted, Type, TypeCtx, TypeKind, Types},
 };
 
 pub struct Finder<'core, 'a> {
@@ -485,7 +488,8 @@ impl<'core, 'a> Finder<'core, 'a> {
                 .and(types.unify(rest, type_params[2]))
                 .is_success()
               {
-                found.push(TypeCtx { types, inner: TirImpl::Tuple(elements.len()) });
+                let impl_ = TirImpl::Synthetic(SyntheticImpl::Tuple(elements.len()));
+                found.push(TypeCtx { types, inner: impl_ });
               }
             }
           }
@@ -503,7 +507,8 @@ impl<'core, 'a> Finder<'core, 'a> {
                 .and(types.unify(rest, type_params[2]))
                 .is_success()
               {
-                found.push(TypeCtx { types, inner: TirImpl::Object(key, entries.len()) });
+                let impl_ = TirImpl::Synthetic(SyntheticImpl::Object(key, entries.len()));
+                found.push(TypeCtx { types, inner: impl_ });
               }
             }
           }
@@ -517,7 +522,8 @@ impl<'core, 'a> Finder<'core, 'a> {
               let mut types = types.clone();
               let content = types.import(&self.sigs.structs[*struct_id], Some(struct_params)).data;
               if types.unify(content, type_params[1]).is_success() {
-                found.push(TypeCtx { types, inner: TirImpl::Struct(struct_.name) });
+                let impl_ = TirImpl::Synthetic(SyntheticImpl::Struct(*struct_id));
+                found.push(TypeCtx { types, inner: impl_ });
               }
             }
           }

--- a/vine/src/components/parser.rs
+++ b/vine/src/components/parser.rs
@@ -455,6 +455,9 @@ impl<'core, 'src> VineParser<'core, 'src> {
     if self.eat(Token::Hole)? {
       return Ok(TyKind::Hole);
     }
+    if self.eat(Token::Bang)? {
+      return Ok(TyKind::Never);
+    }
     if self.eat(Token::Fn)? {
       return Ok(TyKind::Fn(self.parse_path()?));
     }

--- a/vine/src/components/resolver.rs
+++ b/vine/src/components/resolver.rs
@@ -543,6 +543,7 @@ impl<'core, 'a> Resolver<'core, 'a> {
     match &*ty.kind {
       TyKind::Error(e) => self.types.error(*e),
       TyKind::Hole => self.resolve_ty_hole(span, inference),
+      TyKind::Never => self.types.new(TypeKind::Never),
       TyKind::Paren(t) => self.resolve_ty(t, inference),
       TyKind::Tuple(tys) => self.resolve_ty_tuple(tys, inference),
       TyKind::Object(entries) => self.resolve_ty_object(entries, inference),

--- a/vine/src/components/synthesizer.rs
+++ b/vine/src/components/synthesizer.rs
@@ -1,12 +1,15 @@
+use std::mem::take;
+
 use ivy::ast::{Net, Nets, Tree};
-use vine_util::idx::Counter;
+use vine_util::idx::{Counter, IdxVec};
 
 use crate::structures::{
   ast::Ident,
-  chart::{Chart, StructId, TraitConstId, TraitFnId},
-  resolutions::Rels,
-  specializations::Spec,
+  chart::{Chart, EnumId, StructId, TraitConstId, TraitFnId, VariantId},
+  resolutions::{FnRel, FnRelId, Rels},
+  specializations::{Spec, Specializations},
   template::global_name,
+  tir::TirImpl,
   vir::StageId,
 };
 
@@ -15,6 +18,7 @@ pub enum SyntheticImpl<'core> {
   Tuple(usize),
   Object(Ident<'core>, usize),
   Struct(StructId),
+  Enum(EnumId),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -23,12 +27,15 @@ pub enum SyntheticItem<'core> {
   CompositeReconstruct(usize),
   Ident(Ident<'core>),
   Identity,
+  EnumVariantNames(EnumId),
+  EnumMatch(EnumId),
+  EnumReconstruct(EnumId),
 }
 
 struct Synthesizer<'core, 'a> {
   nets: &'a mut Nets,
-  #[allow(unused)]
   chart: &'a Chart<'core>,
+  specs: &'a Specializations<'core>,
   spec: &'a Spec<'core>,
   var_id: Counter<usize>,
   stages: Counter<StageId>,
@@ -37,10 +44,11 @@ struct Synthesizer<'core, 'a> {
 pub fn synthesize<'core>(
   nets: &mut Nets,
   chart: &Chart<'core>,
+  specs: &Specializations<'core>,
   spec: &Spec<'core>,
   item: SyntheticItem<'core>,
 ) {
-  Synthesizer { nets, chart, spec, var_id: Counter::default(), stages: Counter::default() }
+  Synthesizer { nets, chart, specs, spec, var_id: Counter::default(), stages: Counter::default() }
     .synthesize(item);
 }
 
@@ -81,6 +89,9 @@ impl<'core> Synthesizer<'core, '_> {
       SyntheticItem::CompositeReconstruct(len) => self.synthesize_composite_reconstruct(len),
       SyntheticItem::Ident(ident) => self.synthesize_ident(ident),
       SyntheticItem::Identity => self.synthesize_identity(),
+      SyntheticItem::EnumVariantNames(enum_id) => self.synthesize_enum_variant_names(enum_id),
+      SyntheticItem::EnumMatch(enum_id) => self.synthesize_enum_match(enum_id),
+      SyntheticItem::EnumReconstruct(enum_id) => self.synthesize_enum_reconstruct(enum_id),
     };
     self.nets.insert(stage, net);
   }
@@ -117,6 +128,135 @@ impl<'core> Synthesizer<'core, '_> {
     let id = self.stages.next();
     global_name(self.spec, id)
   }
+
+  fn synthesize_enum_variant_names(&mut self, enum_id: EnumId) -> Net {
+    Net::new(
+      self.list(self.chart.enums[enum_id].variants.values().map(|x| x.name.0 .0), Self::string),
+    )
+  }
+
+  fn synthesize_enum_match(&mut self, enum_id: EnumId) -> Net {
+    let fn_ = match self.spec.rels.fns[FnRelId(0)] {
+      Ok((spec_id, stage_id)) => {
+        Tree::Global(global_name(self.specs.specs[spec_id].as_ref().unwrap(), stage_id))
+      }
+      Err(_) => Tree::Erase,
+    };
+    let f = self.new_wire();
+    let t = self.new_wire();
+    Net::new(Tree::n_ary(
+      "fn",
+      [
+        Tree::Erase,
+        self.match_enum(
+          enum_id,
+          |self_, variant_id| {
+            let has_data = self_.chart.enums[enum_id].variants[variant_id].data.is_some();
+            let data = self_.new_wire();
+            let f = self_.new_wire();
+            let t = self_.new_wire();
+            Net {
+              root: Tree::n_ary(
+                "enum",
+                has_data.then_some(data.0).into_iter().chain([Tree::n_ary("x", [f.0, t.0])]),
+              ),
+              pairs: Vec::from([(
+                fn_.clone(),
+                Tree::n_ary(
+                  "fn",
+                  [f.1, self_.variant(variant_id, has_data.then_some(data.1)), t.1],
+                ),
+              )]),
+            }
+          },
+          Tree::n_ary("x", [f.0, t.0]),
+        ),
+        f.1,
+        t.1,
+      ],
+    ))
+  }
+
+  fn synthesize_enum_reconstruct(&mut self, enum_id: EnumId) -> Net {
+    let mut cur_net = Net::new(Tree::Erase);
+    for (variant_id, variant) in self.chart.enums[enum_id].variants.iter().rev() {
+      let has_data = variant.data.is_some();
+      let mut prev_net = Some(cur_net);
+      let out = self.new_wire();
+      let match_ = self.match_enum(
+        enum_id,
+        |self_, v| {
+          let data = self_.new_wire();
+          if v.0 == 0 {
+            Net::new(Tree::n_ary(
+              "enum",
+              [
+                if has_data { data.0 } else { Tree::Erase },
+                self_.enum_(enum_id, variant_id, |_| has_data.then_some(data.1)),
+              ],
+            ))
+          } else {
+            prev_net.take().unwrap()
+          }
+        },
+        out.0,
+      );
+      if variant_id.0 == 0 {
+        cur_net = Net::new(Tree::n_ary("fn", [Tree::Erase, match_, out.1]));
+      } else {
+        cur_net = Net::new(Tree::n_ary("enum", [match_, out.1]));
+      }
+    }
+    cur_net
+  }
+
+  fn enum_(
+    &mut self,
+    enum_id: EnumId,
+    variant_id: VariantId,
+    content: impl FnOnce(&mut Self) -> Option<Tree>,
+  ) -> Tree {
+    let enum_def = &self.chart.enums[enum_id];
+    let wire = self.new_wire();
+    let mut variant = Tree::n_ary("enum", content(self).into_iter().chain([wire.0]));
+    Tree::n_ary(
+      "enum",
+      (0..enum_def.variants.len())
+        .map(|i| if variant_id.0 == i { take(&mut variant) } else { Tree::Erase })
+        .chain([wire.1]),
+    )
+  }
+
+  fn match_enum(
+    &mut self,
+    enum_id: EnumId,
+    mut arm: impl FnMut(&mut Self, VariantId) -> Net,
+    ctx: Tree,
+  ) -> Tree {
+    let enum_def = &self.chart.enums[enum_id];
+    Tree::n_ary(
+      "enum",
+      enum_def
+        .variants
+        .keys()
+        .map(|i| {
+          let stage = self.new_stage();
+          let net = arm(self, i);
+          self.nets.insert(stage.clone(), net);
+          Tree::Global(stage)
+        })
+        .chain([ctx]),
+    )
+  }
+
+  fn variant(&mut self, variant_id: VariantId, data: Option<Tree>) -> Tree {
+    let variant_enum = self.chart.builtins.variant.unwrap();
+    let mut cur = self.enum_(variant_enum, VariantId(0), |_| Some(data.unwrap_or(Tree::Erase)));
+    for _ in 0..variant_id.0 {
+      cur = self.enum_(variant_enum, VariantId(1), |_| Some(cur));
+    }
+    cur
+  }
 }
 
 impl<'core> SyntheticImpl<'core> {
@@ -129,6 +269,11 @@ impl<'core> SyntheticImpl<'core> {
       },
       SyntheticImpl::Struct(_) => match fn_id {
         TraitFnId(0) | TraitFnId(1) => SyntheticItem::Identity,
+        _ => unreachable!(),
+      },
+      SyntheticImpl::Enum(enum_id) => match fn_id {
+        TraitFnId(0) => SyntheticItem::EnumMatch(enum_id),
+        TraitFnId(1) => SyntheticItem::EnumReconstruct(enum_id),
         _ => unreachable!(),
       },
     }
@@ -145,6 +290,11 @@ impl<'core> SyntheticImpl<'core> {
         TraitConstId(0) => SyntheticItem::Ident(chart.structs[struct_id].name),
         _ => unreachable!(),
       },
+      SyntheticImpl::Enum(enum_id) => match const_id {
+        TraitConstId(0) => SyntheticItem::Ident(chart.enums[enum_id].name),
+        TraitConstId(1) => SyntheticItem::EnumVariantNames(enum_id),
+        _ => unreachable!(),
+      },
     }
   }
 }
@@ -155,7 +305,12 @@ impl<'core> SyntheticItem<'core> {
       SyntheticItem::CompositeDeconstruct(_)
       | SyntheticItem::CompositeReconstruct(_)
       | SyntheticItem::Ident(_)
-      | SyntheticItem::Identity => Rels::default(),
+      | SyntheticItem::Identity
+      | SyntheticItem::EnumVariantNames(_)
+      | SyntheticItem::EnumReconstruct(_) => Rels::default(),
+      SyntheticItem::EnumMatch(_) => {
+        Rels { consts: IdxVec::new(), fns: IdxVec::from([FnRel::Impl(TirImpl::Param(0))]) }
+      }
     }
   }
 }

--- a/vine/src/components/synthesizer.rs
+++ b/vine/src/components/synthesizer.rs
@@ -1,0 +1,161 @@
+use ivy::ast::{Net, Nets, Tree};
+use vine_util::idx::Counter;
+
+use crate::structures::{
+  ast::Ident,
+  chart::{Chart, StructId, TraitConstId, TraitFnId},
+  resolutions::Rels,
+  specializations::Spec,
+  template::global_name,
+  vir::StageId,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum SyntheticImpl<'core> {
+  Tuple(usize),
+  Object(Ident<'core>, usize),
+  Struct(StructId),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum SyntheticItem<'core> {
+  CompositeDeconstruct(usize),
+  CompositeReconstruct(usize),
+  Ident(Ident<'core>),
+  Identity,
+}
+
+struct Synthesizer<'core, 'a> {
+  nets: &'a mut Nets,
+  #[allow(unused)]
+  chart: &'a Chart<'core>,
+  spec: &'a Spec<'core>,
+  var_id: Counter<usize>,
+  stages: Counter<StageId>,
+}
+
+pub fn synthesize<'core>(
+  nets: &mut Nets,
+  chart: &Chart<'core>,
+  spec: &Spec<'core>,
+  item: SyntheticItem<'core>,
+) {
+  Synthesizer { nets, chart, spec, var_id: Counter::default(), stages: Counter::default() }
+    .synthesize(item);
+}
+
+impl<'core> Synthesizer<'core, '_> {
+  fn new_wire(&mut self) -> (Tree, Tree) {
+    let var = format!("s{}", self.var_id.next());
+    (Tree::Var(var.clone()), Tree::Var(var))
+  }
+
+  fn list<T>(
+    &mut self,
+    items: impl IntoIterator<Item = T, IntoIter: DoubleEndedIterator>,
+    mut f: impl FnMut(&mut Self, T) -> Tree,
+  ) -> Tree {
+    let end = self.new_wire();
+    let mut len = 0;
+    let buf = Tree::n_ary(
+      "tup",
+      items
+        .into_iter()
+        .map(|t| {
+          len += 1;
+          f(self, t)
+        })
+        .chain([end.0]),
+    );
+    Tree::n_ary("tup", [Tree::N32(len), buf, end.1])
+  }
+
+  fn string(&mut self, str: &str) -> Tree {
+    self.list(str.chars(), |_, char| Tree::N32(char as u32))
+  }
+
+  fn synthesize(&mut self, item: SyntheticItem<'core>) {
+    let stage = self.new_stage();
+    let net = match item {
+      SyntheticItem::CompositeDeconstruct(len) => self.synthesize_composite_deconstruct(len),
+      SyntheticItem::CompositeReconstruct(len) => self.synthesize_composite_reconstruct(len),
+      SyntheticItem::Ident(ident) => self.synthesize_ident(ident),
+      SyntheticItem::Identity => self.synthesize_identity(),
+    };
+    self.nets.insert(stage, net);
+  }
+
+  fn synthesize_composite_deconstruct(&mut self, len: usize) -> Net {
+    let x = self.new_wire();
+    Net::new(if len == 1 {
+      Tree::n_ary("fn", [Tree::Erase, x.0, Tree::n_ary("tup", [x.1, Tree::Erase])])
+    } else {
+      Tree::n_ary("fn", [Tree::Erase, x.0, x.1])
+    })
+  }
+
+  fn synthesize_composite_reconstruct(&mut self, len: usize) -> Net {
+    let x = self.new_wire();
+    let y = self.new_wire();
+    Net::new(if len == 1 {
+      Tree::n_ary("fn", [Tree::Erase, x.0, Tree::Erase, x.1])
+    } else {
+      Tree::n_ary("fn", [Tree::Erase, x.0, y.0, Tree::n_ary("tup", [x.1, y.1])])
+    })
+  }
+
+  fn synthesize_ident(&mut self, ident: Ident<'core>) -> Net {
+    Net::new(self.string(ident.0 .0))
+  }
+
+  fn synthesize_identity(&mut self) -> Net {
+    let x = self.new_wire();
+    Net::new(Tree::n_ary("fn", [Tree::Erase, x.0, x.1]))
+  }
+
+  fn new_stage(&mut self) -> String {
+    let id = self.stages.next();
+    global_name(self.spec, id)
+  }
+}
+
+impl<'core> SyntheticImpl<'core> {
+  pub fn fn_(self, _: &Chart<'core>, fn_id: TraitFnId) -> SyntheticItem<'core> {
+    match self {
+      SyntheticImpl::Tuple(len) | SyntheticImpl::Object(_, len) => match fn_id {
+        TraitFnId(0) => SyntheticItem::CompositeDeconstruct(len),
+        TraitFnId(1) => SyntheticItem::CompositeReconstruct(len),
+        _ => unreachable!(),
+      },
+      SyntheticImpl::Struct(_) => match fn_id {
+        TraitFnId(0) | TraitFnId(1) => SyntheticItem::Identity,
+        _ => unreachable!(),
+      },
+    }
+  }
+
+  pub fn const_(self, chart: &Chart<'core>, const_id: TraitConstId) -> SyntheticItem<'core> {
+    match self {
+      SyntheticImpl::Tuple(_) => unreachable!(),
+      SyntheticImpl::Object(key, _) => match const_id {
+        TraitConstId(0) => SyntheticItem::Ident(key),
+        _ => unreachable!(),
+      },
+      SyntheticImpl::Struct(struct_id) => match const_id {
+        TraitConstId(0) => SyntheticItem::Ident(chart.structs[struct_id].name),
+        _ => unreachable!(),
+      },
+    }
+  }
+}
+
+impl<'core> SyntheticItem<'core> {
+  pub fn rels(self) -> Rels<'core> {
+    match self {
+      SyntheticItem::CompositeDeconstruct(_)
+      | SyntheticItem::CompositeReconstruct(_)
+      | SyntheticItem::Ident(_)
+      | SyntheticItem::Identity => Rels::default(),
+    }
+  }
+}

--- a/vine/src/features/builtin.rs
+++ b/vine/src/features/builtin.rs
@@ -43,6 +43,8 @@ pub enum Builtin {
   Tuple,
   Object,
   Struct,
+  Enum,
+  Variant,
 }
 
 impl<'core> VineParser<'core, '_> {
@@ -96,6 +98,8 @@ impl<'core> VineParser<'core, '_> {
       "Tuple" => Builtin::Tuple,
       "Object" => Builtin::Object,
       "Struct" => Builtin::Struct,
+      "Enum" => Builtin::Enum,
+      "Variant" => Builtin::Variant,
       _ => Err(Diag::BadBuiltin { span })?,
     })
   }
@@ -139,6 +143,8 @@ pub struct Builtins {
   pub tuple: Option<TraitId>,
   pub object: Option<TraitId>,
   pub struct_: Option<TraitId>,
+  pub enum_: Option<TraitId>,
+  pub variant: Option<EnumId>,
 }
 
 impl<'core> Charter<'core, '_> {
@@ -210,6 +216,8 @@ impl<'core> Charter<'core, '_> {
       Builtin::Tuple => set(&mut builtins.tuple, trait_id),
       Builtin::Object => set(&mut builtins.object, trait_id),
       Builtin::Struct => set(&mut builtins.struct_, trait_id),
+      Builtin::Enum => set(&mut builtins.enum_, trait_id),
+      Builtin::Variant => set(&mut builtins.variant, enum_id),
     }
   }
 }

--- a/vine/src/structures/ast.rs
+++ b/vine/src/structures/ast.rs
@@ -376,6 +376,7 @@ pub struct Ty<'core> {
 #[derive(Debug, Clone)]
 pub enum TyKind<'core> {
   Hole,
+  Never,
   Paren(Ty<'core>),
   Fn(Path<'core>),
   Tuple(Vec<Ty<'core>>),

--- a/vine/src/structures/ast/visit.rs
+++ b/vine/src/structures/ast/visit.rs
@@ -199,6 +199,7 @@ pub trait VisitMut<'core, 'a> {
   fn _visit_type(&mut self, ty: &'a mut Ty<'core>) {
     match &mut *ty.kind {
       TyKind::Hole => {}
+      TyKind::Never => {}
       TyKind::Paren(t) | TyKind::Ref(t) | TyKind::Inverse(t) => self.visit_type(t),
       TyKind::Path(p) | TyKind::Fn(p) => self.visit(&mut p.generics),
       TyKind::Tuple(a) => {

--- a/vine/src/structures/checkpoint.rs
+++ b/vine/src/structures/checkpoint.rs
@@ -285,21 +285,11 @@ impl<'core> Resolutions<'core> {
 
 impl<'core> Specializations<'core> {
   fn revert(&mut self, checkpoint: &Checkpoint) {
-    let Specializations {
-      lookup,
-      specs,
-      composite_deconstruct,
-      composite_reconstruct,
-      ident_const,
-      identity,
-    } = self;
+    let Specializations { lookup, specs, synthetic } = self;
     specs.truncate(checkpoint.specs.0);
     lookup.truncate(checkpoint.fragments.0);
     lookup.values_mut().for_each(|map| map.retain(|_, s| *s < checkpoint.specs));
-    composite_deconstruct.retain(|_, s| *s < checkpoint.specs);
-    composite_reconstruct.retain(|_, s| *s < checkpoint.specs);
-    ident_const.retain(|_, s| *s < checkpoint.specs);
-    revert_idx(identity, checkpoint.specs);
+    synthetic.retain(|_, s| *s < checkpoint.specs);
   }
 }
 

--- a/vine/src/structures/checkpoint.rs
+++ b/vine/src/structures/checkpoint.rs
@@ -213,6 +213,8 @@ impl Builtins {
       tuple,
       object,
       struct_,
+      enum_,
+      variant,
     } = self;
     revert_idx(prelude, checkpoint.defs);
     revert_idx(bool, checkpoint.opaque_types);
@@ -243,6 +245,8 @@ impl Builtins {
     revert_idx(tuple, checkpoint.traits);
     revert_idx(object, checkpoint.traits);
     revert_idx(struct_, checkpoint.traits);
+    revert_idx(enum_, checkpoint.traits);
+    revert_idx(variant, checkpoint.enums);
   }
 }
 

--- a/vine/src/structures/template.rs
+++ b/vine/src/structures/template.rs
@@ -55,7 +55,7 @@ impl TemplateStage {
   }
 }
 
-fn global_name(spec: &Spec, stage_id: StageId) -> String {
+pub fn global_name(spec: &Spec, stage_id: StageId) -> String {
   let mut str = spec.path.to_owned();
   if !spec.singular {
     write!(str, ":{}", spec.index).unwrap();

--- a/vine/src/structures/tir.rs
+++ b/vine/src/structures/tir.rs
@@ -2,12 +2,15 @@ use class::Classes;
 use ivy::ast::Net;
 use vine_util::{idx::IdxVec, new_idx};
 
-use crate::structures::{
-  ast::{Flex, Ident, LogicalOp, Span},
-  chart::{EnumId, FnId, ImplId, StructId, VariantId},
-  diag::ErrorGuaranteed,
-  resolutions::{ConstRelId, FnRelId, Rels},
-  types::{Type, Types},
+use crate::{
+  components::synthesizer::SyntheticImpl,
+  structures::{
+    ast::{Flex, LogicalOp, Span},
+    chart::{EnumId, FnId, ImplId, StructId, VariantId},
+    diag::ErrorGuaranteed,
+    resolutions::{ConstRelId, FnRelId, Rels},
+    types::{Type, Types},
+  },
 };
 
 new_idx!(pub TargetId);
@@ -174,9 +177,7 @@ pub enum TirImpl<'core> {
   Closure(ClosureId),
   ForkClosure(ClosureId),
   DropClosure(ClosureId),
-  Tuple(usize),
-  Object(Ident<'core>, usize),
-  Struct(Ident<'core>),
+  Synthetic(SyntheticImpl<'core>),
 }
 
 impl TirExpr {

--- a/vine/src/tools/fmt.rs
+++ b/vine/src/tools/fmt.rs
@@ -255,6 +255,7 @@ impl<'core: 'src, 'src> Formatter<'src> {
     match &*ty.kind {
       TyKind::Error(_) => unreachable!(),
       TyKind::Hole => Doc("_"),
+      TyKind::Never => Doc("!"),
       TyKind::Paren(pat) => Doc::paren(self.fmt_ty(pat)),
       TyKind::Tuple(elements) => self.fmt_ty_tuple(elements),
       TyKind::Ref(ty) => self.fmt_ty_ref(ty),

--- a/vine/std/debug/Show.vi
+++ b/vine/std/debug/Show.vi
@@ -1,7 +1,7 @@
 
 use ops::Cast;
 use data::List as List_;
-use derive::{Object as Object_, Struct, Tuple as Tuple_};
+use derive::{Enum, Object as Object_, Struct, Tuple as Tuple_, Variant};
 
 pub trait Show[T] {
   fn .show(self: &T) -> Show;
@@ -121,18 +121,8 @@ pub mod Show {
     "\n" ++ String(List_::new(indent, ' '))
   }
 
-  #[become(unsafe::erase)]
-  pub impl drop: Drop[Show] {
-    fn drop(self: Show) {
-      match self {
-        Literal(_) {}
-        Constructor(_) {}
-        Tuple(_) {}
-        Object(_) {}
-        List(_) {}
-      }
-    }
-  }
+  pub impl fork: Fork[Show];
+  pub impl drop: Drop[Show];
 
   pub trait ShowTuple[T] {
     fn .show_tuple(&self: &T) -> List_[Show];
@@ -188,6 +178,35 @@ pub mod Show {
   pub impl struct_[S, C; Struct[S, C], Show[C]]: Show[S] {
     fn show(&struct_: &S) -> Show {
       Show::Constructor(Struct::name, Show::show(&struct_ as &C))
+    }
+  }
+
+  pub trait ShowVariant[V] {
+    fn .show_variant(&self: &V, variant_names: List_[String]) -> Show;
+  }
+
+  #[basic]
+  pub impl enum_[E, V; Enum[E, V], ShowVariant[V]]: Show[E] {
+    fn show(&enum_: &E) -> Show {
+      Enum::match_ref(&enum_, fn (&variant: &V) { variant.show_variant(Enum::variant_names) })
+    }
+  }
+
+  pub mod ShowVariant {
+    pub impl never: ShowVariant[!] {
+      fn show_variant(&never: &!, _: List_[String]) -> Show {
+        never as Show
+      }
+    }
+
+    pub impl variant[I, R; Show[I], ShowVariant[R]]: ShowVariant[Variant[I, R]] {
+      fn show_variant(&self: &Variant[I, R], variant_names: List_[String]) -> Show {
+        let (init_name, rest_names) = variant_names.head_tail().unwrap();
+        match &self {
+          &Variant::Init(init) { Show::Constructor(init_name, init.show()) }
+          &Variant::Rest(rest) { rest.show_variant(rest_names) }
+        }
+      }
     }
   }
 }

--- a/vine/std/derive.vi
+++ b/vine/std/derive.vi
@@ -81,3 +81,30 @@ pub mod Struct {
     }
   }
 }
+
+#[builtin = "Enum"]
+pub trait Enum[Enum, Variants] {
+  const name: String;
+  const variant_names: List[String];
+  fn match_[F, T; fn F(Variants) -> T](enum_: Enum, f: F) -> T;
+  fn reconstruct(variant: Variants) -> Enum;
+}
+
+pub mod Enum {
+  pub fn match_ref[E, V, F, T; Enum[E, V], fn F(&V) -> T](&enum_: &E, f: F) -> T {
+    Enum::match_(
+      enum_,
+      fn (variant: V) {
+        let result = f(&variant);
+        enum_ = Enum::reconstruct(variant);
+        result
+      },
+    )
+  }
+}
+
+#[builtin = "Variant"]
+pub enum Variant[I, R] {
+  Init(I),
+  Rest(R),
+}

--- a/vine/std/logical/Option.vi
+++ b/vine/std/logical/Option.vi
@@ -70,23 +70,6 @@ pub mod Option {
     }
   }
 
-  #[become(unsafe::duplicate)]
-  pub impl fork[T+]: Fork[Option[T]] {
-    fn fork(&self: &Option[T]) -> Option[T] {
-      match &self {
-        &Some(value) { Some(value) }
-        &None { None }
-      }
-    }
-  }
-
-  #[become(unsafe::erase)]
-  pub impl drop[T?]: Drop[Option[T]] {
-    fn drop(self: Option[T]) {
-      match self {
-        Some(_) {}
-        None {}
-      }
-    }
-  }
+  pub impl fork[T+]: Fork[Option[T]];
+  pub impl drop[T?]: Drop[Option[T]];
 }

--- a/vine/std/logical/Result.vi
+++ b/vine/std/logical/Result.vi
@@ -55,32 +55,8 @@ pub mod Result {
     }
   }
 
-  pub impl show[T, E; Show[T], Show[E]]: Show[Result[T, E]] {
-    fn show(&self: &Result[T, E]) -> Show {
-      match &self {
-        &Ok(value) { Show::Constructor("Ok", value.show()) }
-        &Err(value) { Show::Constructor("Err", value.show()) }
-      }
-    }
-  }
+  pub impl show[T, E; Show[T], Show[E]]: Show[Result[T, E]];
 
-  #[become(unsafe::duplicate)]
-  pub impl fork[T+, E+]: Fork[Result[T, E]] {
-    fn fork(&self: &Result[T, E]) -> Result[T, E] {
-      match &self {
-        &Ok(value) { Ok(value) }
-        &Err(value) { Err(value) }
-      }
-    }
-  }
-
-  #[become(unsafe::erase)]
-  pub impl drop[T?, E?]: Drop[Result[T, E]] {
-    fn drop(self: Result[T, E]) {
-      match self {
-        Ok(_) {}
-        Err(_) {}
-      }
-    }
-  }
+  pub impl fork[T+, E+]: Fork[Result[T, E]];
+  pub impl drop[T?, E?]: Drop[Result[T, E]];
 }

--- a/vine/std/ops/flex.vi
+++ b/vine/std/ops/flex.vi
@@ -1,5 +1,5 @@
 
-use derive::{Composite, Struct};
+use derive::{Composite, Enum, Struct, Variant};
 
 #[builtin = "Fork"]
 pub trait Fork[T] {
@@ -47,7 +47,25 @@ pub mod Fork {
     }
   }
 
+  #[basic]
+  #[become(unsafe::duplicate)]
+  pub impl enum_[E, V; Enum[E, V], Fork[V]]: Fork[E] {
+    fn fork(&self: &E) -> E {
+      Enum::match_ref(&self, fn (&variant) { Enum::reconstruct(variant) })
+    }
+  }
+
   pub impl never: Fork[!] = unsafe::duplicate;
+
+  #[become(unsafe::duplicate)]
+  pub impl variant[I+, R+]: Fork[Variant[I, R]] {
+    fn fork(&self: &Variant[I, R]) -> Variant[I, R] {
+      match &self {
+        &Variant::Init(init) { Variant::Init(init) }
+        &Variant::Rest(rest) { Variant::Rest(rest) }
+      }
+    }
+  }
 }
 
 pub mod Drop {
@@ -80,5 +98,23 @@ pub mod Drop {
     }
   }
 
+  #[basic]
+  #[become(unsafe::erase)]
+  pub impl enum_[E, V; Enum[E, V], Drop[V]]: Drop[E] {
+    fn drop(self: E) {
+      Enum::match_(self, fn (_) {})
+    }
+  }
+
   pub impl never: Drop[!] = unsafe::erase;
+
+  #[become(unsafe::erase)]
+  pub impl variant[I?, R?]: Drop[Variant[I, R]] {
+    fn drop(self: Variant[I, R]) {
+      match self {
+        Variant::Init(_) {}
+        Variant::Rest(_) {}
+      }
+    }
+  }
 }

--- a/vine/std/ops/flex.vi
+++ b/vine/std/ops/flex.vi
@@ -46,6 +46,8 @@ pub mod Fork {
       content as S
     }
   }
+
+  pub impl never: Fork[!] = unsafe::duplicate;
 }
 
 pub mod Drop {
@@ -77,4 +79,6 @@ pub mod Drop {
       _ = struct_ as C;
     }
   }
+
+  pub impl never: Drop[!] = unsafe::erase;
 }

--- a/vine/std/ops/ops.vi
+++ b/vine/std/ops/ops.vi
@@ -31,4 +31,10 @@ pub mod Cast {
       ref
     }
   }
+
+  pub impl never[T]: Cast[!, T] {
+    fn cast(_: !) -> T {
+      unsafe::eraser
+    }
+  }
 }


### PR DESCRIPTION
Introduces the `Enum` trait, and a helper enum, `Variant`:
```rs
pub trait Enum[Enum, Variants] {
  const name: String;
  const variant_names: List[String];
  fn match_[F, T; fn F(Variants) -> T](enum_: Enum, f: F) -> T;
  fn reconstruct(variant: Variants) -> Enum;
}

pub enum Variant[I, R] {
  Init(I),
  Rest(R),
}
```

The compiler automatically implements this trait for `Enum` types like follows:
```rs
pub impl option_enum[T]: Enum[Option[T], Variant[T, Variant[(), !]]] {
  const name: String = "Option";
  const variant_names: List[String] = ["Some", "None"];

  fn match[F, T; fn F(Variant[T, Variant[(), !]]) -> T](enum_: Option[T], f: F) -> T {
    match enum_ {
      Some(content) { f(Variant::Init(content)) }
      None { f(Variant::Rest(Variant::Init(())) }
    }
  }

  fn reconstruct(variant: Variant[T, Variant[(), !]]) -> Option[T] {
    match variant {
      Variant::Init(content) { Some(content) }
      Variant::Rest(Variant::Init(())) { None }
      Variant::Rest(Variant::Rest(never)) { never as Option[T] }
    }
  }
}
```

This doesn't support distinguishing between an enum variant with no content and a variant with a content of `()` – but I eventually want to remove this distinction anyway.

Resolves #169.