### PR TITLE
vine: format `let / else match` without trailing commas

### DIFF
--- a/tests/programs/fmt/match.vi
+++ b/tests/programs/fmt/match.vi
@@ -1,0 +1,10 @@
+
+pub fn main(&io: &IO) {
+  let Some(x) = Some(-4) else match { None {}};
+  let Ok(y) = Ok(3) else match { Err(err) { return; }};
+
+  match None {
+    Some(_) { return; }
+         _  { return; }
+  }
+}

--- a/tests/snaps/vine/fmt/match.fmt.vi
+++ b/tests/snaps/vine/fmt/match.fmt.vi
@@ -1,0 +1,20 @@
+
+pub fn main(&io: &IO) {
+  let Some(x) = Some(-4) else match {
+    None {}
+  };
+  let Ok(y) = Ok(3) else match {
+    Err(err) {
+      return;
+    }
+  };
+
+  match None {
+    Some(_) {
+      return;
+    }
+    _ {
+      return;
+    }
+  }
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -103,6 +103,7 @@ fn tests(t: &mut DynTester) {
 
     t.group("fmt", |t| {
       test_vi_fmt(t, "tests/programs/fmt/comment.vi");
+      test_vi_fmt(t, "tests/programs/fmt/match.vi");
       test_vi_fmt(t, "tests/programs/fmt/objects.vi");
       test_vi_fmt(t, "tests/programs/fmt/uses.vi");
     });

--- a/vine/src/features/let_.rs
+++ b/vine/src/features/let_.rs
@@ -55,7 +55,7 @@ impl<'core: 'src, 'src> Formatter<'src> {
         Some(LetElse::Block(b)) => Doc::concat([Doc(" else "), self.fmt_block(b, false)]),
         Some(LetElse::Match(a)) => Doc::concat([
           Doc(" else match "),
-          Doc::brace_comma(
+          Doc::brace_multiline(
             a.iter()
               .map(|(p, b)| Doc::concat([self.fmt_pat(p), Doc(" "), self.fmt_block(b, false)])),
           ),


### PR DESCRIPTION
Format the match arms of `let / else match` expressions without trailing commas like the arms of a `match` expressions. This was particularly problematic since the parser does not allow commas.