### PR TITLE
vine: make `std::debug::debug_state` less cursed

### DIFF
--- a/vine/src/components/specializer.rs
+++ b/vine/src/components/specializer.rs
@@ -153,6 +153,9 @@ impl<'core, 'a> Specializer<'core, 'a> {
     fn_id: FnId,
     mut impls: Vec<ImplTree<'core>>,
   ) -> Result<(SpecId, StageId), ErrorGuaranteed> {
+    if self.chart.builtins.debug_state == Some(fn_id) {
+      return Ok((self.instantiate_synthetic_item(SyntheticItem::DebugState, vec![]), StageId(0)));
+    }
     match fn_id {
       FnId::Concrete(fn_id) => {
         let fragment_id = self.resolutions.fns[fn_id];

--- a/vine/src/features/builtin.rs
+++ b/vine/src/features/builtin.rs
@@ -47,6 +47,7 @@ pub enum Builtin {
   Struct,
   Enum,
   Variant,
+  DebugState,
 }
 
 impl<'core> VineParser<'core, '_> {
@@ -104,6 +105,7 @@ impl<'core> VineParser<'core, '_> {
       "Struct" => Builtin::Struct,
       "Enum" => Builtin::Enum,
       "Variant" => Builtin::Variant,
+      "debug_state" => Builtin::DebugState,
       _ => Err(Diag::BadBuiltin { span })?,
     })
   }
@@ -151,6 +153,8 @@ pub struct Builtins {
   pub struct_: Option<TraitId>,
   pub enum_: Option<TraitId>,
   pub variant: Option<EnumId>,
+
+  pub debug_state: Option<FnId>,
 }
 
 impl<'core> Charter<'core, '_> {
@@ -226,6 +230,7 @@ impl<'core> Charter<'core, '_> {
       Builtin::Struct => set(&mut builtins.struct_, trait_id),
       Builtin::Enum => set(&mut builtins.enum_, trait_id),
       Builtin::Variant => set(&mut builtins.variant, enum_id),
+      Builtin::DebugState => set(&mut builtins.debug_state, fn_id),
     }
   }
 }

--- a/vine/src/features/inline_ivy.rs
+++ b/vine/src/features/inline_ivy.rs
@@ -117,11 +117,6 @@ impl<'core> Distiller<'core, '_> {
 
 impl<'core> Emitter<'core, '_> {
   pub(crate) fn emit_inline_ivy(&mut self, binds: &Vec<(String, Port)>, out: &Port, net: &Net) {
-    if net.pairs.is_empty() && matches!(&net.root, Tree::Var(var) if var == "debug") {
-      let pair = (self.emit_port(out), self.tap_debug());
-      self.pairs.push(pair);
-      return;
-    }
     for (var, port) in binds {
       let port = self.emit_port(port);
       self.pairs.push((Tree::Var(var.clone()), port));

--- a/vine/src/structures/checkpoint.rs
+++ b/vine/src/structures/checkpoint.rs
@@ -227,6 +227,7 @@ impl Builtins {
       struct_,
       enum_,
       variant,
+      debug_state,
     } = self;
     revert_idx(prelude, checkpoint.defs);
     revert_idx(bool, checkpoint.opaque_types);
@@ -261,6 +262,7 @@ impl Builtins {
     revert_idx(struct_, checkpoint.traits);
     revert_idx(enum_, checkpoint.traits);
     revert_idx(variant, checkpoint.enums);
+    revert_fn(debug_state, checkpoint);
   }
 }
 

--- a/vine/std/debug/debug.vi
+++ b/vine/std/debug/debug.vi
@@ -56,8 +56,9 @@ pub mod debug {
     }
   }
 
+  #[builtin = "debug_state"]
   fn debug_state() -> &DebugState {
-    inline_ivy! () -> &DebugState { debug }
+    unsafe::eraser
   }
 
   #[frameless]


### PR DESCRIPTION
This was previously implemented via an `inline_ivy!` which contained solely `debug`, which was hardcoded to give the debug state, which is quite horrible. This is now done much more sanely using `#[builtin = "debug_state"]` which overrides the function body to instead use a synthetic item.