### PR TITLE
std: fix `Nat::le`

### DIFF
--- a/tests/programs/repl/Nat.vi
+++ b/tests/programs/repl/Nat.vi
@@ -62,3 +62,6 @@ Nat::from_parts([N32::maximum, N32::maximum, N32::maximum, N32::maximum]) + Nat:
 Nat::from_parts([1, 1]) * 1[Nat]
 4294967298[Nat] * 4294967295
 4294967296[Nat] * 4294967296[Nat]
+
+Nat::from_parts([2]) < Nat::from_parts([1, 2])
+Nat::from_parts([2]) <= Nat::from_parts([1, 2])

--- a/tests/snaps/vine/repl/Nat.repl.vi
+++ b/tests/snaps/vine/repl/Nat.repl.vi
@@ -247,3 +247,14 @@ let io: IO = <IO>;
 18446744073709551616
 
 let io: IO = <IO>;
+> 
+
+let io: IO = <IO>;
+> Nat::from_parts([2]) < Nat::from_parts([1, 2])
+true
+
+let io: IO = <IO>;
+> Nat::from_parts([2]) <= Nat::from_parts([1, 2])
+true
+
+let io: IO = <IO>;

--- a/vine/std/numeric/Nat.vi
+++ b/vine/std/numeric/Nat.vi
@@ -366,7 +366,7 @@ pub mod Nat {
       a.cmp(&b) is Ord::Lt
     }
 
-    fn le(&Nat(a), &Nat(b)) -> Bool {
+    fn le(&a: &Nat, &b: &Nat) -> Bool {
       !(a.cmp(&b) is Ord::Gt)
     }
   }


### PR DESCRIPTION
The implementation was errantly comparing the order of the lists (lexicographically) rather than the Nats themselves.