### PR TITLE
vine: skip finding impls with `??` types

### DIFF
--- a/tests/snaps/vine/fail/atypical.txt
+++ b/tests/snaps/vine/fail/atypical.txt
@@ -41,14 +41,9 @@ error tests/programs/fail/atypical.vi:4:8 - cannot drop `?0`
 error tests/programs/fail/atypical.vi:4:11 - cannot drop `(?1, ??, ??)`
 error tests/programs/fail/atypical.vi:12:3 - search limit reached when finding impl of trait `Drop[?29]`
 error tests/programs/fail/atypical.vi:13:14 - search limit reached when finding impl of trait `Drop[?34]`
-error tests/programs/fail/atypical.vi:14:3 - cannot find impl of trait `Drop[??]`
-error tests/programs/fail/atypical.vi:16:3 - cannot find impl of trait `Drop[??]`
-error tests/programs/fail/atypical.vi:17:3 - cannot find impl of trait `Drop[??]`
 error tests/programs/fail/atypical.vi:22:7 - expected a complete pattern
 error tests/programs/fail/atypical.vi:23:4 - search limit reached when finding impl of trait `Drop[?73]`
 error tests/programs/fail/atypical.vi:28:14 - search limit reached when finding impl of trait `Drop[?83]`
-error tests/programs/fail/atypical.vi:30:3 - cannot find impl of trait `Drop[??]`
-error tests/programs/fail/atypical.vi:32:3 - cannot find impl of trait `Drop[??]`
 error tests/programs/fail/atypical.vi:10:8 - search limit reached when finding flex of type `?19`
 error tests/programs/fail/atypical.vi:10:11 - search limit reached when finding flex of type `?20`
 error tests/programs/fail/atypical.vi:18:14 - search limit reached when finding flex of type `?54`

--- a/tests/snaps/vine/fail/hallo_world.txt
+++ b/tests/snaps/vine/fail/hallo_world.txt
@@ -5,4 +5,3 @@ error tests/programs/fail/hallo_world.vi:8:13 - cannot find `io` in `::std`
 error tests/programs/fail/hallo_world.vi:9:3 - cannot find `io` in `::hallo_world::main`
 error tests/programs/fail/hallo_world.vi:9:14 - cannot find `hallo` in `::hallo_world::main`
 error tests/programs/fail/hallo_world.vi:9:21 - cannot find `world` in `::hallo_world::main`
-error tests/programs/fail/hallo_world.vi:9:3 - type `??` has no method `println`

--- a/tests/snaps/vine/fail/is_not.txt
+++ b/tests/snaps/vine/fail/is_not.txt
@@ -6,8 +6,6 @@ error tests/programs/fail/is_not.vi:5:26 - cannot find `y` in `::is_not::main`
 error tests/programs/fail/is_not.vi:5:29 - cannot find `z` in `::is_not::main`
 error tests/programs/fail/is_not.vi:5:3 - missing else block
 error tests/programs/fail/is_not.vi:7:3 - cannot find `y` in `::is_not::main`
-error tests/programs/fail/is_not.vi:4:3 - cannot find impl of trait `Drop[??]`
-error tests/programs/fail/is_not.vi:5:3 - cannot find impl of trait `Drop[(??, ??)]`
 error tests/programs/fail/is_not.vi:2:13 - search limit reached when finding flex of type `?0`
 error tests/programs/fail/is_not.vi:3:11 - search limit reached when finding flex of type `?0`
 error tests/programs/fail/is_not.vi:4:13 - search limit reached when finding flex of type `?0`

--- a/tests/snaps/vine/fail/visibility.txt
+++ b/tests/snaps/vine/fail/visibility.txt
@@ -12,4 +12,3 @@ error tests/programs/fail/visibility.vi:21:24 - `::visibility::lib::y` is only v
 error tests/programs/fail/visibility.vi:21:15 - `::visibility::lib::y` is only visible within `::visibility::lib`
 error tests/programs/fail/visibility.vi:21:7 - `::visibility::lib::y` is only visible within `::visibility::lib`
 error - `::visibility::main` is only visible within `::visibility`
-error tests/programs/fail/visibility.vi:19:3 - cannot find impl of trait `Drop[??]`

--- a/vine/Cargo.toml
+++ b/vine/Cargo.toml
@@ -18,3 +18,4 @@ vine-util = { path = "../util" }
 absolute_paths = "warn"
 large_enum_variant = "allow"
 too_many_arguments = "allow"
+type_complexity = "allow"

--- a/vine/src/features/method.rs
+++ b/vine/src/features/method.rs
@@ -95,7 +95,7 @@ impl Resolver<'_> {
   ) -> Result<(FnId, TypeCtx<Vec<Type>>), ErrorGuaranteed> {
     let mut finder =
       Finder::new(self.chart, self.sigs, self.diags, self.cur_def, self.cur_generics, span);
-    let mut results = finder.find_method(&self.types, receiver, name.clone());
+    let mut results = finder.find_method(&self.types, receiver, name.clone())?;
 
     if results.len() == 1 {
       Ok(results.pop().unwrap())


### PR DESCRIPTION
Removes errors like
```
cannot find impl of trait `Drop[??]
```