### PR TITLE
lsp: compile libs before checkpointing

### DIFF
--- a/lsp/src/lib.rs
+++ b/lsp/src/lib.rs
@@ -414,6 +414,7 @@ pub async fn lsp(libs: Vec<PathBuf>, entrypoints: Vec<String>) {
     compiler.loader.load_mod(&lib, &mut compiler.diags);
   }
 
+  _ = compiler.compile(());
   let checkpoint = compiler.checkpoint();
 
   let (service, socket) = LspService::new(|client| Backend {


### PR DESCRIPTION
#151 broke the LSP when libraries (e.g. `#root`) were provided, as it would checkpoint before compiling the libs, so after saving once, the libs would no longer exist in compilation, leading to great numbers of errors (particularly for `#root`).

(It is non-ideal that there are not tests that would catch this but I do not know of a straightforward way to test the LSP at the moment.)

@vjjft Can you confirm this fixes the issue you encountered?