### PR TITLE
vine: `vine test` improvements

### DIFF
--- a/cli/src/common.rs
+++ b/cli/src/common.rs
@@ -46,7 +46,7 @@ impl RunArgs {
     };
     let mut extrinsics = Extrinsics::default();
 
-    host.register_default_extrinsics(&mut extrinsics);
+    host.register_default_extrinsics_with_stdio(&mut extrinsics);
     host.insert_nets(&nets);
 
     let main = host.get("::").expect("missing main");

--- a/cli/src/ivy_cli.rs
+++ b/cli/src/ivy_cli.rs
@@ -83,7 +83,7 @@ impl IvyReplCommand {
     let heap = Heap::new();
     let mut extrinsics = Extrinsics::default();
 
-    host.register_default_extrinsics(&mut extrinsics);
+    host.register_default_extrinsics_with_stdio(&mut extrinsics);
     host.insert_nets(&nets);
 
     let mut ivm = IVM::new(&heap, &extrinsics);

--- a/cli/src/ivy_cli.rs
+++ b/cli/src/ivy_cli.rs
@@ -45,7 +45,7 @@ impl IvyRunCommand {
   pub fn execute(self) -> Result<()> {
     let src_contents = fs::read_to_string(self.src.clone())?;
     let nets = IvyParser::parse(&src_contents).unwrap();
-    self.run_args.run(nets, false);
+    self.run_args.run(nets).check(false);
     Ok(())
   }
 }

--- a/cli/src/ivy_cli.rs
+++ b/cli/src/ivy_cli.rs
@@ -45,7 +45,7 @@ impl IvyRunCommand {
   pub fn execute(self) -> Result<()> {
     let src_contents = fs::read_to_string(self.src.clone())?;
     let nets = IvyParser::parse(&src_contents).unwrap();
-    self.run_args.run(nets).check(false);
+    self.run_args.run(&nets).check(false);
     Ok(())
   }
 }

--- a/cli/src/vine_cli.rs
+++ b/cli/src/vine_cli.rs
@@ -133,7 +133,7 @@ impl VineRunCommand {
     let debug = self.compile.debug;
     let (mut nets, _) = self.compile.compile();
     self.optimizations.apply(&mut nets);
-    self.run_args.run(nets, !debug);
+    self.run_args.run(nets).check(!debug);
     Ok(())
   }
 }

--- a/cli/src/vine_cli.rs
+++ b/cli/src/vine_cli.rs
@@ -163,6 +163,9 @@ impl VineTestCommand {
 
     let (mut nets, mut compiler) = self.compile.compile();
 
+    // TODO: need to keep test entrypoints in order to run optimizer
+    // self.optimizations.apply(&mut nets);
+
     let test_fn_ids: Vec<_> = compiler
       .chart
       .tests
@@ -181,9 +184,6 @@ impl VineTestCommand {
     eprintln!();
 
     let mut failed = false;
-
-    // TODO: need to keep test entrypoints in order to run optimizer
-    // self.optimizations.apply(&mut nets);
 
     for test_fn_id in test_fn_ids {
       let def_id = compiler.chart.concrete_fns[test_fn_id].def;

--- a/cli/src/vine_cli.rs
+++ b/cli/src/vine_cli.rs
@@ -231,7 +231,7 @@ impl VineReplCommand {
     let host = &mut Host::default();
     let heap = Heap::new();
     let mut extrinsics = Extrinsics::default();
-    host.register_default_extrinsics(&mut extrinsics);
+    host.register_default_extrinsics_with_stdio(&mut extrinsics);
 
     let mut ivm = IVM::new(&heap, &extrinsics);
     let config = Config::new(!self.no_debug, false);

--- a/cli/src/vine_cli.rs
+++ b/cli/src/vine_cli.rs
@@ -133,7 +133,7 @@ impl VineRunCommand {
     let debug = self.compile.debug;
     let (mut nets, _) = self.compile.compile();
     self.optimizations.apply(&mut nets);
-    self.run_args.run(nets).check(!debug);
+    self.run_args.run(&nets).check(!debug);
     Ok(())
   }
 }

--- a/ivy/src/host/ext.rs
+++ b/ivy/src/host/ext.rs
@@ -108,7 +108,7 @@ impl<'ivm> Host<'ivm> {
 
       "io_print_char" => |a, b| {
         a.as_ty(&io);
-        let _ = write!((io_print_char_output_fn)(), "{}", char::try_from(as_n32(b)).unwrap());
+        write!((io_print_char_output_fn)(), "{}", char::try_from(as_n32(b)).unwrap()).unwrap();
         ExtVal::new(io, 0)
       },
       "io_print_byte" => |a, b| {

--- a/ivy/src/host/ext.rs
+++ b/ivy/src/host/ext.rs
@@ -34,8 +34,8 @@ impl<'ivm> Host<'ivm> {
     io_input_fn: FI,
     io_output_fn: FO,
   ) where
-    FI: Fn() -> R + Sync + 'ivm,
-    FO: Clone + Fn() -> W + Sync + 'ivm,
+    FI: Copy + Fn() -> R + Sync + 'ivm,
+    FO: Copy + Fn() -> W + Sync + 'ivm,
     W: Write,
     R: Read,
   {
@@ -52,11 +52,6 @@ impl<'ivm> Host<'ivm> {
     let new_n32 = move |x: u32| ExtVal::new(n32, x);
     let new_f32 = move |x: f32| ExtVal::new(f32, x.to_bits());
     let new_bool = move |x: bool| new_n32(x as u32);
-
-    let io_print_char_output_fn = io_output_fn.clone();
-    let io_print_byte_output_fn = io_output_fn.clone();
-    let io_flush_output_fn = io_output_fn;
-    let io_read_byte_input_fn = io_input_fn;
 
     define_ext_fns!(self, extrinsics,
       "seq" => |a, _b| a,
@@ -108,24 +103,24 @@ impl<'ivm> Host<'ivm> {
 
       "io_print_char" => |a, b| {
         a.as_ty(&io);
-        write!((io_print_char_output_fn)(), "{}", char::try_from(as_n32(b)).unwrap()).unwrap();
+        write!((io_output_fn)(), "{}", char::try_from(as_n32(b)).unwrap()).unwrap();
         ExtVal::new(io, 0)
       },
       "io_print_byte" => |a, b| {
         a.as_ty(&io);
-        (io_print_byte_output_fn)().write_all(&[as_n32(b) as u8]).unwrap();
+        (io_output_fn)().write_all(&[as_n32(b) as u8]).unwrap();
         ExtVal::new(io, 0)
       },
       "io_flush" => |a, _b| {
         a.as_ty(&io);
-        (io_flush_output_fn)().flush().unwrap();
+        (io_output_fn)().flush().unwrap();
         ExtVal::new(io, 0)
       },
       "io_read_byte" => |a, b| {
         a.as_ty(&io);
         let default = as_n32(b) as u8;
         let mut buf = [default];
-        _ = (io_read_byte_input_fn)().read(&mut buf).unwrap();
+        _ = (io_input_fn)().read(&mut buf).unwrap();
         new_n32(buf[0] as u32)
       }
     );

--- a/ivy/src/optimize/pre_reduce.rs
+++ b/ivy/src/optimize/pre_reduce.rs
@@ -18,7 +18,7 @@ pub fn pre_reduce(nets: &mut Nets) {
   let heap = &Heap::new();
   let mut host = &mut Host::default();
   let mut extrinsics = Extrinsics::default();
-  host.register_default_extrinsics(&mut extrinsics);
+  host.register_default_extrinsics_with_stdio(&mut extrinsics);
   host._insert_nets(nets, true);
 
   for (name, net) in nets.iter_mut() {

--- a/root/IO.vi
+++ b/root/IO.vi
@@ -22,7 +22,7 @@ pub mod IO {
   /// Prints the given character to stdout.
   pub fn .print_char(&io: &IO, char: Char) {
     inline_ivy! (io0 <- io, io1 -> io, char <- char) -> () { _
-      io0 = @io_print_char(char io1) 
+      io0 = @io_print_char(char io1)
     }
   }
 
@@ -34,14 +34,14 @@ pub mod IO {
 
   pub fn .print_byte(&io: &IO, byte: N32) {
     inline_ivy! (io0 <- io, io1 -> io, byte <- byte) -> () { _
-      io0 = @io_print_byte(byte io1) 
+      io0 = @io_print_byte(byte io1)
     }
   }
 
   /// Flushes any buffered output to stdout.
   pub fn .flush(&io: &IO) {
     inline_ivy! (io0 <- io, io1 -> io) -> () { _
-      io0 = @io_flush(0 io1) 
+      io0 = @io_flush(0 io1)
     }
   }
 
@@ -92,7 +92,7 @@ pub mod IO {
     inline_ivy! (io0 <- io, io3 -> io, default <- default) -> Char {
       byte
       io0 = dup(io1 io2)
-      io1 = @io_read_byte(default dup(byte @seq$(io2 io3))) 
+      io1 = @io_read_byte(default dup(byte @seq$(io2 io3)))
     }
   }
 

--- a/root/debug/debug.vi
+++ b/root/debug/debug.vi
@@ -82,6 +82,7 @@ pub mod debug {
     for frame in state.stack.iter() {
       state.io.print("  @ {frame}\n");
     }
+    unsafe::erase(&state.io);
     unsafe::eraser
   }
 


### PR DESCRIPTION
1. runs all test entrypoints when running `vine test`, instead of just printing them out
2. prints out whether each test failed or succeeded
3. captures any stdout during test execution
4. erases the io handle on `debug::error`

As a followup, we should probably have a separate stderr for debug output, and both of those should be capturable during `RunArgs::run`.