### PR TITLE
tooling: add edition to rustfmt.toml

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,4 @@
+edition = "2024"
 tab_spaces = 2
 use_small_heuristics = "Max"
 max_width = 100


### PR DESCRIPTION
Without this, invoking `rustfmt` directly requires that we supply `--edition 2024` as a CLI argument. In an editor, running `rustfmt` is much faster than `cargo fmt`.