### PR TITLE
ci: add workflow to auto-close issues

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -17,10 +17,10 @@ jobs:
       - name: close linked issues
         shell: nu {0}
         run: |
-          let body = gh pr view ${{ github.event.pull_request.number }} --json body | from json | get body
-          let url = gh pr view ${{ github.event.pull_request.number }} --json url | from json | get url
+          let number = ${{ github.event.pull_request.number }}
+          let body = gh pr view $number --json body | from json | get body
           let issues = $body | parse --regex '(?i)(?:(?:clos|resolv)e[sd]?|fix(?:e[sd])?):?\s*#(?P<issue>\d+)'
-          let comment = $"completed in ($url)"
+          let comment = $"- #($number)"
           $issues | each { gh issue close $in.issue --reason completed --comment $comment } | ignore
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Captures `(?i)(?:resolves|fixes)\s+#(?P<issue>\d+)` messages in PR bodies which were merged into either `main` or `dev`, and closes those issues.

Initially, `gh pr view <pr> --json closingIssuesReferences` was considered, but PRs initially opened to `dev` (and not to `main`), will not have this data populated.

Resolves #510 