### PR TITLE
lsp: fix bug when compiling syntax errors

### DIFF
--- a/vine/src/compiler.rs
+++ b/vine/src/compiler.rs
@@ -90,12 +90,14 @@ impl Compiler {
     mut hooks: impl Hooks,
     checkpoint: &Checkpoint,
   ) -> Result<(), ErrorGuaranteed> {
+    let loaded = take(&mut self.loaded);
+
     self.diags.bail()?;
 
     let chart = &mut self.chart;
 
     let mut charter = Charter { chart, diags: &mut self.diags, annotations: &mut self.annotations };
-    charter.chart(take(&mut self.loaded));
+    charter.chart(loaded);
     hooks.chart(&mut charter);
 
     let mut resolver = Resolver::new(


### PR DESCRIPTION
Fixes a bug that after compiling with syntax errors, the loaded modules would not be cleared, meaning that the next compilation would have all files duplicated, causing a ton of problems.

@nilscrm can you confirm this fixes the issue you encountered?