### PR TITLE
tooling: add cargo-expand to devShell, fix nativeBuildInputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -88,7 +88,8 @@
 
         devShells.default = craneLib.devShell {
           name = "vine-dev";
-          nativeBuildInputs = [
+          packages = [
+            pkgs.cargo-expand
             pkgs.nushell
             pkgs.nodejs_24
             pkgs.tree-sitter


### PR DESCRIPTION
[`crane.devShell` filters out `nativeBuildInputs`](https://github.com/ipetkov/crane/blob/a2812c19f1ed2e5ed5ce2ef7109798b575c180e1/lib/devShell.nix#L18-L21)