### PR TITLE
root: implement drop and fork for Iterator::Windows

### DIFF
--- a/root/data/Iterator.vi
+++ b/root/data/Iterator.vi
@@ -381,7 +381,7 @@ pub mod Iterator[I, T; Iterator[I, T]] {
     }
   }
 
-  pub struct Windows[I, R](Option[R], I);
+  pub struct* Windows[I, R](Option[R], I);
 
   pub fn .windows[I, T, R; Iterator[I, T]](iter: I) -> Windows[I, R] {
     Windows(None(), iter)


### PR DESCRIPTION
This allows e.g. using `Windows` with `zip`.