### PR TITLE
root: improve zip

### DIFF
--- a/root/data/Iterator.vi
+++ b/root/data/Iterator.vi
@@ -1,6 +1,7 @@
 
 use ops::{Cast, comparison::Ord};
 use derive::Tuple;
+use util::transmute;
 
 pub trait Iterator[Self, Item] {
   #[builtin = "advance"]
@@ -264,17 +265,33 @@ pub mod Iterator[I, T; Iterator[I, T]] {
     }
   }
 
-  pub fn .zip[... I?, T?, J?, U; Iterator[J, U]](i: I, j: J) -> Zip[I, J] {
+  pub fn .zip[... I?, T?, J?, U; Iterator[J, U]](i: I, j: J) -> Zip[(I, J)] {
     Zip(i, j)
   }
 
-  pub struct* Zip[I, J]((I, J));
+  pub struct* Zip[Is](Is);
 
-  pub mod Zip[...] {
-    pub impl [... I?, T?, J?, U; Iterator[J, U]]: Iterator[Zip[I, J], (T, U)] {
-      fn advance(Zip[I, J](i, j)) -> Option[((T, U), Zip[I, J])] {
-        if i.advance() is Some(t, i) and j.advance() is Some(u, j) {
-          Some((t, u), Zip(i, j))
+  pub mod Zip[Is] {
+    pub impl iter_singleton[I, T; Iterator[I, T]]: Iterator[Zip[(I,)], (T,)] {
+      fn advance(Zip[(I,)]((iter,))) -> Option[((T,), Zip[(I,)])] {
+        safe transmute[Option[(T, I)], Option[((T,), Zip[(I,)])]](iter.advance())
+      }
+    }
+
+    pub impl iter_tuple[
+      IS, I, IR, TS, T, TR;
+      Tuple[IS, I, IR],
+      Iterator[I, T],
+      Iterator[Zip[IR], TR],
+      Tuple[TS, T, TR],
+      Drop[I],
+      Drop[IR],
+      Drop[T];
+    ]: Iterator[Zip[IS], TS] {
+      fn advance(Zip[IS](iters)) -> Option[(TS, Zip[IS])] {
+        let (i, ir) = iters as (I, IR);
+        if i.advance() is Some(t, i) and Zip(ir).advance() is Some(tr, Zip(ir)) {
+          Some((t, tr) as TS, Zip((i, ir) as IS))
         } else {
           None()
         }
@@ -585,5 +602,25 @@ pub mod Iterate {
 
   pub fn .iter_ref[C, I, T; Iterate[&C, I, T]](&collection: &C) -> I {
     iter(&collection)
+  }
+
+  pub impl iterate_singleton[C, I, T; Iterate[C, I, T]]: Iterate[(C,), Zip[(I,)], (T,)] {
+    fn iter((c: C,)) -> Zip[(I,)] {
+      Zip((c.iter(),))
+    }
+  }
+
+  pub impl iterate_tuple[
+    Cs, C, Cr, Is, I, Ir, Ts, T, Tr;
+    Tuple[Cs, C, Cr],
+    Iterate[C, I, T],
+    Iterate[Cr, Zip[Ir], Tr],
+    Tuple[Is, I, Ir],
+    Tuple[Ts, T, Tr];
+  ]: Iterate[Cs, Zip[Is], Ts] {
+    fn iter(cs: Cs) -> Zip[Is] {
+      let (c, cr) = cs as (C, Cr);
+      Zip((c.iter(), cr.iter()!) as Is)
+    }
   }
 }

--- a/root/numeric/Nat/Nat.vi
+++ b/root/numeric/Nat/Nat.vi
@@ -216,7 +216,7 @@ pub mod Nat {
     fn bit_and(a: Nat, b: Nat) -> Nat {
       let ~trim = true;
       let result = [];
-      for (a, b) in a!.iter().zip(b!.iter()) {
+      for (a, b) in (a!, b!) {
         let num = a & b;
         if !~trim {
           result.push_back(num);
@@ -350,7 +350,7 @@ pub mod Nat {
         a.len() > b.len() { Ord::Gt() }
         _ {
           let ord = Ord::Eq();
-          for (x, y) in a.iter().zip(b.iter()) {
+          for (x, y) in (a, b) {
             ord = match x.cmp(&y) {
               Ord::Lt() { Ord::Lt() }
               Ord::Eq() { ord }

--- a/root/numeric/Nat/div_rem.vi
+++ b/root/numeric/Nat/div_rem.vi
@@ -90,7 +90,7 @@ pub fn .div_rem(a: Nat, d: Nat) -> (Nat, Nat) {
     let ~borrow;
     let underflow = a_hi < ~borrow;
 
-    for (&a_num, &d_num) in a!.iter_ref().zip(d!.iter_ref()) {
+    for (&a_num, &d_num) in (&a!, &d!) {
       let &borrow = &~borrow;
       let N64(prod, new_borrow) = N64::mul_n32_n32(d_num, q_est) + borrow;
       new_borrow += (a_num < prod) as N32;
@@ -106,7 +106,7 @@ pub fn .div_rem(a: Nat, d: Nat) -> (Nat, Nat) {
 
       let ~carry: Bool;
 
-      for (&a_num, &d_num) in a!.iter_ref().zip(d!.iter_ref()) {
+      for (&a_num, &d_num) in (&a!, &d!) {
         let &carry = &~carry;
         let d_carry = d_num + carry as N32;
         carry = N32::add_high(d_num, carry as N32) | N32::add_high(a_num, d_carry);

--- a/root/unicode/String.vi
+++ b/root/unicode/String.vi
@@ -108,7 +108,7 @@ pub mod String {
     if self.len() < prefix.len() {
       return false;
     }
-    for (&a, &b) in self.iter_ref().zip(prefix.iter_ref()) {
+    for (&a, &b) in (&self, &prefix) {
       if a != b {
         return false;
       }
@@ -121,7 +121,7 @@ pub mod String {
       return false;
     }
     let skip = self.len() - suffix.len();
-    for (&a, &b) in self.iter_ref().skip(skip).zip(suffix.iter_ref()) {
+    for (&a, &b) in (self.iter_ref().skip(skip), &suffix) {
       if a != b {
         return false;
       }

--- a/tests/programs/iterator_party.vi
+++ b/tests/programs/iterator_party.vi
@@ -63,7 +63,7 @@ pub fn main(_: &IO) {
     debug::log("{a}, {b}");
     let a = (0..a).inspect(fn* (&x: &N32) { debug::log("x: {x}") });
     let b = (0..b).inspect(fn* (&y: &N32) { debug::log("y: {y}") });
-    for t in a.zip(b) {
+    for t in (a, b) {
       debug::log("{t.show()}");
     }
   }

--- a/tests/snaps/programs/iterator_party/stats
+++ b/tests/snaps/programs/iterator_party/stats
@@ -1,15 +1,15 @@
 
 Interactions
-  Total            1_256_551
-  Annihilate         729_219
+  Total            1_256_573
+  Annihilate         729_230
   Commute                686
   Copy               104_547
-  Erase              177_713
+  Erase              177_724
   Expand              79_555
   Call               122_172
   Branch              42_659
 
 Memory
   Heap             1_444_496 B
-  Allocated       28_185_056 B
-  Freed           28_185_056 B
+  Allocated       28_185_408 B
+  Freed           28_185_408 B


### PR DESCRIPTION
Before:
```rs
for ((a, b), &c) in x.iter().zip(y.iter()).zip(z.iter_ref()) {
  ...
}
```
After:
```rs
for (a, b, &c) in (x, y, &z) {
  ...
}
```