### PR TITLE
vine: remove `vi:graft:lazy` node

### DIFF
--- a/ivm/src/runtime/interact.rs
+++ b/ivm/src/runtime/interact.rs
@@ -91,7 +91,7 @@ impl<'ivm> Runtime<'ivm, '_> {
       sym!((Graft, c), (Comb, d)) if d.label() != 0 => self.copy(c, d),
       sym!((Graft, c), (_, p)) => self._graft(c, p),
       ((Comb, a), (Comb, b)) if a.label() == b.label() => self.annihilate(a, b),
-      ((Comb, a), (Comb, b)) => self.commute(a, b),
+      ((Comb, a), (Comb, b)) | sym!((Comb, a), (ExtFn, b)) => self.commute(a, b),
       sym!((Erase, n), (_, b)) => self.copy(n, b),
       sym!((ExtVal, n), (Comb, b)) => {
         let x = unsafe { n.as_ext_val() };

--- a/root/debug/debug.vi
+++ b/root/debug/debug.vi
@@ -14,7 +14,7 @@ pub const enabled: Bool = debug_state() is Some(_);
 pub fn log[T; Cast[T, String]](msg: T) {
   let msg = msg as String;
   if debug_state() is Some(&state) {
-    let &frame = state.stack.top().assume();
+    let frame = state.stack.top().assume();
     state.io.print("[{frame.file}:{frame.line}:{frame.col}] {msg}\n")
   }
 }
@@ -96,7 +96,7 @@ fn debug_state() -> Option[&DebugState] {
   safe eraser
 }
 
-pub struct Stack((Bool, Frame), Stack);
+pub struct Stack(Lazy[Option[Frame]], Stack);
 
 pub mod Stack {
   pub impl : Fork[Stack] = safe duplicate;
@@ -104,18 +104,32 @@ pub mod Stack {
 
   use #root::data::Iterator;
 
-  pub fn .top(&Stack((present, frame), _)) -> Option[&Frame] {
-    if present {
-      Some(&frame)
-    }
+  pub fn .top(&Stack(entry, _)) -> Option[Frame] {
+    entry.get()
   }
 
   pub impl : Iterator[Stack, Frame] {
-    fn advance(Stack((present, frame), rest)) -> Option[(Frame, Stack)] {
-      if present {
+    fn advance(Stack(entry, rest)) -> Option[(Frame, Stack)] {
+      if entry.get() is Some(frame) {
         Some(frame, rest)
       }
     }
+  }
+}
+
+struct Lazy[T](~Request[T]);
+enum Request[T] {
+  Get(~T),
+}
+
+mod Lazy {
+  pub impl fork[T]: Fork[Lazy[T]] = safe duplicate;
+  pub impl drop[T]: Drop[Lazy[T]] = safe erase;
+
+  pub fn .get[T](Lazy[T](~request)) -> T {
+    let value;
+    request = Request::Get(~value);
+    value
   }
 }
 

--- a/tests/snaps/programs/div_by_zero/stats
+++ b/tests/snaps/programs/div_by_zero/stats
@@ -4,15 +4,15 @@ Error: the net did not return its `IO` handle
 Error: a linear extrinsic was erased
 
 Interactions
-  Total                3_545
-  Annihilate           2_111
-  Commute                 19
-  Copy                   260
-  Erase                  243
-  Graft                  257
-  Extrinsic              655
+  Total                2_011
+  Annihilate             968
+  Commute                 12
+  Copy                   305
+  Erase                  242
+  Graft                  122
+  Extrinsic              362
 
 Memory
-  Heap                 6_160 B
-  Allocated           84_656 B
-  Freed               84_656 B
+  Heap                 4_608 B
+  Allocated           42_832 B
+  Freed               42_832 B

--- a/tests/snaps/programs/iterator_party/stats
+++ b/tests/snaps/programs/iterator_party/stats
@@ -1,14 +1,14 @@
 
 Interactions
-  Total            1_323_839
-  Annihilate         723_051
-  Commute             20_091
-  Copy               139_851
-  Erase              103_779
-  Graft               92_637
-  Extrinsic          244_430
+  Total            1_290_951
+  Annihilate         671_402
+  Commute                807
+  Copy               186_824
+  Erase              142_214
+  Graft               82_492
+  Extrinsic          207_212
 
 Memory
-  Heap             2_349_504 B
-  Allocated       30_503_696 B
-  Freed           30_503_696 B
+  Heap             1_635_216 B
+  Allocated       28_357_280 B
+  Freed           28_357_280 B

--- a/tests/snaps/programs/option_party/stats
+++ b/tests/snaps/programs/option_party/stats
@@ -4,15 +4,15 @@ Error: the net did not return its `IO` handle
 Error: a linear extrinsic was erased
 
 Interactions
-  Total               20_745
-  Annihilate          12_670
-  Commute                 21
-  Copy                 1_206
-  Erase                1_787
-  Graft                1_617
-  Extrinsic            3_444
+  Total               23_283
+  Annihilate          11_374
+  Commute                 14
+  Copy                 3_822
+  Erase                3_494
+  Graft                1_464
+  Extrinsic            3_115
 
 Memory
-  Heap                34_544 B
-  Allocated          489_120 B
-  Freed              489_120 B
+  Heap                36_208 B
+  Allocated          482_816 B
+  Freed              482_816 B

--- a/vine/src/backend.rs
+++ b/vine/src/backend.rs
@@ -148,10 +148,12 @@ pub fn optimizations<'r>(vi: &'r Guide, table: &mut Table) -> impl use<'r> + Reg
   let vi_x = [vi.tuple, vi.fn_, vi.dbg, vi.ref_, vi.interface];
   (
     graft(vi.graft, false),
-    graft(vi.graft_lazy, true),
     annihilate([vi.dup].into_iter().chain(vi_x)),
-    commute([vi.dup], [vi.eraser, vi.tuple].into_iter().chain(vi_data)),
-    erase([vi.eraser].into_iter().chain(vi_x), [vi.eraser].into_iter().chain(vi_data).chain(vi_x)),
+    commute([vi.dup], [vi.eraser, vi.tuple, vi.enum_match].into_iter().chain(vi_data)),
+    erase(
+      [vi.eraser].into_iter().chain(vi_x),
+      [vi.eraser, vi.enum_match].into_iter().chain(vi_data).chain(vi_x),
+    ),
     eta_reduce(vi_x, [vi.eraser], vi_x),
     Interaction([(vi.bool, vi.bool_if)], move |engine, _, net, bool, cond| {
       let value = engine.name(bool).payload.as_u32().unwrap() != 0;
@@ -188,7 +190,7 @@ pub fn vi_to_ivm<'r>(vi: &'r Guide, ivm: &'r IvmGuide) -> impl Register<Translat
     chain_binary([ivm.x, ivm.y]),
     elide_unary([ivm.x, ivm.y]),
     replace_nilary([ivm.x, ivm.y, vi.eraser], ivm.eraser),
-    replace_path([vi.graft, vi.graft_lazy], ivm.graft),
+    replace_path([vi.graft], ivm.graft),
     replace_path([vi.n32, vi.bool], ivm.n32),
     replace_path([vi.f32], ivm.f32),
     map_name([vi.bool_if], move |_, name| {

--- a/vine/src/compiler.rs
+++ b/vine/src/compiler.rs
@@ -13,7 +13,7 @@ use crate::{
     analyzer::analyze,
     charter::Charter,
     distiller::Distiller,
-    emitter::{emit, main_net},
+    emitter::{emit, insert_main_net},
     finder::FinderCache,
     loader::{FileId, Module},
     normalizer::normalize,
@@ -213,11 +213,8 @@ impl Compiler {
     entrypoint: FragmentId,
     translator: &Translator<'_>,
   ) {
-    let entrypoint = self.entrypoint_name(table, entrypoint);
-    let main = table.add_path_name("iv:main");
-    let mut net = main_net(self.debug, entrypoint, &Guide::build(table));
-    translator.translate(table, &mut net);
-    nets.insert(main, net);
+    let name = self.entrypoint_name(table, entrypoint);
+    insert_main_net(self.debug, table, nets, name, translator);
   }
 }
 
@@ -250,7 +247,6 @@ guide!(pub Guide {
   dbg: PathId = "vi:dbg",
   fn_: PathId = "vi:fn",
   graft: PathId = "vi:graft",
-  graft_lazy: PathId = "vi:graft:lazy",
   black_box: PathId = "iv:black_box",
 
   n32_and: NameId = "vi:n32:and",
@@ -298,6 +294,7 @@ guide!(pub Guide {
   synthetic_const_alias: PathId = "vi:synthetic:const_alias",
   synthetic_call_fn: PathId = "vi:synthetic:call_fn",
   synthetic_frame: PathId = "vi:synthetic:frame",
+  synthetic_frame_end: NameId = "vi:synthetic:frame_end",
   synthetic_debug_state: PathId = "vi:synthetic:debug_state",
   synthetic_n32: PathId = "vi:synthetic:n32",
   synthetic_string: PathId = "vi:synthetic:string",

--- a/vine/src/components/emitter.rs
+++ b/vine/src/components/emitter.rs
@@ -1,14 +1,18 @@
-use std::{collections::BTreeMap, mem::take};
+use std::{
+  collections::{BTreeMap, HashMap},
+  mem::take,
+};
 
 use ivy::{
-  name::{NameId, Table},
+  name::{FromTable, NameId, Table},
   net::{FlatNet, Wire},
+  translate::Translator,
 };
 use vine_util::idx::IdxVec;
 
 use crate::{
   compiler::Guide,
-  features::{debug::main_net_debug, enum_::enum_name, local::LocalEmissionState},
+  features::{debug::insert_main_net_debug, enum_::enum_name, local::LocalEmissionState},
   structures::{
     chart::Chart,
     resolutions::{ConstRelId, FnRelId, Fragment},
@@ -309,18 +313,26 @@ impl<'a> Emitter<'a> {
   }
 }
 
-pub(crate) fn main_net(debug: bool, main: NameId, guide: &Guide) -> FlatNet {
+pub(crate) fn insert_main_net(
+  debug: bool,
+  table: &mut Table,
+  nets: &mut HashMap<NameId, FlatNet>,
+  entrypoint: NameId,
+  translator: &Translator<'_>,
+) {
   if debug {
-    main_net_debug(main, guide)
+    insert_main_net_debug(table, nets, entrypoint, translator);
   } else {
+    let guide = Guide::build(table);
     let mut net = FlatNet::default();
     let [io0, io1] = net.wires();
     let free = net.make(guide.tuple, [io0, io1]);
     net.free.push(free);
-    let main = net.make(guide.graft.with_children([main]), []);
+    let main = net.make(guide.graft.with_children([entrypoint]), []);
     let ref_ = net.make(guide.ref_, [io0, io1]);
     let nil = net.make(guide.tuple, []);
     net.add(guide.fn_, main, [ref_, nil]);
-    net
+    translator.translate(table, &mut net);
+    nets.insert(guide.main, net);
   }
 }

--- a/vine/src/components/synthesizer.rs
+++ b/vine/src/components/synthesizer.rs
@@ -246,9 +246,10 @@ impl Synthesizer<'_> {
     let line = self.net.make(self.guide.n32.with_payload(pos.line as u32 + 1), []);
     let col = self.net.make(self.guide.n32.with_payload(pos.col as u32 + 1), []);
     let frame = self.net.make(self.guide.tuple, [col, file, line, path]);
-    let continuation = self.net.make(self.guide.n32.with_payload(1u32), []);
-    let entry = self.net.make(self.guide.tuple, [continuation, frame]);
-    self.net.free.push(entry);
+    let option = self.enum_(self.chart.builtins.option.unwrap(), VariantId(1), frame);
+    let nil = self.net.make(self.guide.tuple, []);
+    let root = self.net.make(self.guide.interface, [option, nil]);
+    self.net.free.push(root);
   }
 
   fn synthesize_debug_state(&mut self) {

--- a/vine/src/features/debug.rs
+++ b/vine/src/features/debug.rs
@@ -1,8 +1,9 @@
-use std::mem::replace;
+use std::{collections::HashMap, mem::replace};
 
 use ivy::{
-  name::NameId,
+  name::{FromTable, NameId, Table},
   net::{FlatNet, Wire},
+  translate::Translator,
 };
 use vine_util::nat::Nat;
 
@@ -42,8 +43,10 @@ impl Emitter<'_> {
       self.net.wires();
     let dbg_in = replace(&mut self.debug_state.as_mut().unwrap().0, dbg_out);
     self.net.add(self.guide.tuple, dbg_in, [io_in, stack_in]);
+    let enum_ = self.table.add_name(self.guide.enum_.with_payload(1u32));
     let frame_name = self.table.add_name(frame_name);
-    let frame_in = self.net.make(self.guide.graft_lazy.with_children([frame_name]), []);
+    let nil = self.net.make(self.guide.tuple, []);
+    let frame_in = self.net.make(self.guide.enum_match.with_children([enum_, frame_name]), [nil]);
     let new_stack_in = self.net.make(self.guide.tuple, [frame_in, stack_in]);
     let new_dbg_in = self.net.make(self.guide.tuple, [io_in, new_stack_in]);
     let ref_ = self.net.make(self.guide.ref_, [new_dbg_in, new_dbg_out]);
@@ -67,7 +70,24 @@ impl Emitter<'_> {
   }
 }
 
-pub(crate) fn main_net_debug(main: NameId, guide: &Guide) -> FlatNet {
+pub(crate) fn insert_main_net_debug(
+  table: &mut Table,
+  nets: &mut HashMap<NameId, FlatNet>,
+  entrypoint: NameId,
+  translator: &Translator<'_>,
+) {
+  let guide = Guide::build(table);
+
+  let mut net = <FlatNet>::default();
+  let nil = net.make(guide.tuple, []);
+  let enum_ = table.add_name(guide.enum_.with_payload(1u32));
+  let option = net.make(guide.enum_variant.with_payload(0u32).with_children([enum_]), [nil]);
+  let nil = net.make(guide.tuple, []);
+  let root = net.make(guide.interface, [option, nil]);
+  net.free.push(root);
+  translator.translate(table, &mut net);
+  nets.insert(guide.synthetic_frame_end, net);
+
   let mut net = FlatNet::default();
   let [io_in, io_out, main_io_in, main_io_out, dbg_io_in, dbg_io_out] = net.wires();
   let free = net.make(guide.tuple, [io_in, io_out]);
@@ -78,11 +98,11 @@ pub(crate) fn main_net_debug(main: NameId, guide: &Guide) -> FlatNet {
   net.add(merge, main_io_out, [dbg_io_out, io_out]);
   let dbg_state_ref = {
     let stack_in = {
-      let zero = net.make(guide.n32.with_payload(0u32), []);
+      let enum_ = table.add_name(guide.enum_.with_payload(1u32));
+      let nil = net.make(guide.tuple, []);
+      let end = net.make(guide.enum_match.with_children([enum_, guide.synthetic_frame_end]), [nil]);
       let eraser = net.make(guide.eraser, []);
-      let sentinel = net.make(guide.tuple, [zero, eraser]);
-      let eraser = net.make(guide.eraser, []);
-      net.make(guide.tuple, [sentinel, eraser])
+      net.make(guide.tuple, [end, eraser])
     };
     let dbg_state_in = net.make(guide.tuple, [dbg_io_in, stack_in]);
     let stack_out = net.make(guide.eraser, []);
@@ -90,11 +110,12 @@ pub(crate) fn main_net_debug(main: NameId, guide: &Guide) -> FlatNet {
     net.make(guide.ref_, [dbg_state_in, dbg_state_out])
   };
   let main_io_ref = net.make(guide.ref_, [main_io_in, main_io_out]);
-  let main = net.make(guide.graft.with_children([main]), []);
+  let main = net.make(guide.graft.with_children([entrypoint]), []);
   let nil = net.make(guide.tuple, []);
   let call = net.make(guide.fn_, [main_io_ref, nil]);
   net.add(guide.dbg, main, [dbg_state_ref, call]);
-  net
+  translator.translate(table, &mut net);
+  nets.insert(guide.main, net);
 }
 
 pub(crate) fn frame_data(path: &str, span: Span) -> Nat {


### PR DESCRIPTION
Previously, Vine relied on graft nodes (aka global nodes) being lazy, in the sense that they would only expand if they interacted with a non-eraser node. With #545, this was largely removed, with the exception of debug mode, which used them to avoid having the stack be excessively large. This replaces the usage of these vestigial `vi:graft:lazy` nodes with a univariant enum match, which accomplishes a similar function. Thus, all current usage of `vi:graft` nodes can be eagerly expanded (and indeed, this is done by the optimizer).