### PR TITLE
vine: use two free ports in match branches

### DIFF
--- a/ivy/src/translate.rs
+++ b/ivy/src/translate.rs
@@ -1,21 +1,27 @@
-use std::{collections::HashMap, rc::Rc};
+use std::{collections::HashMap, mem::take, rc::Rc};
 
 use vine_util::{idx::Counter, new_idx, register::Register};
 
 use crate::{
   name::{NameId, PathId, Table},
-  net::{FlatNet, FlatNode},
+  net::{FlatNet, FlatNode, Wire},
 };
 
 pub mod common;
 
 new_idx!(RuleId);
 
-#[derive(Default)]
+#[allow(clippy::type_complexity)]
 pub struct Translator<'a> {
   rule_id: Counter<RuleId>,
-  #[allow(clippy::type_complexity)]
   rules: HashMap<PathId, Vec<(RuleId, Rc<dyn Fn(FlatNode, &mut Table, &mut FlatNet) + 'a>)>>,
+  free: Vec<(RuleId, Box<dyn Fn(Vec<Wire>, &mut Table, &mut FlatNet) + 'a>)>,
+}
+
+impl Default for Translator<'_> {
+  fn default() -> Self {
+    Self { rule_id: Counter(RuleId(1)), rules: HashMap::new(), free: Vec::new() }
+  }
 }
 
 impl<'a> Translator<'a> {
@@ -29,7 +35,7 @@ impl<'a> Translator<'a> {
     rules.register(self);
   }
 
-  pub fn register_one(
+  fn register_rule(
     &mut self,
     paths: impl IntoIterator<Item = PathId>,
     rule: impl Fn(FlatNode, &mut Table, &mut FlatNet) + 'a,
@@ -41,10 +47,22 @@ impl<'a> Translator<'a> {
     }
   }
 
+  fn register_free(&mut self, rule: impl Fn(Vec<Wire>, &mut Table, &mut FlatNet) + 'a) {
+    let id = self.rule_id.next();
+    let rule = Box::new(rule);
+    self.free.push((id, rule));
+  }
+
   pub fn translate(&self, table: &mut Table, net: &mut FlatNet) {
     let mut final_nodes = Vec::with_capacity(net.nodes.len());
     for _ in 0..net.nodes.len() {
       self.apply(table, net, &mut final_nodes, RuleId(0));
+    }
+    for (id, rule) in &self.free {
+      rule(take(&mut net.free), table, net);
+      for _ in 0..net.nodes.len() {
+        self.apply(table, net, &mut final_nodes, *id)
+      }
     }
     assert!(net.nodes.is_empty());
     net.nodes = final_nodes;
@@ -64,12 +82,12 @@ impl<'a> Translator<'a> {
   ) {
     let node = net.nodes.pop().unwrap();
     if let Some(rules) = self.rules.get(&node.name.path)
-      && let Some((id, rule)) = rules.iter().find(|&&(id, _)| id >= base_rule)
+      && let Some((id, rule)) = rules.iter().find(|&&(id, _)| id > base_rule)
     {
       let base_node = net.nodes.len();
       rule(node, table, net);
       for _ in 0..(net.nodes.len() - base_node) {
-        self.apply(table, net, final_nodes, RuleId(id.0 + 1));
+        self.apply(table, net, final_nodes, *id);
       }
     } else {
       final_nodes.push(node);
@@ -87,6 +105,16 @@ impl<'a, I: IntoIterator<Item = PathId>, F: Fn(FlatNode, &mut Table, &mut FlatNe
 {
   fn register(self, translator: &mut Translator<'a>) {
     let Translate(paths, f) = self;
-    translator.register_one(paths, f);
+    translator.register_rule(paths, f);
+  }
+}
+
+pub struct TranslateFree<F: Fn(Vec<Wire>, &mut Table, &mut FlatNet)>(pub F);
+
+impl<'a, F: Fn(Vec<Wire>, &mut Table, &mut FlatNet) + 'a> Register<Translator<'a>>
+  for TranslateFree<F>
+{
+  fn register(self, registry: &mut Translator<'a>) {
+    registry.register_free(self.0);
   }
 }

--- a/vine/src/backend.rs
+++ b/vine/src/backend.rs
@@ -17,7 +17,7 @@ use ivy::{
   net::FlatNet,
   prune::prune,
   translate::{
-    Translate, Translator,
+    Translate, TranslateFree, Translator,
     common::{chain_binary, elide_unary, map_name, replace_name, replace_nilary, replace_path},
   },
 };
@@ -172,11 +172,9 @@ pub fn optimizations<'r>(vi: &'r Guide, table: &mut Table) -> impl use<'r> + Reg
       let [pri, content] = engine.remove_node_n(variant);
       let [pri_, ctx] = engine.remove_node_n(match_);
       engine.remove_wire(pri, pri_);
-      let [interface, content_, ctx_] = engine.insert_node_n(net, vi.interface.into());
-      let [graft] = engine.insert_node_n(net, vi.graft.with_children([graft_name]));
+      let [content_, ctx_] = engine.insert_node_n(net, vi.graft.with_children([graft_name]));
       engine.link(content, content_);
       engine.link(ctx, ctx_);
-      engine.link(graft, interface);
       true
     }),
     arithmetic(vi, table),
@@ -209,6 +207,14 @@ pub fn vi_to_ivm<'r>(vi: &'r Guide, ivm: &'r IvmGuide) -> impl Register<Translat
       net.add(ivm.x, enum_, [tag, content]);
       let ctx = net.make(ivm.x, [content, ctx]);
       net.add(ivm.branch.with_children(branches), tag, [ctx]);
+    }),
+    TranslateFree(move |free, _, net| {
+      if free.len() == 2 {
+        let free = net.make(ivm.x, free);
+        net.free = vec![free];
+      } else {
+        net.free = free;
+      }
     }),
     Translate([ivm.branch], move |node, _, net| {
       let [ctx] = *node.aux else { unreachable!() };

--- a/vine/src/components/emitter.rs
+++ b/vine/src/components/emitter.rs
@@ -69,8 +69,7 @@ impl<'a> Emitter<'a> {
     (interface.incoming != 0 && !interface.inline()).then(|| {
       self.wire_offset = 0;
       self.net.wires.0.0 = stage.wires.0.0;
-      let root = self.emit_header(&stage.header, interface);
-      self.net.free.push(root);
+      self.emit_header(&stage.header, interface);
       self._emit_stage(stage);
       for (local, state) in take(&mut self.locals) {
         self.finish_local(&self.vir.locals[local], state);
@@ -261,26 +260,30 @@ impl<'a> Emitter<'a> {
     }
   }
 
-  fn emit_header(&mut self, header: &Header, interface: &Interface) -> Wire {
+  fn emit_header(&mut self, header: &Header, interface: &Interface) {
     match header {
       Header::Const(port) => {
         let port = self.emit_port(port);
-        self.with_debug(port)
+        let root = self.with_debug(port);
+        self.net.free.push(root);
       }
       Header::Fn(params, result) => {
         let wires = params.iter().chain([result]).map(|i| self.emit_port(i)).collect::<Vec<_>>();
         let func = self.net.make(self.guide.fn_, wires);
-        self.with_debug(func)
+        let root = self.with_debug(func);
+        self.net.free.push(root);
       }
       Header::Bare => {
         let interface = self.emit_interface(interface, false);
-        self.with_debug(interface)
+        let root = self.with_debug(interface);
+        self.net.free.push(root);
       }
       Header::Match(_, _, data) => {
         let interface = self.emit_interface(interface, false);
         let data = self.emit_port(data);
         let ctx = self.with_debug(interface);
-        self.net.make(self.guide.interface, [data, ctx])
+        self.net.free.push(data);
+        self.net.free.push(ctx);
       }
       Header::Closure(params, result) => {
         let interface = self.emit_interface(interface, false);
@@ -288,7 +291,8 @@ impl<'a> Emitter<'a> {
         let result = self.emit_port(result);
         let tuple = self.net.make(self.guide.tuple, params);
         let func = self.net.make(self.guide.fn_, [interface, tuple, result]);
-        self.with_debug(func)
+        let root = self.with_debug(func);
+        self.net.free.push(root);
       }
       Header::Fork(former, latter) => {
         let interface = self.emit_interface(interface, false);
@@ -296,18 +300,21 @@ impl<'a> Emitter<'a> {
         let latter = self.emit_port(latter);
         let ref_ = self.net.make(self.guide.ref_, [interface, latter]);
         let func = self.net.make(self.guide.fn_, [ref_, former]);
-        self.with_debug(func)
+        let root = self.with_debug(func);
+        self.net.free.push(root);
       }
       Header::Drop => {
         let interface = self.emit_interface(interface, false);
         let nil = self.net.make(self.guide.tuple, []);
         let func = self.net.make(self.guide.fn_, [interface, nil]);
-        self.with_debug(func)
+        let root = self.with_debug(func);
+        self.net.free.push(root);
       }
       Header::Entry(ports) => {
         let ports = ports.iter().map(|p| self.emit_port(p)).collect::<Vec<_>>();
         let interface = self.net.make(self.guide.interface, ports);
-        self.with_debug(interface)
+        let root = self.with_debug(interface);
+        self.net.free.push(root);
       }
     }
   }

--- a/vine/src/components/synthesizer.rs
+++ b/vine/src/components/synthesizer.rs
@@ -248,8 +248,8 @@ impl Synthesizer<'_> {
     let frame = self.net.make(self.guide.tuple, [col, file, line, path]);
     let option = self.enum_(self.chart.builtins.option.unwrap(), VariantId(1), frame);
     let nil = self.net.make(self.guide.tuple, []);
-    let root = self.net.make(self.guide.interface, [option, nil]);
-    self.net.free.push(root);
+    self.net.free.push(option);
+    self.net.free.push(nil);
   }
 
   fn synthesize_debug_state(&mut self) {
@@ -298,8 +298,8 @@ impl Synthesizer<'_> {
       .map(|i| {
         self.stage(|self_| {
           let [content, ctx] = self_.net.wires();
-          let free = self_.net.make(self_.guide.interface, [content, ctx]);
-          self_.net.free.push(free);
+          self_.net.free.push(content);
+          self_.net.free.push(ctx);
           arm(self_, i, content, ctx)
         })
       })

--- a/vine/src/features/debug.rs
+++ b/vine/src/features/debug.rs
@@ -83,8 +83,8 @@ pub(crate) fn insert_main_net_debug(
   let enum_ = table.add_name(guide.enum_.with_payload(1u32));
   let option = net.make(guide.enum_variant.with_payload(0u32).with_children([enum_]), [nil]);
   let nil = net.make(guide.tuple, []);
-  let root = net.make(guide.interface, [option, nil]);
-  net.free.push(root);
+  net.free.push(option);
+  net.free.push(nil);
   translator.translate(table, &mut net);
   nets.insert(guide.synthetic_frame_end, net);
 


### PR DESCRIPTION
This changes Vine ivy to expect match branch nets to have two free ports (first for content; second for context) instead of one with a `vi:interface` node.

Based on #561 