### PR TITLE
vine: swap content and ctx free ports in match headers

### DIFF
--- a/tests/snaps/aoc_2024/day_01/stats
+++ b/tests/snaps/aoc_2024/day_01/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic            2_587
 
 Parallelism
-  Depth                3_234
+  Depth                3_225
   Breadth                  3
-  Speedup                 56 cB
+  Speedup                 57 cB
 
 Memory
-  Heap                16_512 B
-  Allocated          260_704 B
-  Freed              260_704 B
+  Heap                16_864 B
+  Allocated          259_168 B
+  Freed              259_168 B

--- a/tests/snaps/aoc_2024/day_02/stats
+++ b/tests/snaps/aoc_2024/day_02/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic            4_328
 
 Parallelism
-  Depth                5_416
+  Depth                5_391
   Breadth                  3
   Speedup                 57 cB
 
 Memory
-  Heap                14_464 B
-  Allocated          443_088 B
-  Freed              443_088 B
+  Heap                14_928 B
+  Allocated          441_264 B
+  Freed              441_264 B

--- a/tests/snaps/aoc_2024/day_03/stats
+++ b/tests/snaps/aoc_2024/day_03/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic            5_214
 
 Parallelism
-  Depth                7_530
+  Depth                7_526
   Breadth                  3
   Speedup                 52 cB
 
 Memory
-  Heap                11_424 B
-  Allocated          562_048 B
-  Freed              562_048 B
+  Heap                11_760 B
+  Allocated          561_568 B
+  Freed              561_568 B

--- a/tests/snaps/aoc_2024/day_04/stats
+++ b/tests/snaps/aoc_2024/day_04/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic            8_631
 
 Parallelism
-  Depth                1_990
+  Depth                1_982
   Breadth                 20
   Speedup                131 cB
 
 Memory
-  Heap               113_328 B
-  Allocated          839_456 B
-  Freed              839_456 B
+  Heap               114_144 B
+  Allocated          839_200 B
+  Freed              839_200 B

--- a/tests/snaps/aoc_2024/day_05/stats
+++ b/tests/snaps/aoc_2024/day_05/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic           11_601
 
 Parallelism
-  Depth                4_502
+  Depth                4_494
   Breadth                 10
   Speedup                100 cB
 
 Memory
-  Heap                34_304 B
-  Allocated          945_392 B
-  Freed              945_392 B
+  Heap                35_312 B
+  Allocated          944_432 B
+  Freed              944_432 B

--- a/tests/snaps/aoc_2024/day_06/stats
+++ b/tests/snaps/aoc_2024/day_06/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic          168_625
 
 Parallelism
-  Depth               58_594
+  Depth               58_584
   Breadth                 11
   Speedup                106 cB
 
 Memory
-  Heap               273_216 B
-  Allocated       14_510_336 B
-  Freed           14_510_336 B
+  Heap               271_904 B
+  Allocated       14_507_392 B
+  Freed           14_507_392 B

--- a/tests/snaps/aoc_2024/day_07/stats
+++ b/tests/snaps/aoc_2024/day_07/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic            7_604
 
 Parallelism
-  Depth                3_354
+  Depth                3_371
   Breadth                  9
   Speedup                 97 cB
 
 Memory
-  Heap                20_896 B
-  Allocated          681_056 B
-  Freed              681_056 B
+  Heap                22_336 B
+  Allocated          683_376 B
+  Freed              683_376 B

--- a/tests/snaps/aoc_2024/day_08/stats
+++ b/tests/snaps/aoc_2024/day_08/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic            8_875
 
 Parallelism
-  Depth               17_379
+  Depth               17_367
   Breadth                  2
   Speedup                 44 cB
 
 Memory
-  Heap                22_528 B
-  Allocated        1_079_984 B
-  Freed            1_079_984 B
+  Heap                24_128 B
+  Allocated        1_079_488 B
+  Freed            1_079_488 B

--- a/tests/snaps/aoc_2024/day_09/stats
+++ b/tests/snaps/aoc_2024/day_09/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic            1_507
 
 Parallelism
-  Depth                1_108
+  Depth                1_100
   Breadth                  5
   Speedup                 72 cB
 
 Memory
-  Heap                14_672 B
-  Allocated          130_496 B
-  Freed              130_496 B
+  Heap                13_808 B
+  Allocated          129_408 B
+  Freed              129_408 B

--- a/tests/snaps/aoc_2024/day_10/stats
+++ b/tests/snaps/aoc_2024/day_10/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic            4_637
 
 Parallelism
-  Depth                4_909
+  Depth                4_890
   Breadth                  5
   Speedup                 73 cB
 
 Memory
-  Heap                59_520 B
-  Allocated          564_896 B
-  Freed              564_896 B
+  Heap                58_496 B
+  Allocated          564_432 B
+  Freed              564_432 B

--- a/tests/snaps/aoc_2024/day_11/stats
+++ b/tests/snaps/aoc_2024/day_11/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic        1_008_980
 
 Parallelism
-  Depth            2_053_805
+  Depth            2_053_804
   Breadth                  2
   Speedup                 35 cB
 
 Memory
-  Heap               115_904 B
-  Allocated      103_837_616 B
-  Freed          103_837_616 B
+  Heap               115_072 B
+  Allocated      103_823_792 B
+  Freed          103_823_792 B

--- a/tests/snaps/aoc_2024/day_12/stats
+++ b/tests/snaps/aoc_2024/day_12/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic           52_235
 
 Parallelism
-  Depth               47_004
+  Depth               47_003
   Breadth                  4
   Speedup                 62 cB
 
 Memory
-  Heap                87_584 B
-  Allocated        4_063_200 B
-  Freed            4_063_200 B
+  Heap                87_520 B
+  Allocated        4_061_216 B
+  Freed            4_061_216 B

--- a/tests/snaps/aoc_2024/day_13/stats
+++ b/tests/snaps/aoc_2024/day_13/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic           12_095
 
 Parallelism
-  Depth               19_402
+  Depth               19_401
   Breadth                  2
   Speedup                 44 cB
 
 Memory
-  Heap                42_928 B
-  Allocated        1_200_816 B
-  Freed            1_200_816 B
+  Heap                43_312 B
+  Allocated        1_200_592 B
+  Freed            1_200_592 B

--- a/tests/snaps/aoc_2024/day_14/stats
+++ b/tests/snaps/aoc_2024/day_14/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic            4_545
 
 Parallelism
-  Depth                2_998
+  Depth                2_996
   Breadth                  6
   Speedup                 81 cB
 
 Memory
-  Heap                13_792 B
-  Allocated          415_856 B
-  Freed              415_856 B
+  Heap                13_776 B
+  Allocated          415_552 B
+  Freed              415_552 B

--- a/tests/snaps/aoc_2024/day_15/stats
+++ b/tests/snaps/aoc_2024/day_15/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic          254_659
 
 Parallelism
-  Depth              223_449
+  Depth              222_880
   Breadth                  4
   Speedup                 62 cB
 
 Memory
-  Heap             1_639_232 B
-  Allocated       19_100_400 B
-  Freed           19_100_400 B
+  Heap             1_587_744 B
+  Allocated       19_084_912 B
+  Freed           19_084_912 B

--- a/tests/snaps/aoc_2024/day_16/stats
+++ b/tests/snaps/aoc_2024/day_16/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic          224_968
 
 Parallelism
-  Depth              229_142
+  Depth              229_356
   Breadth                  4
   Speedup                 61 cB
 
 Memory
-  Heap               330_464 B
-  Allocated       19_768_080 B
-  Freed           19_768_080 B
+  Heap               306_624 B
+  Allocated       19_771_136 B
+  Freed           19_771_136 B

--- a/tests/snaps/aoc_2024/day_17/stats
+++ b/tests/snaps/aoc_2024/day_17/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic            4_388
 
 Parallelism
-  Depth                8_443
+  Depth                8_438
   Breadth                  2
   Speedup                 34 cB
 
 Memory
-  Heap                 8_512 B
-  Allocated          403_120 B
-  Freed              403_120 B
+  Heap                 8_608 B
+  Allocated          402_592 B
+  Freed              402_592 B

--- a/tests/snaps/aoc_2024/day_18/stats
+++ b/tests/snaps/aoc_2024/day_18/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic           33_102
 
 Parallelism
-  Depth               14_346
+  Depth               14_352
   Breadth                  8
   Speedup                 94 cB
 
 Memory
-  Heap                41_392 B
-  Allocated        2_595_984 B
-  Freed            2_595_984 B
+  Heap                41_536 B
+  Allocated        2_595_216 B
+  Freed            2_595_216 B

--- a/tests/snaps/aoc_2024/day_19/stats
+++ b/tests/snaps/aoc_2024/day_19/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic            8_867
 
 Parallelism
-  Depth                2_280
+  Depth                2_272
   Breadth                 24
   Speedup                139 cB
 
 Memory
-  Heap               160_208 B
-  Allocated        1_190_944 B
-  Freed            1_190_944 B
+  Heap               161_104 B
+  Allocated        1_185_328 B
+  Freed            1_185_328 B

--- a/tests/snaps/aoc_2024/day_20/stats
+++ b/tests/snaps/aoc_2024/day_20/stats
@@ -14,6 +14,6 @@ Parallelism
   Speedup                120 cB
 
 Memory
-  Heap               237_104 B
-  Allocated        7_404_864 B
-  Freed            7_404_864 B
+  Heap               240_304 B
+  Allocated        7_404_544 B
+  Freed            7_404_544 B

--- a/tests/snaps/aoc_2024/day_21/stats
+++ b/tests/snaps/aoc_2024/day_21/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic          380_945
 
 Parallelism
-  Depth                3_032
-  Breadth                444
+  Depth                3_027
+  Breadth                445
   Speedup                265 cB
 
 Memory
-  Heap             2_910_144 B
-  Allocated       27_267_872 B
-  Freed           27_267_872 B
+  Heap             2_915_200 B
+  Allocated       27_254_496 B
+  Freed           27_254_496 B

--- a/tests/snaps/aoc_2024/day_22/stats
+++ b/tests/snaps/aoc_2024/day_22/stats
@@ -14,6 +14,6 @@ Parallelism
   Speedup                 32 cB
 
 Memory
-  Heap             4_534_064 B
-  Allocated      162_352_672 B
-  Freed          162_352_672 B
+  Heap             4_451_392 B
+  Allocated      162_464_128 B
+  Freed          162_464_128 B

--- a/tests/snaps/aoc_2024/day_23/stats
+++ b/tests/snaps/aoc_2024/day_23/stats
@@ -14,6 +14,6 @@ Parallelism
   Speedup                 66 cB
 
 Memory
-  Heap                27_488 B
-  Allocated          933_136 B
-  Freed              933_136 B
+  Heap                27_424 B
+  Allocated          932_480 B
+  Freed              932_480 B

--- a/tests/snaps/aoc_2024/day_24/stats
+++ b/tests/snaps/aoc_2024/day_24/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic           38_449
 
 Parallelism
-  Depth               53_813
+  Depth               53_800
   Breadth                  3
   Speedup                 54 cB
 
 Memory
-  Heap                68_544 B
-  Allocated        4_181_328 B
-  Freed            4_181_328 B
+  Heap                67_456 B
+  Allocated        4_178_416 B
+  Freed            4_178_416 B

--- a/tests/snaps/aoc_2024/day_25/stats
+++ b/tests/snaps/aoc_2024/day_25/stats
@@ -14,6 +14,6 @@ Parallelism
   Speedup                 71 cB
 
 Memory
-  Heap                 7_072 B
-  Allocated          358_176 B
-  Freed              358_176 B
+  Heap                 7_136 B
+  Allocated          358_032 B
+  Freed              358_032 B

--- a/tests/snaps/examples/cat/stats
+++ b/tests/snaps/examples/cat/stats
@@ -14,6 +14,6 @@ Parallelism
   Speedup                 14 cB
 
 Memory
-  Heap                 1_232 B
-  Allocated           19_648 B
-  Freed               19_648 B
+  Heap                 1_248 B
+  Allocated           19_312 B
+  Freed               19_312 B

--- a/tests/snaps/examples/fib/stats
+++ b/tests/snaps/examples/fib/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic            3_868
 
 Parallelism
-  Depth                1_072
-  Breadth                 11
-  Speedup                107 cB
+  Depth                  898
+  Breadth                 13
+  Speedup                114 cB
 
 Memory
-  Heap                10_896 B
-  Allocated          278_208 B
-  Freed              278_208 B
+  Heap                 8_288 B
+  Allocated          271_216 B
+  Freed              271_216 B

--- a/tests/snaps/examples/fib_repl/stats
+++ b/tests/snaps/examples/fib_repl/stats
@@ -14,6 +14,6 @@ Parallelism
   Speedup                 22 cB
 
 Memory
-  Heap                 1_296 B
-  Allocated      400_158_976 B
-  Freed          400_158_976 B
+  Heap                 1_312 B
+  Allocated      400_157_904 B
+  Freed          400_157_904 B

--- a/tests/snaps/examples/fizzbuzz/stats
+++ b/tests/snaps/examples/fizzbuzz/stats
@@ -14,6 +14,6 @@ Parallelism
   Speedup                 85 cB
 
 Memory
-  Heap                 2_400 B
-  Allocated          272_944 B
-  Freed              272_944 B
+  Heap                 2_304 B
+  Allocated          267_936 B
+  Freed              267_936 B

--- a/tests/snaps/examples/guessing_game/stats
+++ b/tests/snaps/examples/guessing_game/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic            1_629
 
 Parallelism
-  Depth                3_120
+  Depth                3_117
   Breadth                  1
   Speedup                 25 cB
 
 Memory
-  Heap                 8_640 B
-  Allocated          117_776 B
-  Freed              117_776 B
+  Heap                 8_112 B
+  Allocated          115_600 B
+  Freed              115_600 B

--- a/tests/snaps/examples/hello_world/stats
+++ b/tests/snaps/examples/hello_world/stats
@@ -10,5 +10,5 @@ Interactions
 
 Memory
   Heap                   704 B
-  Allocated            6_480 B
-  Freed                6_480 B
+  Allocated            6_272 B
+  Freed                6_272 B

--- a/tests/snaps/examples/mandelbrot/stats
+++ b/tests/snaps/examples/mandelbrot/stats
@@ -14,6 +14,6 @@ Parallelism
   Speedup                263 cB
 
 Memory
-  Heap             1_284_384 B
+  Heap             1_148_160 B
   Allocated      185_122_656 B
   Freed          185_122_656 B

--- a/tests/snaps/examples/mandelbrot_sixel/stats
+++ b/tests/snaps/examples/mandelbrot_sixel/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic       60_023_736
 
 Parallelism
-  Depth              246_446
-  Breadth                612
-  Speedup                279 cB
+  Depth              174_964
+  Breadth                863
+  Speedup                294 cB
 
 Memory
-  Heap            16_524_032 B
-  Allocated    3_200_953_216 B
-  Freed        3_200_953_216 B
+  Heap            16_262_144 B
+  Allocated    3_203_826_160 B
+  Freed        3_203_826_160 B

--- a/tests/snaps/examples/mandelbrot_tga/stats
+++ b/tests/snaps/examples/mandelbrot_tga/stats
@@ -9,6 +9,6 @@ Interactions
   Extrinsic       276_824_227
 
 Memory
-  Heap             50_333_296 B
-  Allocated    14_200_233_216 B
-  Freed        14_200_233_216 B
+  Heap             16_778_944 B
+  Allocated    14_200_232_992 B
+  Freed        14_200_232_992 B

--- a/tests/snaps/examples/primeness/stats
+++ b/tests/snaps/examples/primeness/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic            4_890
 
 Parallelism
-  Depth                1_571
-  Breadth                 10
-  Speedup                102 cB
+  Depth                1_093
+  Breadth                 15
+  Speedup                118 cB
 
 Memory
-  Heap                17_536 B
-  Allocated          362_896 B
-  Freed              362_896 B
+  Heap                 8_912 B
+  Allocated          353_712 B
+  Freed              353_712 B

--- a/tests/snaps/examples/stream_primes/stats
+++ b/tests/snaps/examples/stream_primes/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic       40_551_984
 
 Parallelism
-  Depth              389_012
-  Breadth                372
-  Speedup                257 cB
+  Depth              379_041
+  Breadth                382
+  Speedup                258 cB
 
 Memory
-  Heap               209_088 B
-  Allocated    2_873_840_656 B
-  Freed        2_873_840_656 B
+  Heap               227_072 B
+  Allocated    2_781_361_584 B
+  Freed        2_781_361_584 B

--- a/tests/snaps/examples/sub_min/stats
+++ b/tests/snaps/examples/sub_min/stats
@@ -9,6 +9,6 @@ Interactions
   Extrinsic              209
 
 Memory
-  Heap                 3_648 B
-  Allocated           21_392 B
-  Freed               21_392 B
+  Heap                 3_696 B
+  Allocated           21_040 B
+  Freed               21_040 B

--- a/tests/snaps/examples/sum_divisors/stats
+++ b/tests/snaps/examples/sum_divisors/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic           13_379
 
 Parallelism
-  Depth                2_205
+  Depth                2_183
   Breadth                 19
   Speedup                129 cB
 
 Memory
-  Heap                14_800 B
-  Allocated          893_520 B
-  Freed              893_520 B
+  Heap                12_992 B
+  Allocated          880_080 B
+  Freed              880_080 B

--- a/tests/snaps/programs/array_from_list/stats
+++ b/tests/snaps/programs/array_from_list/stats
@@ -10,5 +10,5 @@ Interactions
 
 Memory
   Heap           144_000_576 B
-  Allocated      928_019_120 B
-  Freed          928_019_120 B
+  Allocated      928_019_008 B
+  Freed          928_019_008 B

--- a/tests/snaps/programs/array_order/stats
+++ b/tests/snaps/programs/array_order/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic            4_577
 
 Parallelism
-  Depth                  720
-  Breadth                 20
-  Speedup                132 cB
+  Depth                  530
+  Breadth                 28
+  Speedup                145 cB
 
 Memory
   Heap                47_808 B
-  Allocated          301_568 B
-  Freed              301_568 B
+  Allocated          298_496 B
+  Freed              298_496 B

--- a/tests/snaps/programs/array_smoothsort/stats
+++ b/tests/snaps/programs/array_smoothsort/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic            8_527
 
 Parallelism
-  Depth                8_719
+  Depth                8_709
   Breadth                  3
   Speedup                 53 cB
 
 Memory
-  Heap                14_384 B
-  Allocated          609_088 B
-  Freed              609_088 B
+  Heap                13_552 B
+  Allocated          607_296 B
+  Freed              607_296 B

--- a/tests/snaps/programs/array_to_list/stats
+++ b/tests/snaps/programs/array_to_list/stats
@@ -10,5 +10,5 @@ Interactions
 
 Memory
   Heap           192_000_448 B
-  Allocated      832_018_496 B
-  Freed          832_018_496 B
+  Allocated      832_018_384 B
+  Freed          832_018_384 B

--- a/tests/snaps/programs/basic_diverge/stats
+++ b/tests/snaps/programs/basic_diverge/stats
@@ -15,5 +15,5 @@ Parallelism
 
 Memory
   Heap                 2_368 B
-  Allocated           16_320 B
-  Freed               16_320 B
+  Allocated           15_824 B
+  Freed               15_824 B

--- a/tests/snaps/programs/become/stats
+++ b/tests/snaps/programs/become/stats
@@ -9,6 +9,6 @@ Interactions
   Extrinsic              259
 
 Memory
-  Heap                 2_944 B
-  Allocated           21_104 B
-  Freed               21_104 B
+  Heap                 1_824 B
+  Allocated           20_544 B
+  Freed               20_544 B

--- a/tests/snaps/programs/brainfuck/stats
+++ b/tests/snaps/programs/brainfuck/stats
@@ -14,6 +14,6 @@ Parallelism
   Speedup                 37 cB
 
 Memory
-  Heap                 3_232 B
+  Heap                 3_344 B
   Allocated          151_568 B
   Freed              151_568 B

--- a/tests/snaps/programs/break_result/stats
+++ b/tests/snaps/programs/break_result/stats
@@ -15,5 +15,5 @@ Parallelism
 
 Memory
   Heap                   688 B
-  Allocated            5_616 B
-  Freed                5_616 B
+  Allocated            5_440 B
+  Freed                5_440 B

--- a/tests/snaps/programs/centimanes/stats
+++ b/tests/snaps/programs/centimanes/stats
@@ -14,6 +14,6 @@ Parallelism
   Speedup                 60 cB
 
 Memory
-  Heap                19_248 B
-  Allocated          366_544 B
-  Freed              366_544 B
+  Heap                16_096 B
+  Allocated          365_968 B
+  Freed              365_968 B

--- a/tests/snaps/programs/classify_primes/stats
+++ b/tests/snaps/programs/classify_primes/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic          132_958
 
 Parallelism
-  Depth               27_577
-  Breadth                 16
-  Speedup                121 cB
+  Depth               14_834
+  Breadth                 30
+  Speedup                148 cB
 
 Memory
-  Heap               322_736 B
-  Allocated        9_713_440 B
-  Freed            9_713_440 B
+  Heap                22_912 B
+  Allocated        9_502_336 B
+  Freed            9_502_336 B

--- a/tests/snaps/programs/cli_args/stats
+++ b/tests/snaps/programs/cli_args/stats
@@ -9,6 +9,6 @@ Interactions
   Extrinsic              441
 
 Memory
-  Heap                 4_096 B
-  Allocated           39_056 B
-  Freed               39_056 B
+  Heap                 3_072 B
+  Allocated           38_640 B
+  Freed               38_640 B

--- a/tests/snaps/programs/cond_diverge/stats
+++ b/tests/snaps/programs/cond_diverge/stats
@@ -15,5 +15,5 @@ Parallelism
 
 Memory
   Heap                   800 B
-  Allocated            2_880 B
-  Freed                2_880 B
+  Allocated            2_864 B
+  Freed                2_864 B

--- a/tests/snaps/programs/configurable/stats
+++ b/tests/snaps/programs/configurable/stats
@@ -9,6 +9,6 @@ Interactions
   Extrinsic              226
 
 Memory
-  Heap                 3_632 B
-  Allocated           23_792 B
-  Freed               23_792 B
+  Heap                 3_648 B
+  Allocated           23_216 B
+  Freed               23_216 B

--- a/tests/snaps/programs/cons/stats
+++ b/tests/snaps/programs/cons/stats
@@ -10,5 +10,5 @@ Interactions
 
 Memory
   Heap                 5_920 B
-  Allocated           93_840 B
-  Freed               93_840 B
+  Allocated           92_032 B
+  Freed               92_032 B

--- a/tests/snaps/programs/cubes/stats
+++ b/tests/snaps/programs/cubes/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic          296_546
 
 Parallelism
-  Depth                9_273
-  Breadth                141
-  Speedup                215 cB
+  Depth                6_705
+  Breadth                195
+  Speedup                229 cB
 
 Memory
-  Heap             1_636_096 B
-  Allocated       27_006_848 B
-  Freed           27_006_848 B
+  Heap             1_638_208 B
+  Allocated       27_122_656 B
+  Freed           27_122_656 B

--- a/tests/snaps/programs/cyclist/stats
+++ b/tests/snaps/programs/cyclist/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic           22_754
 
 Parallelism
-  Depth                6_151
-  Breadth                 12
-  Speedup                111 cB
+  Depth                4_352
+  Breadth                 18
+  Speedup                126 cB
 
 Memory
-  Heap                72_336 B
-  Allocated        1_814_448 B
-  Freed            1_814_448 B
+  Heap                42_832 B
+  Allocated        1_783_312 B
+  Freed            1_783_312 B

--- a/tests/snaps/programs/div_by_zero/stats
+++ b/tests/snaps/programs/div_by_zero/stats
@@ -13,6 +13,6 @@ Interactions
   Extrinsic              362
 
 Memory
-  Heap                 4_608 B
-  Allocated           42_832 B
-  Freed               42_832 B
+  Heap                 3_472 B
+  Allocated           42_112 B
+  Freed               42_112 B

--- a/tests/snaps/programs/f32_ops/stats
+++ b/tests/snaps/programs/f32_ops/stats
@@ -9,6 +9,6 @@ Interactions
   Extrinsic        8_160_460
 
 Memory
-  Heap            35_557_936 B
-  Allocated      515_474_384 B
-  Freed          515_474_384 B
+  Heap            24_049_056 B
+  Allocated      503_784_096 B
+  Freed          503_784_096 B

--- a/tests/snaps/programs/f32_roundabout/stats
+++ b/tests/snaps/programs/f32_roundabout/stats
@@ -9,6 +9,6 @@ Interactions
   Extrinsic        8_388_698
 
 Memory
-  Heap             2_262_400 B
-  Allocated      753_605_024 B
-  Freed          753_605_024 B
+  Heap             2_114_112 B
+  Allocated      764_095_072 B
+  Freed          764_095_072 B

--- a/tests/snaps/programs/f64_ops/stats
+++ b/tests/snaps/programs/f64_ops/stats
@@ -9,6 +9,6 @@ Interactions
   Extrinsic       27_242_206
 
 Memory
-  Heap            61_603_680 B
-  Allocated    1_634_169_136 B
-  Freed        1_634_169_136 B
+  Heap            32_071_520 B
+  Allocated    1_613_637_056 B
+  Freed        1_613_637_056 B

--- a/tests/snaps/programs/f64_roundabout/stats
+++ b/tests/snaps/programs/f64_roundabout/stats
@@ -9,6 +9,6 @@ Interactions
   Extrinsic       91_275_683
 
 Memory
-  Heap             3_741_120 B
-  Allocated    7_668_530_144 B
-  Freed        7_668_530_144 B
+  Heap             2_882_112 B
+  Allocated    7_949_647_200 B
+  Freed        7_949_647_200 B

--- a/tests/snaps/programs/file/stats
+++ b/tests/snaps/programs/file/stats
@@ -9,6 +9,6 @@ Interactions
   Extrinsic            2_928
 
 Memory
-  Heap                 7_184 B
-  Allocated          247_216 B
-  Freed              247_216 B
+  Heap                 6_400 B
+  Allocated          242_128 B
+  Freed              242_128 B

--- a/tests/snaps/programs/final_countdown/stats
+++ b/tests/snaps/programs/final_countdown/stats
@@ -15,5 +15,5 @@ Parallelism
 
 Memory
   Heap                 2_864 B
-  Allocated           41_776 B
-  Freed               41_776 B
+  Allocated           40_576 B
+  Freed               40_576 B

--- a/tests/snaps/programs/find_primes/stats
+++ b/tests/snaps/programs/find_primes/stats
@@ -15,5 +15,5 @@ Parallelism
 
 Memory
   Heap                 1_056 B
-  Allocated       61_652_944 B
-  Freed           61_652_944 B
+  Allocated       61_577_440 B
+  Freed           61_577_440 B

--- a/tests/snaps/programs/heap/stats
+++ b/tests/snaps/programs/heap/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic          487_259
 
 Parallelism
-  Depth              371_829
+  Depth              368_864
   Breadth                  6
   Speedup                 84 cB
 
 Memory
-  Heap             1_980_800 B
-  Allocated       54_139_712 B
-  Freed           54_139_712 B
+  Heap             1_932_432 B
+  Allocated       54_027_744 B
+  Freed           54_027_744 B

--- a/tests/snaps/programs/implicit_else/stats
+++ b/tests/snaps/programs/implicit_else/stats
@@ -9,6 +9,6 @@ Interactions
   Extrinsic            6_840
 
 Memory
-  Heap                16_432 B
-  Allocated          634_736 B
-  Freed              634_736 B
+  Heap                15_920 B
+  Allocated          631_856 B
+  Freed              631_856 B

--- a/tests/snaps/programs/int_edges/stats
+++ b/tests/snaps/programs/int_edges/stats
@@ -9,6 +9,6 @@ Interactions
   Extrinsic        2_098_019
 
 Memory
-  Heap               981_680 B
-  Allocated      181_611_888 B
-  Freed          181_611_888 B
+  Heap               940_816 B
+  Allocated      182_189_504 B
+  Freed          182_189_504 B

--- a/tests/snaps/programs/inverse/stats
+++ b/tests/snaps/programs/inverse/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic              247
 
 Parallelism
-  Depth                  173
-  Breadth                  6
-  Speedup                 79 cB
+  Depth                  143
+  Breadth                  7
+  Speedup                 87 cB
 
 Memory
   Heap                 5_152 B
-  Allocated           22_560 B
-  Freed               22_560 B
+  Allocated           22_000 B
+  Freed               22_000 B

--- a/tests/snaps/programs/iterator_party/stats
+++ b/tests/snaps/programs/iterator_party/stats
@@ -9,6 +9,6 @@ Interactions
   Extrinsic          207_212
 
 Memory
-  Heap             1_635_216 B
-  Allocated       28_357_280 B
-  Freed           28_357_280 B
+  Heap               721_808 B
+  Allocated       27_848_944 B
+  Freed           27_848_944 B

--- a/tests/snaps/programs/lambda/stats
+++ b/tests/snaps/programs/lambda/stats
@@ -14,6 +14,6 @@ Parallelism
   Speedup                 35 cB
 
 Memory
-  Heap                10_544 B
-  Allocated          646_608 B
-  Freed              646_608 B
+  Heap                10_640 B
+  Allocated          645_360 B
+  Freed              645_360 B

--- a/tests/snaps/programs/lcs/stats
+++ b/tests/snaps/programs/lcs/stats
@@ -14,6 +14,6 @@ Parallelism
   Speedup                338 cB
 
 Memory
-  Heap         1_079_606_224 B
-  Allocated    5_446_249_888 B
-  Freed        5_446_249_888 B
+  Heap           864_384_320 B
+  Allocated    5_382_249_840 B
+  Freed        5_382_249_840 B

--- a/tests/snaps/programs/life/stats
+++ b/tests/snaps/programs/life/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic       14_998_347
 
 Parallelism
-  Depth              395_718
-  Breadth                203
-  Speedup                231 cB
+  Depth              361_878
+  Breadth                222
+  Speedup                235 cB
 
 Memory
-  Heap           333_293_168 B
-  Allocated    1_996_243_872 B
-  Freed        1_996_243_872 B
+  Heap           319_021_920 B
+  Allocated    1_995_634_128 B
+  Freed        1_995_634_128 B

--- a/tests/snaps/programs/log_brute/stats
+++ b/tests/snaps/programs/log_brute/stats
@@ -9,6 +9,6 @@ Interactions
   Extrinsic       56_640_424
 
 Memory
-  Heap           281_631_744 B
-  Allocated    5_181_986_048 B
-  Freed        5_181_986_048 B
+  Heap           262_403_072 B
+  Allocated    5_218_026_048 B
+  Freed        5_218_026_048 B

--- a/tests/snaps/programs/logic/stats
+++ b/tests/snaps/programs/logic/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic              608
 
 Parallelism
-  Depth                  285
-  Breadth                  8
-  Speedup                 93 cB
+  Depth                  190
+  Breadth                 12
+  Speedup                111 cB
 
 Memory
-  Heap                13_088 B
-  Allocated           53_504 B
-  Freed               53_504 B
+  Heap                12_368 B
+  Allocated           51_920 B
+  Freed               51_920 B

--- a/tests/snaps/programs/loop_break_continue/stats
+++ b/tests/snaps/programs/loop_break_continue/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic              133
 
 Parallelism
-  Depth                  109
+  Depth                  108
   Breadth                  3
-  Speedup                 51 cB
+  Speedup                 52 cB
 
 Memory
   Heap                 1_744 B
-  Allocated            6_688 B
-  Freed                6_688 B
+  Allocated            6_624 B
+  Freed                6_624 B

--- a/tests/snaps/programs/loop_vi_loop/stats
+++ b/tests/snaps/programs/loop_vi_loop/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic              699
 
 Parallelism
-  Depth                  179
-  Breadth                 12
-  Speedup                109 cB
+  Depth                  150
+  Breadth                 14
+  Speedup                116 cB
 
 Memory
-  Heap                 7_872 B
-  Allocated           44_544 B
-  Freed               44_544 B
+  Heap                 7_840 B
+  Allocated           43_888 B
+  Freed               43_888 B

--- a/tests/snaps/programs/main/stats
+++ b/tests/snaps/programs/main/stats
@@ -10,5 +10,5 @@ Interactions
 
 Memory
   Heap                   560 B
-  Allocated            2_576 B
-  Freed                2_576 B
+  Allocated            2_512 B
+  Freed                2_512 B

--- a/tests/snaps/programs/mandelbrot_f64/stats
+++ b/tests/snaps/programs/mandelbrot_f64/stats
@@ -9,6 +9,6 @@ Interactions
   Extrinsic        6_687_263
 
 Memory
-  Heap               179_008 B
+  Heap                91_072 B
   Allocated      318_569_728 B
   Freed          318_569_728 B

--- a/tests/snaps/programs/map_ops/stats
+++ b/tests/snaps/programs/map_ops/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic            7_715
 
 Parallelism
-  Depth                3_039
-  Breadth                  9
-  Speedup                 99 cB
+  Depth                2_836
+  Breadth                 10
+  Speedup                102 cB
 
 Memory
-  Heap                29_088 B
-  Allocated          648_608 B
-  Freed              648_608 B
+  Heap                28_816 B
+  Allocated          639_216 B
+  Freed              639_216 B

--- a/tests/snaps/programs/map_test/stats
+++ b/tests/snaps/programs/map_test/stats
@@ -9,6 +9,6 @@ Interactions
   Extrinsic        4_932_787
 
 Memory
-  Heap             6_887_392 B
-  Allocated      466_248_592 B
-  Freed          466_248_592 B
+  Heap             6_511_536 B
+  Allocated      467_239_632 B
+  Freed          467_239_632 B

--- a/tests/snaps/programs/maybe_set/stats
+++ b/tests/snaps/programs/maybe_set/stats
@@ -15,5 +15,5 @@ Parallelism
 
 Memory
   Heap                   768 B
-  Allocated            4_608 B
-  Freed                4_608 B
+  Allocated            4_480 B
+  Freed                4_480 B

--- a/tests/snaps/programs/n64_div_rem/stats
+++ b/tests/snaps/programs/n64_div_rem/stats
@@ -9,6 +9,6 @@ Interactions
   Extrinsic        1_360_308
 
 Memory
-  Heap             3_154_336 B
-  Allocated       82_904_176 B
-  Freed           82_904_176 B
+  Heap             2_561_872 B
+  Allocated       81_783_248 B
+  Freed           81_783_248 B

--- a/tests/snaps/programs/named_impls/stats
+++ b/tests/snaps/programs/named_impls/stats
@@ -9,6 +9,6 @@ Interactions
   Extrinsic               84
 
 Memory
-  Heap                 2_336 B
-  Allocated           10_016 B
-  Freed               10_016 B
+  Heap                 2_448 B
+  Allocated            9_872 B
+  Freed                9_872 B

--- a/tests/snaps/programs/nat_div/stats
+++ b/tests/snaps/programs/nat_div/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic        2_421_021
 
 Parallelism
-  Depth              106_313
+  Depth              106_310
   Breadth                 80
   Speedup                191 cB
 
 Memory
-  Heap             8_479_664 B
-  Allocated      184_186_544 B
-  Freed          184_186_544 B
+  Heap             8_445_952 B
+  Allocated      184_319_952 B
+  Freed          184_319_952 B

--- a/tests/snaps/programs/nat_edges/stats
+++ b/tests/snaps/programs/nat_edges/stats
@@ -9,6 +9,6 @@ Interactions
   Extrinsic       67_747_977
 
 Memory
-  Heap            53_127_648 B
-  Allocated    5_655_950_096 B
-  Freed        5_655_950_096 B
+  Heap            26_290_048 B
+  Allocated    5_672_494_224 B
+  Freed        5_672_494_224 B

--- a/tests/snaps/programs/no_return/stats
+++ b/tests/snaps/programs/no_return/stats
@@ -15,5 +15,5 @@ Parallelism
 
 Memory
   Heap                   800 B
-  Allocated            8_640 B
-  Freed                8_640 B
+  Allocated            8_352 B
+  Freed                8_352 B

--- a/tests/snaps/programs/nothing_lasts_forever/stats
+++ b/tests/snaps/programs/nothing_lasts_forever/stats
@@ -19,5 +19,5 @@ Parallelism
 
 Memory
   Heap                   720 B
-  Allocated           92_224 B
-  Freed               92_224 B
+  Allocated           90_880 B
+  Freed               90_880 B

--- a/tests/snaps/programs/opaque/stats
+++ b/tests/snaps/programs/opaque/stats
@@ -10,5 +10,5 @@ Interactions
 
 Memory
   Heap                   704 B
-  Allocated            4_000 B
-  Freed                4_000 B
+  Allocated            3_904 B
+  Freed                3_904 B

--- a/tests/snaps/programs/option_party/stats
+++ b/tests/snaps/programs/option_party/stats
@@ -13,6 +13,6 @@ Interactions
   Extrinsic            3_115
 
 Memory
-  Heap                36_208 B
-  Allocated          482_816 B
-  Freed              482_816 B
+  Heap                33_456 B
+  Allocated          476_240 B
+  Freed              476_240 B

--- a/tests/snaps/programs/par/stats
+++ b/tests/snaps/programs/par/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic            2_749
 
 Parallelism
-  Depth                  984
+  Depth                  982
   Breadth                  9
   Speedup                 96 cB
 
 Memory
-  Heap                28_672 B
-  Allocated          198_720 B
-  Freed              198_720 B
+  Heap                28_240 B
+  Allocated          194_064 B
+  Freed              194_064 B

--- a/tests/snaps/programs/pretty_div/stats
+++ b/tests/snaps/programs/pretty_div/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic              592
 
 Parallelism
-  Depth                  395
-  Breadth                  5
-  Speedup                 72 cB
+  Depth                  327
+  Breadth                  6
+  Speedup                 80 cB
 
 Memory
   Heap                 6_144 B
-  Allocated           46_624 B
-  Freed               46_624 B
+  Allocated           45_280 B
+  Freed               45_280 B

--- a/tests/snaps/programs/primenesses/stats
+++ b/tests/snaps/programs/primenesses/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic            2_528
 
 Parallelism
-  Depth                3_180
+  Depth                3_173
   Breadth                  3
   Speedup                 50 cB
 
 Memory
-  Heap                12_496 B
-  Allocated          219_424 B
-  Freed              219_424 B
+  Heap                12_208 B
+  Allocated          215_872 B
+  Freed              215_872 B

--- a/tests/snaps/programs/quine/stats
+++ b/tests/snaps/programs/quine/stats
@@ -9,6 +9,6 @@ Interactions
   Extrinsic            3_055
 
 Memory
-  Heap                19_072 B
-  Allocated          245_328 B
-  Freed              245_328 B
+  Heap                18_992 B
+  Allocated          240_928 B
+  Freed              240_928 B

--- a/tests/snaps/programs/regex/stats
+++ b/tests/snaps/programs/regex/stats
@@ -9,6 +9,6 @@ Interactions
   Extrinsic       12_919_871
 
 Memory
-  Heap            34_162_864 B
-  Allocated    1_215_768_848 B
-  Freed        1_215_768_848 B
+  Heap            17_912_192 B
+  Allocated    1_220_699_376 B
+  Freed        1_220_699_376 B

--- a/tests/snaps/programs/segmented_sieve/stats
+++ b/tests/snaps/programs/segmented_sieve/stats
@@ -9,6 +9,6 @@ Interactions
   Extrinsic       226_545_616
 
 Memory
-  Heap             48_671_040 B
-  Allocated    15_361_162_272 B
-  Freed        15_361_162_272 B
+  Heap             48_652_416 B
+  Allocated    15_348_432_128 B
+  Freed        15_348_432_128 B

--- a/tests/snaps/programs/sieve/stats
+++ b/tests/snaps/programs/sieve/stats
@@ -9,6 +9,6 @@ Interactions
   Extrinsic       32_626_713
 
 Memory
-  Heap             4_802_528 B
-  Allocated    2_163_072_592 B
-  Freed        2_163_072_592 B
+  Heap             4_802_560 B
+  Allocated    2_162_328_048 B
+  Freed        2_162_328_048 B

--- a/tests/snaps/programs/so_random/stats
+++ b/tests/snaps/programs/so_random/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic           13_667
 
 Parallelism
-  Depth                2_298
-  Breadth                 16
-  Speedup                122 cB
+  Depth                1_442
+  Breadth                 26
+  Speedup                143 cB
 
 Memory
-  Heap                28_112 B
-  Allocated          835_184 B
-  Freed              835_184 B
+  Heap                10_720 B
+  Allocated          819_584 B
+  Freed              819_584 B

--- a/tests/snaps/programs/sort/stats
+++ b/tests/snaps/programs/sort/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic       17_128_441
 
 Parallelism
-  Depth           12_277_596
+  Depth           12_177_617
   Breadth                  6
-  Speedup                 78 cB
+  Speedup                 79 cB
 
 Memory
-  Heap            54_983_696 B
-  Allocated    1_761_672_432 B
-  Freed        1_761_672_432 B
+  Heap            54_983_328 B
+  Allocated    1_750_385_344 B
+  Freed        1_750_385_344 B

--- a/tests/snaps/programs/specializations/stats
+++ b/tests/snaps/programs/specializations/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic            1_014
 
 Parallelism
-  Depth                  516
-  Breadth                  8
-  Speedup                 94 cB
+  Depth                  465
+  Breadth                  9
+  Speedup                 99 cB
 
 Memory
-  Heap                14_016 B
-  Allocated           97_008 B
-  Freed               97_008 B
+  Heap                14_544 B
+  Allocated           95_424 B
+  Freed               95_424 B

--- a/tests/snaps/programs/square_case/stats
+++ b/tests/snaps/programs/square_case/stats
@@ -14,6 +14,6 @@ Parallelism
   Speedup                 21 cB
 
 Memory
-  Heap                 1_200 B
+  Heap                 1_248 B
   Allocated           99_760 B
   Freed               99_760 B

--- a/tests/snaps/programs/the_greatest_show/stats
+++ b/tests/snaps/programs/the_greatest_show/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic           12_806
 
 Parallelism
-  Depth               15_452
+  Depth               15_441
   Breadth                  3
   Speedup                 57 cB
 
 Memory
-  Heap                84_896 B
-  Allocated        1_228_976 B
-  Freed            1_228_976 B
+  Heap                77_568 B
+  Allocated        1_207_552 B
+  Freed            1_207_552 B

--- a/tests/snaps/programs/tiny_f64/stats
+++ b/tests/snaps/programs/tiny_f64/stats
@@ -15,5 +15,5 @@ Parallelism
 
 Memory
   Heap                 1_440 B
-  Allocated            8_960 B
-  Freed                8_960 B
+  Allocated            8_768 B
+  Freed                8_768 B

--- a/tests/snaps/programs/unary/stats
+++ b/tests/snaps/programs/unary/stats
@@ -9,6 +9,6 @@ Interactions
   Extrinsic              730
 
 Memory
-  Heap                 4_896 B
-  Allocated           75_232 B
-  Freed               75_232 B
+  Heap                 5_296 B
+  Allocated           73_824 B
+  Freed               73_824 B

--- a/tests/snaps/programs/verbose_add/stats
+++ b/tests/snaps/programs/verbose_add/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic              251
 
 Parallelism
-  Depth                  232
+  Depth                  201
   Breadth                  4
-  Speedup                 61 cB
+  Speedup                 67 cB
 
 Memory
-  Heap                 2_768 B
-  Allocated           21_248 B
-  Freed               21_248 B
+  Heap                 2_816 B
+  Allocated           20_592 B
+  Freed               20_592 B

--- a/tests/snaps/programs/when_break_continue/stats
+++ b/tests/snaps/programs/when_break_continue/stats
@@ -9,11 +9,11 @@ Interactions
   Extrinsic            1_943
 
 Parallelism
-  Depth                1_047
-  Breadth                  6
-  Speedup                 81 cB
+  Depth                  734
+  Breadth                  9
+  Speedup                 97 cB
 
 Memory
-  Heap                21_456 B
-  Allocated          158_560 B
-  Freed              158_560 B
+  Heap                13_296 B
+  Allocated          153_184 B
+  Freed              153_184 B

--- a/vine/src/backend.rs
+++ b/vine/src/backend.rs
@@ -172,7 +172,7 @@ pub fn optimizations<'r>(vi: &'r Guide, table: &mut Table) -> impl use<'r> + Reg
       let [pri, content] = engine.remove_node_n(variant);
       let [pri_, ctx] = engine.remove_node_n(match_);
       engine.remove_wire(pri, pri_);
-      let [content_, ctx_] = engine.insert_node_n(net, vi.graft.with_children([graft_name]));
+      let [ctx_, content_] = engine.insert_node_n(net, vi.graft.with_children([graft_name]));
       engine.link(content, content_);
       engine.link(ctx, ctx_);
       true
@@ -205,7 +205,7 @@ pub fn vi_to_ivm<'r>(vi: &'r Guide, ivm: &'r IvmGuide) -> impl Register<Translat
       let branches = node.name.children;
       let [tag, content] = net.wires();
       net.add(ivm.x, enum_, [tag, content]);
-      let ctx = net.make(ivm.x, [content, ctx]);
+      let ctx = net.make(ivm.x, [ctx, content]);
       net.add(ivm.branch.with_children(branches), tag, [ctx]);
     }),
     TranslateFree(move |free, _, net| {

--- a/vine/src/components/emitter.rs
+++ b/vine/src/components/emitter.rs
@@ -282,8 +282,8 @@ impl<'a> Emitter<'a> {
         let interface = self.emit_interface(interface, false);
         let data = self.emit_port(data);
         let ctx = self.with_debug(interface);
-        self.net.free.push(data);
         self.net.free.push(ctx);
+        self.net.free.push(data);
       }
       Header::Closure(params, result) => {
         let interface = self.emit_interface(interface, false);

--- a/vine/src/components/synthesizer.rs
+++ b/vine/src/components/synthesizer.rs
@@ -248,8 +248,8 @@ impl Synthesizer<'_> {
     let frame = self.net.make(self.guide.tuple, [col, file, line, path]);
     let option = self.enum_(self.chart.builtins.option.unwrap(), VariantId(1), frame);
     let nil = self.net.make(self.guide.tuple, []);
-    self.net.free.push(option);
     self.net.free.push(nil);
+    self.net.free.push(option);
   }
 
   fn synthesize_debug_state(&mut self) {
@@ -298,8 +298,8 @@ impl Synthesizer<'_> {
       .map(|i| {
         self.stage(|self_| {
           let [content, ctx] = self_.net.wires();
-          self_.net.free.push(content);
           self_.net.free.push(ctx);
+          self_.net.free.push(content);
           arm(self_, i, content, ctx)
         })
       })

--- a/vine/src/features/debug.rs
+++ b/vine/src/features/debug.rs
@@ -83,8 +83,8 @@ pub(crate) fn insert_main_net_debug(
   let enum_ = table.add_name(guide.enum_.with_payload(1u32));
   let option = net.make(guide.enum_variant.with_payload(0u32).with_children([enum_]), [nil]);
   let nil = net.make(guide.tuple, []);
-  net.free.push(option);
   net.free.push(nil);
+  net.free.push(option);
   translator.translate(table, &mut net);
   nets.insert(guide.synthetic_frame_end, net);
 


### PR DESCRIPTION
In some ivy dialect there can be match interactions with or without contents. This makes the free port order consistent where the first free port is always the context and the second the content if it exists.