### PR TITLE
lsp: more explicit text_document_sync capability

### DIFF
--- a/lsp/src/lib.rs
+++ b/lsp/src/lib.rs
@@ -312,7 +312,12 @@ impl<H: Hooks> LanguageServer for Backend<H> {
           // TODO(#411): handle properly
           PositionEncodingKind::UTF16
         }),
-        text_document_sync: Some(TextDocumentSyncCapability::Kind(TextDocumentSyncKind::FULL)),
+        text_document_sync: Some(TextDocumentSyncCapability::Options(TextDocumentSyncOptions {
+          open_close: Some(true),
+          change: Some(TextDocumentSyncKind::FULL),
+          save: Some(TextDocumentSyncSaveOptions::Supported(true)),
+          ..Default::default()
+        })),
         document_formatting_provider: Some(OneOf::Left(true)),
         workspace: Some(WorkspaceServerCapabilities {
           workspace_folders: Some(WorkspaceFoldersServerCapabilities {

--- a/tests/lsp/root.yml
+++ b/tests/lsp/root.yml
@@ -17,7 +17,10 @@
         hoverProvider: true
         positionEncoding: utf-16
         referencesProvider: true
-        textDocumentSync: 1
+        textDocumentSync:
+          change: 1
+          openClose: true
+          save: true
         workspace:
           workspaceFolders:
             changeNotifications: true

--- a/tests/snaps/lsp/diags.log.yml
+++ b/tests/snaps/lsp/diags.log.yml
@@ -15,7 +15,10 @@
         hoverProvider: true
         positionEncoding: utf-16
         referencesProvider: true
-        textDocumentSync: 1
+        textDocumentSync:
+          change: 1
+          openClose: true
+          save: true
         workspace:
           workspaceFolders:
             changeNotifications: true

--- a/tests/snaps/lsp/docs.log.yml
+++ b/tests/snaps/lsp/docs.log.yml
@@ -15,7 +15,10 @@
         hoverProvider: true
         positionEncoding: utf-16
         referencesProvider: true
-        textDocumentSync: 1
+        textDocumentSync:
+          change: 1
+          openClose: true
+          save: true
         workspace:
           workspaceFolders:
             changeNotifications: true

--- a/tests/snaps/lsp/format.log.yml
+++ b/tests/snaps/lsp/format.log.yml
@@ -15,7 +15,10 @@
         hoverProvider: true
         positionEncoding: utf-16
         referencesProvider: true
-        textDocumentSync: 1
+        textDocumentSync:
+          change: 1
+          openClose: true
+          save: true
         workspace:
           workspaceFolders:
             changeNotifications: true

--- a/tests/snaps/lsp/hello_world.log.yml
+++ b/tests/snaps/lsp/hello_world.log.yml
@@ -15,7 +15,10 @@
         hoverProvider: true
         positionEncoding: utf-16
         referencesProvider: true
-        textDocumentSync: 1
+        textDocumentSync:
+          change: 1
+          openClose: true
+          save: true
         workspace:
           workspaceFolders:
             changeNotifications: true

--- a/tests/snaps/lsp/hover.log.yml
+++ b/tests/snaps/lsp/hover.log.yml
@@ -15,7 +15,10 @@
         hoverProvider: true
         positionEncoding: utf-16
         referencesProvider: true
-        textDocumentSync: 1
+        textDocumentSync:
+          change: 1
+          openClose: true
+          save: true
         workspace:
           workspaceFolders:
             changeNotifications: true

--- a/tests/snaps/lsp/root.log.yml
+++ b/tests/snaps/lsp/root.log.yml
@@ -15,7 +15,10 @@
         hoverProvider: true
         positionEncoding: utf-16
         referencesProvider: true
-        textDocumentSync: 1
+        textDocumentSync:
+          change: 1
+          openClose: true
+          save: true
         workspace:
           workspaceFolders:
             changeNotifications: true


### PR DESCRIPTION
Some clients (e.g. [kakoune-lsp](https://github.com/kakoune-lsp/kakoune-lsp)), do not send `didSave` notifications if the advertised capability is `textDocumentSync: 1`. In my opinion, [the specification on `TextDocumentSyncKind`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocumentSyncKind) is ambiguous on whether `FULL` (which is `1`) implies that `didSave` notifications should be sent, as opposed to only `didChange` notifications. So it's unclear whether the kakoune lsp client is actually non-compiliant here.

This PR more explicitly advertises that we want `didSave` notifications, and `didChange` should send the full text content, which matches up with the expectations in the `Backend` implementation.