### PR TITLE
lsp: filter diags with none span

### DIFF
--- a/lsp/src/lib.rs
+++ b/lsp/src/lib.rs
@@ -54,11 +54,11 @@ impl<H: Hooks> Backend<H> {
 
     let mut diags_by_file = IdxVec::repeat((vec![], vec![]), lsp.compiler.files.len());
     for diag in &lsp.compiler.diags.errors {
-      let Some(span) = diag.span() else { continue };
+      let Some(span) = diag.span().and_then(Span::some) else { continue };
       diags_by_file[span.file].0.push(diag);
     }
     for diag in &lsp.compiler.diags.warnings {
-      let Some(span) = diag.span() else { continue };
+      let Some(span) = diag.span().and_then(Span::some) else { continue };
       diags_by_file[span.file].1.push(diag);
     }
 

--- a/vine/src/structures/ast.rs
+++ b/vine/src/structures/ast.rs
@@ -592,6 +592,10 @@ impl PartialOrd for Span {
 
 impl Span {
   pub const NONE: Span = Span { file: FileId(usize::MAX), start: 0, end: 0 };
+
+  pub fn some(self) -> Option<Span> {
+    (self != Self::NONE).then_some(self)
+  }
 }
 
 impl Display for Path {


### PR DESCRIPTION
- adds `Span::some`
- publishes diagnostics only for non-none spans