### PR TITLE
cli: support specifying an entrypoint

### DIFF
--- a/cli/src/vine_cli.rs
+++ b/cli/src/vine_cli.rs
@@ -254,6 +254,7 @@ pub struct VineTestCommand {
 impl VineTestCommand {
   pub fn execute(mut self) -> Result<()> {
     self.compile.debug = true;
+    self.compile.main_path = None;
 
     let (ref mut table, mut nets, mut compiler) = self.compile.compile();
 

--- a/cli/src/vine_cli.rs
+++ b/cli/src/vine_cli.rs
@@ -137,11 +137,14 @@ pub struct CompileArgs {
   debug: bool,
   #[arg(long, num_args = 2, value_names = ["KEY", "VALUE"])]
   config: Vec<String>,
+  #[arg(long = "main", default_value = "main")]
+  main_path: Option<MainPath>,
 }
 
 impl CompileArgs {
   fn initialize(self) -> Compiler {
-    let mut compiler = Compiler::new(self.debug, build_config(self.config));
+    let mut compiler =
+      Compiler::new(self.debug, self.main_path.map(|p| p.segments), build_config(self.config));
     self.libs.initialize(&mut compiler);
 
     let mut loader = Loader::new(&mut compiler, RealFS, None);
@@ -458,7 +461,7 @@ impl VineReplCommand {
 
     let mut runtime = host.init(&mut heap);
 
-    let mut compiler = Compiler::new(!self.no_debug, build_config(self.config));
+    let mut compiler = Compiler::new(!self.no_debug, None, build_config(self.config));
     self.libs.initialize(&mut compiler);
     let mut repl = match Repl::new(table, &host, &mut runtime, &mut compiler) {
       Ok(repl) => repl,
@@ -868,6 +871,52 @@ impl TypedValueParser for ParseSource {
       }
     }
   }
+}
+
+#[derive(Clone, Debug)]
+struct MainPath {
+  segments: Vec<Ident>,
+}
+
+impl ValueParserFactory for MainPath {
+  type Parser = ParseMainPath;
+  fn value_parser() -> Self::Parser {
+    ParseMainPath
+  }
+}
+
+#[derive(Clone)]
+struct ParseMainPath;
+
+impl TypedValueParser for ParseMainPath {
+  type Value = MainPath;
+
+  fn parse_ref(
+    &self,
+    cmd: &clap::Command,
+    _: Option<&clap::Arg>,
+    value: &OsStr,
+  ) -> Result<Self::Value, clap::Error> {
+    parse_main_path(value).map_err(|e| {
+      clap::Error::raw(ErrorKind::ValueValidation, format!("invalid main path: {e}")).with_cmd(cmd)
+    })
+  }
+}
+
+fn parse_main_path(value: &OsStr) -> Result<MainPath, String> {
+  use vine::components::{lexer::Lexer, parser::Parser};
+
+  let value = value.to_str().ok_or("not valid unicode")?;
+  let mut parser = Parser::new(Lexer::new(FileId(usize::MAX), value)).map_err(|e| e.to_string())?;
+  let path = parser.parse_path().map_err(|e| e.to_string())?;
+  if path.absolute {
+    Err("path must be relative")?
+  }
+  if path.generics.is_some() {
+    Err("path cannot have generics")?
+  }
+
+  Ok(MainPath { segments: path.segments })
 }
 
 fn build_config(args: Vec<String>) -> HashMap<String, String> {

--- a/tests/misc/basic_test.vi
+++ b/tests/misc/basic_test.vi
@@ -19,5 +19,3 @@ pub fn test_capture_failed(&io: &IO) {
   io.println("This should always be printed because of failure");
   debug::error("This message should also be printed")
 }
-
-pub fn main(&_io: &IO) {}

--- a/tests/programs/side_quest.vi
+++ b/tests/programs/side_quest.vi
@@ -1,0 +1,14 @@
+
+// @build --main distant::land::side
+
+pub fn main(&io: &IO) {
+  io.println("this should not print");
+}
+
+pub mod distant {
+  pub mod land {
+    pub fn side(&io: &IO) {
+      io.println("this should print");
+    }
+  }
+}

--- a/tests/snaps/programs/side_quest/output.txt
+++ b/tests/snaps/programs/side_quest/output.txt
@@ -1,0 +1,1 @@
+this should print

--- a/tests/snaps/programs/side_quest/stats
+++ b/tests/snaps/programs/side_quest/stats
@@ -1,0 +1,14 @@
+
+Interactions
+  Total                  363
+  Annihilate             193
+  Commute                  0
+  Copy                    21
+  Erase                   13
+  Graft                   47
+  Extrinsic               89
+
+Memory
+  Heap                   768 B
+  Allocated            7_936 B
+  Freed                7_936 B

--- a/vine/src/compiler.rs
+++ b/vine/src/compiler.rs
@@ -23,7 +23,7 @@ use crate::{
   },
   structures::{
     annotations::Annotations,
-    ast::Span,
+    ast::{Ident, Span},
     chart::{Chart, VisId},
     checkpoint::Checkpoint,
     diag::{Diag, Diags, ErrorGuaranteed, FileInfo},
@@ -38,6 +38,7 @@ use crate::{
 #[derive(Default)]
 pub struct Compiler {
   pub debug: bool,
+  pub main_segments: Option<Vec<Ident>>,
   pub config: HashMap<String, String>,
   pub files: IdxVec<FileId, FileInfo>,
   pub loaded: Vec<Module>,
@@ -54,8 +55,8 @@ pub struct Compiler {
 }
 
 impl Compiler {
-  pub fn new(debug: bool, config: HashMap<String, String>) -> Self {
-    Compiler { debug, config, ..Default::default() }
+  pub fn new(debug: bool, main_path: Option<Vec<Ident>>, config: HashMap<String, String>) -> Self {
+    Compiler { debug, main_segments: main_path, config, ..Default::default() }
   }
 
   pub fn check(&mut self, hooks: impl Hooks) -> Result<(), ErrorGuaranteed> {
@@ -101,6 +102,7 @@ impl Compiler {
     hooks.chart(&mut charter);
 
     let mut resolver = Resolver::new(
+      &self.main_segments,
       &self.config,
       chart,
       &mut self.sigs,

--- a/vine/src/components/resolver.rs
+++ b/vine/src/components/resolver.rs
@@ -1,6 +1,7 @@
 use std::{
   collections::{BTreeMap, HashMap, HashSet},
   mem::take,
+  slice,
 };
 
 use vine_util::{
@@ -31,6 +32,7 @@ use crate::{
 
 #[derive(Debug)]
 pub struct Resolver<'a> {
+  pub(crate) main_segments: &'a Option<Vec<Ident>>,
   pub(crate) chart: &'a Chart,
   pub(crate) config: &'a HashMap<String, String>,
   pub(crate) sigs: &'a mut Signatures,
@@ -86,6 +88,7 @@ impl ScopeBinding {
 
 impl<'a> Resolver<'a> {
   pub fn new(
+    main_segments: &'a Option<Vec<Ident>>,
     config: &'a HashMap<String, String>,
     chart: &'a Chart,
     sigs: &'a mut Signatures,
@@ -96,6 +99,7 @@ impl<'a> Resolver<'a> {
     finder_cache: &'a mut FinderCache,
   ) -> Self {
     Resolver {
+      main_segments,
       config,
       chart,
       sigs,
@@ -178,14 +182,15 @@ impl<'a> Resolver<'a> {
       self.resolve_test_fn(*id);
     }
     if let Some(main_mod) = self.chart.main_mod
+      && let Some(main_segments) = self.main_segments
       && main_mod >= checkpoint.defs
     {
-      self.resolve_main(main_mod);
+      self.resolve_main(main_mod, main_segments);
     }
   }
 
-  fn resolve_main(&mut self, main_mod: DefId) {
-    match self._resolve_main(main_mod) {
+  fn resolve_main(&mut self, main_mod: DefId, main_segments: &[Ident]) {
+    match self._resolve_main(main_mod, main_segments) {
       Ok(main_mod) => {
         self.resolutions.main = Some(self.resolutions.fns[main_mod]);
       }
@@ -195,13 +200,16 @@ impl<'a> Resolver<'a> {
     }
   }
 
-  fn _resolve_main(&mut self, main_mod: DefId) -> Result<ConcreteFnId, Diag> {
+  fn _resolve_main(
+    &mut self,
+    main_mod: DefId,
+    main_segments: &[Ident],
+  ) -> Result<ConcreteFnId, Diag> {
     self.types.reset();
     let span = Span::NONE;
-    let main_mod_name = self.chart.defs[main_mod].name.clone();
-    let main_ident = Ident("main".into());
-    let path =
-      Path { span, absolute: true, segments: vec![main_mod_name, main_ident], generics: None };
+    let main_mod_name = &self.chart.defs[main_mod].name;
+    let segments = [slice::from_ref(main_mod_name), main_segments].concat();
+    let path = Path { span, absolute: true, segments, generics: None };
     let fn_id = self.resolve_path(DefId::NONE, &path, "fn", |def| def.fn_id())?;
     let FnId::Concrete(fn_id) = fn_id else { unreachable!() };
     self.expect_entrypoint_sig(fn_id)?;

--- a/vine/src/features/path.rs
+++ b/vine/src/features/path.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 
 impl Parser<'_> {
-  pub(crate) fn parse_path(&mut self) -> Result<Path, Diag> {
+  pub fn parse_path(&mut self) -> Result<Path, Diag> {
     let span = self.start_span();
     let absolute = self.eat(Token::Hash)?;
     let segments = self.parse_delimited(PATH, Self::parse_ident)?;

--- a/vine/src/features/type_.rs
+++ b/vine/src/features/type_.rs
@@ -131,6 +131,7 @@ impl Resolver<'_> {
     let generics_id = self.chart.type_aliases[type_alias_id].generics;
     let (type_params, _) = self.resolve_generics(path, generics_id, inference);
     Resolver::new(
+      self.main_segments,
       self.config,
       self.chart,
       self.sigs,

--- a/vine/src/structures/checkpoint.rs
+++ b/vine/src/structures/checkpoint.rs
@@ -73,6 +73,7 @@ impl Compiler {
   pub fn revert(&mut self, checkpoint: &Checkpoint) {
     let Compiler {
       debug: _,
+      main_segments: _,
       loaded: _,
       config: _,
       files,


### PR DESCRIPTION
1. Adds a `--main` flag to the vine cli, letting you specify a path to an entrypoint, relative to the main source, which defaults to `main`.
2. `vine test <source>` no longer requires `source` to have an entrypoint defined.