### PR TITLE
ivm: encode with a stack instead of mutual recursion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
 
 [[package]]
+name = "ar_archive_writer"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4087686b4b0a3427190bae57a1d9a478dbb2d40c5dc1bd6e2b6d797913bdd348"
+dependencies = [
+ "object 0.37.3",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -128,7 +137,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.36.5",
  "rustc-demangle",
  "windows-targets 0.52.6",
 ]
@@ -150,6 +159,16 @@ name = "bytes"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
+
+[[package]]
+name = "cc"
+version = "1.2.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -301,6 +320,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "form_urlencoded"
@@ -810,6 +835,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -905,6 +939,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
 ]
 
 [[package]]
@@ -1041,6 +1085,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1076,6 +1126,19 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "stacker"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "640c8cdd92b6b12f5bcb1803ca3bbf5ab96e5e6b6b96b9ab77dabe9e880b3190"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "strsim"
@@ -1355,6 +1418,7 @@ dependencies = [
  "hashbrown",
  "nohash-hasher",
  "slab",
+ "stacker",
 ]
 
 [[package]]

--- a/ivm/src/program.rs
+++ b/ivm/src/program.rs
@@ -195,6 +195,10 @@ impl<'ivm> Encoder<'ivm, '_> {
   }
 
   fn encode_tree(&mut self, tree: TreeNode, reg: Register) {
+    vine_util::ensure_sufficient_stack(|| self._encode_tree(tree, reg));
+  }
+
+  fn _encode_tree(&mut self, tree: TreeNode, reg: Register) {
     match tree {
       TreeNode::Wire(_) => {}
       TreeNode::Node(name, children) => {

--- a/ivy/src/text/ast.rs
+++ b/ivy/src/text/ast.rs
@@ -106,6 +106,13 @@ impl<I> Net<I> {
       where
         F: FnMut(&mut FlatNet, I, Wire),
       {
+        vine_util::ensure_sufficient_stack(|| self._expr(expr))
+      }
+
+      fn _expr<I>(&mut self, expr: Expr<I>) -> Result<Wire, Diag>
+      where
+        F: FnMut(&mut FlatNet, I, Wire),
+      {
         Ok(match expr {
           Expr::Node(name, children) => {
             let pri = self.net.wire();

--- a/ivy/src/text/parser.rs
+++ b/ivy/src/text/parser.rs
@@ -77,6 +77,10 @@ impl<'t, 'src, I, F: FnMut(&mut ParserState<'src, Lexer<'src>>) -> Result<I, Dia
   }
 
   pub fn parse_expr(&mut self) -> Result<Expr<I>, Diag> {
+    vine_util::ensure_sufficient_stack(|| self._parse_expr())
+  }
+
+  pub fn _parse_expr(&mut self) -> Result<Expr<I>, Diag> {
     let mut expr = self.parse_expr_prefix()?;
     while self.check(Token::OpenBrace) {
       let stmts = self.parse_delimited(BRACE, Self::parse_stmt)?;

--- a/tests/programs/overflow.vi
+++ b/tests/programs/overflow.vi
@@ -1,0 +1,6 @@
+
+// @build --opt-all
+
+pub fn main(_: &IO) {
+  black_box((0..10000).collect[List]());
+}

--- a/tests/snaps/programs/overflow/stats
+++ b/tests/snaps/programs/overflow/stats
@@ -1,0 +1,14 @@
+
+Interactions
+  Total               20_006
+  Annihilate               1
+  Commute                  0
+  Copy                10_002
+  Erase               10_002
+  Graft                    1
+  Extrinsic                0
+
+Memory
+  Heap               160_064 B
+  Allocated          160_064 B
+  Freed              160_064 B

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 hashbrown = "0.14.5"
 nohash-hasher = "0.2.0"
 slab = "0.4.12"
+stacker = "0.1.24"
 
 [lints.clippy]
 absolute_paths = "warn"

--- a/util/src/ensure_sufficient_stack.rs
+++ b/util/src/ensure_sufficient_stack.rs
@@ -1,0 +1,8 @@
+const RED_ZONE_SIZE: usize = 32 * 1024; // 32KB
+const MIN_REALLOC_SIZE: usize = 1024 * 1024; // 1MB
+
+/// Grows the stack on demand to prevent stack overflow. Has a little overhead.
+#[inline]
+pub fn ensure_sufficient_stack<T>(f: impl FnOnce() -> T) -> T {
+  stacker::maybe_grow(RED_ZONE_SIZE, MIN_REALLOC_SIZE, f)
+}

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -14,3 +14,6 @@ pub use unwrap_vec::*;
 
 mod exact_size;
 pub use exact_size::*;
+
+mod ensure_sufficient_stack;
+pub use ensure_sufficient_stack::*;


### PR DESCRIPTION
Using [`stacker`](https://docs.rs/stacker), allows the vine & ivm cli to run programs which previously caused a stack overflow e.g. (when run with `vine run --opt-all`):

```rust
pub fn main(_: &IO) {
  black_box((0..10000).collect[List]());
}
```

The above program also works with `vine build --opt-all` and `ivm run`.